### PR TITLE
fix(core): a container's final paragraph mark carries no revision either way

### DIFF
--- a/.changeset/carrier-paragraph-insertions.md
+++ b/.changeset/carrier-paragraph-insertions.md
@@ -2,4 +2,4 @@
 "@stll/folio-core": patch
 ---
 
-Compare: paragraphs added where a container's removed trailing ones were now land in the paragraph that container ends with, and a carrier no merge chain can reach is reserved for the target's last paragraph. Paragraph properties no longer overwrite a paragraph mark another operation in the same batch wrote, a paragraph followed only by a text box is read as ending its container, `w:trPr/w:del` rows keep their cells' marks, and `w:pPr` children are written in schema order.
+Compare: a container's final paragraph mark now carries no revision in either direction. Paragraphs added where a removed trailing run was land in the paragraph the container ends with; paragraphs appended past it rotate the added break one paragraph back; and a carrier no merge chain can reach is reserved for the target's last paragraph. Paragraph properties no longer overwrite a paragraph mark another operation in the same batch wrote, a paragraph followed only by a text box is read as ending its container, `w:trPr/w:del` rows keep their cells' marks, every story is compared as accepted, and `w:pPr` children are written in schema order.

--- a/.changeset/carrier-paragraph-insertions.md
+++ b/.changeset/carrier-paragraph-insertions.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Compare: paragraphs added where a container's removed trailing ones were now land in the paragraph that container ends with, and a carrier no merge chain can reach is reserved for the target's last paragraph. Paragraph properties no longer overwrite a paragraph mark another operation in the same batch wrote, a paragraph followed only by a text box is read as ending its container, `w:trPr/w:del` rows keep their cells' marks, and `w:pPr` children are written in schema order.

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -11,6 +11,7 @@ import { EditorState } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
 import * as import__stll_docx_core_model from '@stll/docx-core/model';
 import { Node as Node_2 } from 'prosemirror-model';
+import { ParagraphMarkChangeKind } from '@stll/docx-core/model';
 import { Plugin as Plugin_2 } from 'prosemirror-state';
 import { PluginKey } from 'prosemirror-state';
 import { Result } from 'better-result';
@@ -408,7 +409,7 @@ export type CompareDocxError = CompareDocxApplyError | CompareDocxFinalParagraph
 // @public
 export class CompareDocxFinalParagraphMarkError extends CompareDocxFinalParagraphMarkError_base<{
     message: string;
-    deletions: readonly FinalParagraphMarkDeletion[];
+    revisions: readonly FinalParagraphMarkRevision[];
 }> {}
 
 // @public
@@ -678,10 +679,10 @@ export type ExtractDocumentStyleSetOptions = {
 export function extractEmbeddedFonts(buffer: ArrayBuffer, docNonce?: string): Promise<EmbeddedFont[]>;
 
 // @public
-export type FinalParagraphMarkDeletion = {
+export type FinalParagraphMarkRevision = {
     container: string;
     paragraphIndex: number;
-    kind: "del" | "moveFrom";
+    kind: ParagraphMarkChangeKind;
 };
 
 // @public (undocumented)

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -11,6 +11,7 @@ import { EditorState } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
 import * as import__stll_docx_core_model from '@stll/docx-core/model';
 import { Node as Node_2 } from 'prosemirror-model';
+import { ParagraphMarkChangeKind } from '@stll/docx-core/model';
 import { Plugin as Plugin_2 } from 'prosemirror-state';
 import { PluginKey } from 'prosemirror-state';
 import { Result } from 'better-result';
@@ -408,7 +409,7 @@ export type CompareDocxError = CompareDocxApplyError | CompareDocxFinalParagraph
 // @public
 export class CompareDocxFinalParagraphMarkError extends CompareDocxFinalParagraphMarkError_base<{
     message: string;
-    deletions: readonly FinalParagraphMarkDeletion[];
+    revisions: readonly FinalParagraphMarkRevision[];
 }> {}
 
 // @public
@@ -678,10 +679,10 @@ export type ExtractDocumentStyleSetOptions = {
 export function extractEmbeddedFonts(buffer: ArrayBuffer, docNonce?: string): Promise<EmbeddedFont[]>;
 
 // @public
-export type FinalParagraphMarkDeletion = {
+export type FinalParagraphMarkRevision = {
     container: string;
     paragraphIndex: number;
-    kind: "del" | "moveFrom";
+    kind: ParagraphMarkChangeKind;
 };
 
 // @public (undocumented)

--- a/benchmarks/compare/refusals.ts
+++ b/benchmarks/compare/refusals.ts
@@ -114,8 +114,8 @@ export const classifyRefusal = (error: CompareDocxError): Refusal => {
     case "CompareDocxFinalParagraphMarkError":
       return {
         bucket: "final-paragraph-mark",
-        shape: `${String(error.deletions.length)} container(s), first ${
-          error.deletions.at(0)?.container ?? "unknown"
+        shape: `${String(error.revisions.length)} container(s), first ${
+          error.revisions.at(0)?.container ?? "unknown"
         }`,
       };
     case "CompareDocxRoundTripError":

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -10,6 +10,7 @@ import type { ParagraphPropertyChangeAttrs } from "../prosemirror/schema/nodes";
 import { marksToTextFormatting } from "../prosemirror/conversion/fromProseDoc";
 import { markStructuralChange } from "../prosemirror/extensions/features/ParagraphChangeTrackerExtension";
 import { requestDeterministicParaIds } from "../prosemirror/extensions/features/ParaIdAllocatorExtension";
+import { paragraphEndsItsContainer } from "../prosemirror/containerFinalParagraph";
 import { isZeroWidthAnchor } from "../prosemirror/zeroWidthAnchors";
 import { getFolioParaIdFromBlockId } from "../types/block-id";
 import type { RunPropertyChange } from "../types/document";
@@ -1857,7 +1858,7 @@ const applyFolioAIEditOperationsInternal = ({
           // node goes as any other would — which is what the tracked path
           // resolves to as well, its mark deleted one paragraph earlier.
           const at = tr.doc.resolve(item.blockFrom);
-          const endsItsContainer = at.index() === at.parent.childCount - 1;
+          const endsItsContainer = paragraphEndsItsContainer(at, item.blockNode.type.name);
           const leavesAParagraph =
             !endsItsContainer || at.nodeBefore?.type.name === item.blockNode.type.name;
           tr = leavesAParagraph
@@ -1914,7 +1915,7 @@ const applyFolioAIEditOperationsInternal = ({
           // matching one elsewhere rather than being a deletion of its own.
           const markPosition = tr.mapping.map(item.blockFrom);
           const markPlace = tr.doc.resolve(markPosition);
-          const endsItsContainer = markPlace.index() === markPlace.parent.childCount - 1;
+          const endsItsContainer = paragraphEndsItsContainer(markPlace, item.blockNode.type.name);
           if (!endsItsContainer && tr.doc.nodeAt(markPosition)?.attrs["pPrMark"] == null) {
             const markRevisionId = revisionSeed++;
             tr = tr.setNodeAttribute(markPosition, "pPrMark", {
@@ -2010,13 +2011,23 @@ const applyFolioAIEditOperationsInternal = ({
         break;
       }
       case "setBlockParagraphProperties": {
-        const patch = paragraphPropertiesPatch(item.blockNode, item.operation.properties);
+        // Rewriting a node's attributes replaces ALL of them, so they have to
+        // be read from the document as it stands rather than from the
+        // resolution-time snapshot. Another operation of the same batch may
+        // already have written to this paragraph — a merge puts its deleted
+        // paragraph mark in `pPrMark`, and the batch runs right to left, so
+        // the mark lands before the properties do. Rebuilding the node from
+        // the stale attributes dropped that mark without a trace: the
+        // properties applied, the merge silently did not.
+        const blockPosition = tr.mapping.map(item.blockFrom);
+        const liveBlock = tr.doc.nodeAt(blockPosition) ?? item.blockNode;
+        const patch = paragraphPropertiesPatch(liveBlock, item.operation.properties);
         if (patch === null) {
           skipped.push({ id: item.operation.id, reason: "noopOperation" });
           continue;
         }
         if (mode === "direct") {
-          tr = tr.setNodeMarkup(item.blockFrom, undefined, { ...item.blockNode.attrs, ...patch });
+          tr = tr.setNodeMarkup(blockPosition, undefined, { ...liveBlock.attrs, ...patch });
           break;
         }
         // Word stores the COMPLETE old pPr inside `w:pPrChange`, so rejecting
@@ -2027,11 +2038,11 @@ const applyFolioAIEditOperationsInternal = ({
         const change: ParagraphPropertyChangeAttrs = {
           type: "paragraphPropertyChange",
           info: { id: revisionId, author, date, ...(initials ? { initials } : {}) },
-          previousFormatting: paragraphPropertiesSnapshot(item.blockNode),
+          previousFormatting: paragraphPropertiesSnapshot(liveBlock),
         };
-        const existing = expectParagraphAttrs(item.blockNode)._propertyChanges;
-        tr = tr.setNodeMarkup(item.blockFrom, undefined, {
-          ...item.blockNode.attrs,
+        const existing = expectParagraphAttrs(liveBlock)._propertyChanges;
+        tr = tr.setNodeMarkup(blockPosition, undefined, {
+          ...liveBlock.attrs,
           ...patch,
           _propertyChanges: [...(Array.isArray(existing) ? existing : []), change],
         });

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -10,7 +10,11 @@ import type { ParagraphPropertyChangeAttrs } from "../prosemirror/schema/nodes";
 import { marksToTextFormatting } from "../prosemirror/conversion/fromProseDoc";
 import { markStructuralChange } from "../prosemirror/extensions/features/ParagraphChangeTrackerExtension";
 import { requestDeterministicParaIds } from "../prosemirror/extensions/features/ParaIdAllocatorExtension";
-import { paragraphEndsItsContainer } from "../prosemirror/containerFinalParagraph";
+import {
+  addedBreakCarrierBefore,
+  finalParagraphsOf,
+  paragraphEndsItsContainer,
+} from "../prosemirror/containerFinalParagraph";
 import { isZeroWidthAnchor } from "../prosemirror/zeroWidthAnchors";
 import { getFolioParaIdFromBlockId } from "../types/block-id";
 import type { RunPropertyChange } from "../types/document";
@@ -944,6 +948,104 @@ const isBatchableParagraphInsertion = (
   const insertTexts = item.insertTexts ?? [""];
   const isEmptyInsert = insertTexts.length === 1 && insertTexts[0]?.length === 0;
   return !(mode === "tracked-changes" && item.operation.pageBreakBefore === true && isEmptyInsert);
+};
+
+type RotateAddedFinalBreaksOptions = {
+  tr: Transaction;
+  /** Revision ids this batch minted, so marks it did not write are left alone. */
+  batchRevisionIds: ReadonlySet<number>;
+  revisionSeed: number;
+  author: string;
+  date: string;
+  initials: string | undefined;
+};
+
+type RotatedAddedFinalBreaks = {
+  transaction: Transaction;
+  nextRevisionId: number;
+};
+
+/**
+ * Move an ADDED paragraph break off every paragraph its container ends with.
+ *
+ * A container's final mark carries no revision in either direction: nothing
+ * follows it, so "join this paragraph with the one after it" and its mirror
+ * both state an edit that cannot be carried out, and a reader is left with a
+ * revision neither accepting nor rejecting everything can clear.
+ *
+ * Appending at a container's end therefore rotates exactly as removing from it
+ * does. The break that was added sits between the paragraph the run was
+ * appended after and the first appended one, so THAT paragraph's mark is the
+ * inserted one, each appended paragraph but the last keeps an inserted mark of
+ * its own, and the paragraph the container now ends with takes the free mark
+ * the run was appended after. Only which paragraph is left markless changes.
+ *
+ * A paragraph's properties live on its mark, so the paragraph that inherits
+ * the free one records the other's as `w:pPrChange` — what a rejection reads
+ * to put the container's ending back the way it was.
+ *
+ * This runs once over the finished document rather than at each insertion:
+ * which paragraph ends a container is only settled when the batch is, and an
+ * insertion that looked final was undone by the next operation writing a table
+ * after it.
+ */
+const withRotatedAddedFinalBreaks = ({
+  tr,
+  batchRevisionIds,
+  revisionSeed,
+  author,
+  date,
+  initials,
+}: RotateAddedFinalBreaksOptions): RotatedAddedFinalBreaks => {
+  const paragraphTypeName = tr.doc.type.schema.nodes["paragraph"]?.name ?? "paragraph";
+  const rotations = finalParagraphsOf(tr.doc, paragraphTypeName).filter(({ node }) => {
+    const mark: unknown = node.attrs["pPrMark"];
+    if (typeof mark !== "object" || mark === null || !("kind" in mark)) {
+      return false;
+    }
+    if (mark.kind !== "ins" && mark.kind !== "moveTo") {
+      return false;
+    }
+    const info: unknown = "info" in mark ? mark.info : undefined;
+    const revisionId =
+      typeof info === "object" && info !== null && "id" in info ? info.id : undefined;
+    return typeof revisionId === "number" && batchRevisionIds.has(revisionId);
+  });
+
+  let next = tr;
+  let nextRevisionId = revisionSeed;
+  // Attribute writes do not move anything, so the positions stay valid.
+  for (const { position: finalPosition, node: final } of rotations) {
+    const carrier = addedBreakCarrierBefore(next.doc.resolve(finalPosition), final.type.name);
+    if (!carrier) {
+      // Nothing to hand the break to. Writing it would be worse than losing
+      // it: the redline would carry a revision no reader can resolve.
+      next = next.setNodeAttribute(finalPosition, "pPrMark", null);
+      continue;
+    }
+    next = next.setNodeAttribute(carrier.position, "pPrMark", final.attrs["pPrMark"]);
+    const previousFormatting = paragraphPropertiesSnapshot(carrier.node);
+    // Both snapshots are built by the same fixed walk over the in-scope keys,
+    // so comparing them serialized compares them key for key.
+    if (JSON.stringify(previousFormatting) === JSON.stringify(paragraphPropertiesSnapshot(final))) {
+      next = next.setNodeAttribute(finalPosition, "pPrMark", null);
+      continue;
+    }
+    const existing = expectParagraphAttrs(final)._propertyChanges;
+    next = next.setNodeMarkup(finalPosition, undefined, {
+      ...final.attrs,
+      pPrMark: null,
+      _propertyChanges: [
+        ...(Array.isArray(existing) ? existing : []),
+        {
+          type: "paragraphPropertyChange",
+          info: { id: nextRevisionId++, author, date, ...(initials ? { initials } : {}) },
+          previousFormatting,
+        } satisfies ParagraphPropertyChangeAttrs,
+      ],
+    });
+  }
+  return { transaction: next, nextRevisionId };
 };
 
 const buildInsertedParagraphs = ({
@@ -2153,6 +2255,16 @@ const applyFolioAIEditOperationsInternal = ({
   if (tr.docChanged) {
     const batchRevisionIds = new Set(applied.flatMap(({ revisionIds }) => revisionIds ?? []));
     tr = withoutRevisionsOnZeroWidthAnchors(tr, batchRevisionIds);
+    const rotated = withRotatedAddedFinalBreaks({
+      tr,
+      batchRevisionIds,
+      revisionSeed,
+      author,
+      date,
+      initials,
+    });
+    tr = rotated.transaction;
+    revisionSeed = rotated.nextRevisionId;
     if (revisionStamp) {
       // Paragraphs this batch creates get their `w14:paraId` from the
       // allocator plugin, which is random by default. A stamped batch has

--- a/packages/core/src/compare/README.md
+++ b/packages/core/src/compare/README.md
@@ -151,24 +151,33 @@ say it went.
   needed: pairing the two ends where the chain does reach the carrier would
   trade a plain "this paragraph was removed" for a removal plus a rewrite that
   reads nothing like the edit.
-- **An inserted mark at a container's end is the mirror case, and stands.** The
-  break was ADDED, so the paragraph it ends was not there before it, and
-  rejecting the addition removes the paragraph and leaves the container ending
-  where it did.
+- **An inserted mark at a container's end rotates the same way.** The break was
+  ADDED, and rejecting an added break closes the paragraph it ends back over
+  the NEXT one — which a container's last paragraph does not have, so the mark
+  survives accepting everything and rejecting everything alike. The break
+  therefore sits where it belongs: between the paragraph the run was appended
+  after and the first appended one. That paragraph's mark is the inserted one,
+  each appended paragraph but the last keeps an inserted mark of its own, and
+  the paragraph the container now ends with takes the free mark, recording the
+  other's properties as `w:pPrChange`. Only which paragraph is left markless
+  changes, so `[A][B ¶ins][C ¶kept]` accepts to `A ¶ B ¶ C` and rejects to
+  `A ¶ B`. The rotation reaches across paragraphs and no further: a table among
+  the appended blocks stops it, and the words the target ends with are written
+  into the base's own last paragraph instead.
 
 The serialize stage refuses a package whose final paragraph mark carries a
-deletion, with `CompareDocxFinalParagraphMarkError` naming the container and
-the paragraph. That one is fatal under `onUnverified: "emit"` too: unlike an
-unproven redline there is no partial result worth handing back, because the
-file does not open. A cell of a row the package is DELETING is the exception
-the format asks for: `w:trPr/w:del` plus a deletion on every mark its cells
-end with is how a removed row is written, and those marks leave with the row.
+revision in either direction, with `CompareDocxFinalParagraphMarkError` naming
+the container and the paragraph. That one is fatal under `onUnverified:
+"emit"` too: unlike an unproven redline there is no partial result worth
+handing back, because the file does not open, or opens carrying a revision no
+reader can clear. A cell of a row the package is DELETING is the exception the
+format asks for: `w:trPr/w:del` plus a deletion on every mark its cells end
+with is how a removed row is written, and those marks leave with the row.
 
-Handing the last new paragraph's mark to the ANCHOR instead reads closer to
-what an editor writes, and is equivalent only while the two stay adjacent. A
-later operation in the same batch — a table inserted between them — separates
-them, and the mark then joins the anchor to the table, which is nothing. The
-rule above needs no adjacency.
+Which paragraph ends a container is settled only when the whole batch is, so
+the rotation runs once over the finished document rather than at each
+insertion: an insertion that looked final is not one after the next operation
+writes a table past it.
 
 A body and every table cell end with a paragraph: a table may never be a
 container's last child. A comparison that adds a table at the end therefore
@@ -240,9 +249,10 @@ Every `detail` is structural — counts, offsets, container kinds — and carrie
 phrase of either document, so it is safe to log, report, or quote.
 
 A parse, apply or serialize failure is still an error under either setting:
-there is no redline to emit. So is a deletion on a container's final paragraph
-mark, for the same reason at the other end — the bytes would be written, and no
-consumer would open them.
+there is no redline to emit. So is any revision on a container's final
+paragraph mark, for the same reason at the other end — the bytes would be
+written, and no consumer would open them, or would open them carrying a
+revision neither accepting nor rejecting everything can clear.
 
 A SKIPPED operation is not automatically one of those. An operation the applier
 had nothing to write for, or could not write in that place — a paragraph inside

--- a/packages/core/src/compare/README.md
+++ b/packages/core/src/compare/README.md
@@ -129,7 +129,28 @@ say it went.
   A paragraph's properties live on its mark, so the carrier's become the
   target's, written as `w:pPrChange` — that is bookkeeping for the merge and
   adds no entry to the change list, which says what it should say: the
-  paragraphs were removed.
+  paragraphs were removed. A carrier with no words to lose is not deleted at
+  all: the removal is entirely the marks in front of it, and an operation that
+  would write no revision is left out of the plan.
+- **Paragraphs ADDED where the removed ones were land in the carrier.** The
+  last of them is written into it as inserted runs before its kept mark; the
+  rest become inserted paragraphs, marks and all, in front of it. So
+  `[del A ¶del][del B][ins A'] ¶kept` accepts to `A'` and rejects to `A ¶ B`,
+  and `[del A ¶del][del B][ins P1 ¶ins][ins P2] ¶kept` accepts to `P1 ¶ P2`.
+  The mark count then works out on its own — one deleted for every removed
+  paragraph but the carrier, one inserted for every added paragraph but the
+  last — so the chain above is not rotated as well.
+- **A carrier nothing precedes is reserved for the target's last paragraph.**
+  A deleted mark joins two paragraphs of ONE container, so with nothing of that
+  container in front of the carrier there is no chain a removal could run down:
+  an empty body, or the blank paragraph a body that ends in a table has to
+  carry because a table may not be a body's last child. The words the story
+  ends with are then written into the carrier, and the alignment is told to
+  hold the two last paragraphs out as a pair before it runs. That is a repair
+  rather than a preference, and the alignment is what says whether it is
+  needed: pairing the two ends where the chain does reach the carrier would
+  trade a plain "this paragraph was removed" for a removal plus a rewrite that
+  reads nothing like the edit.
 - **An inserted mark at a container's end is the mirror case, and stands.** The
   break was ADDED, so the paragraph it ends was not there before it, and
   rejecting the addition removes the paragraph and leaves the container ending
@@ -139,7 +160,9 @@ The serialize stage refuses a package whose final paragraph mark carries a
 deletion, with `CompareDocxFinalParagraphMarkError` naming the container and
 the paragraph. That one is fatal under `onUnverified: "emit"` too: unlike an
 unproven redline there is no partial result worth handing back, because the
-file does not open.
+file does not open. A cell of a row the package is DELETING is the exception
+the format asks for: `w:trPr/w:del` plus a deletion on every mark its cells
+end with is how a removed row is written, and those marks leave with the row.
 
 Handing the last new paragraph's mark to the ANCHOR instead reads closer to
 what an editor writes, and is equivalent only while the two stay adjacent. A
@@ -220,6 +243,15 @@ A parse, apply or serialize failure is still an error under either setting:
 there is no redline to emit. So is a deletion on a container's final paragraph
 mark, for the same reason at the other end — the bytes would be written, and no
 consumer would open them.
+
+A SKIPPED operation is not automatically one of those. An operation the applier
+had nothing to write for, or could not write in that place — a paragraph inside
+a text box or a content control, where a paragraph mark has nowhere to go —
+leaves the redline standing, and whether anything was lost by it is the
+question the round trip already answers. A skip that says the plan did not
+match the document it was planned against is the other kind: the operations
+came from that very snapshot moments earlier, so nothing should have moved
+under them, and the call fails with `CompareDocxApplyError`.
 
 ## Inputs that already carry tracked changes
 

--- a/packages/core/src/compare/compare.property.test.ts
+++ b/packages/core/src/compare/compare.property.test.ts
@@ -23,7 +23,7 @@ import type { FolioAIBlock } from "../ai-edits/types";
 import { compareDocx } from "./compare";
 import { applyEditScript, type EditScript, type EditScriptStep } from "./scenario";
 import type { CompareChange, CompareResult } from "./types";
-import { deletedFinalParagraphMarks } from "./verification";
+import { revisedFinalParagraphMarks } from "./verification";
 
 const FIXTURES_DIR = path.join(import.meta.dir, "../docx/__tests__/__fixtures__/corpus");
 
@@ -427,18 +427,22 @@ const trailingRewriteScriptArb = (
   if (tail.length === 0) {
     return null;
   }
+  const lastIndex = tail.at(-1) ?? 0;
   return fc
     .record({
-      removed: fc.integer({ min: 1, max: Math.min(tail.length, 4) }),
+      // Zero removed is a plain append past the container's end, where the
+      // mark that was ADDED has the same nowhere to go.
+      removed: fc.integer({ min: 0, max: Math.min(tail.length, 4) }),
       inserted: fc.array(sentenceArb, { minLength: 0, maxLength: 3 }),
       anchor: fc.constantFrom("first" as const, "last" as const),
     })
+    .filter(({ removed, inserted }) => removed > 0 || inserted.length > 0)
     .map(({ removed, inserted, anchor }) => {
       const run = tail.slice(tail.length - removed);
-      const anchorIndex = anchor === "first" ? run[0] : run.at(-1);
+      const anchorIndex = (anchor === "first" ? run[0] : run.at(-1)) ?? lastIndex;
       const steps: EditScriptStep[] = inserted.map((text) => ({
         type: "insertParagraphAfter" as const,
-        blockIndex: anchorIndex ?? 0,
+        blockIndex: anchorIndex,
         text,
       }));
       for (const blockIndex of run) {
@@ -662,14 +666,17 @@ describe("compareDocx", () => {
 
   for (const { name, buffer: base, blocks: baseBlocks } of BASE_CASES) {
     test(
-      `no container's final paragraph mark is ever deleted (${name})`,
+      `no container's final paragraph mark carries any revision (${name})`,
       async () => {
         // A deleted paragraph mark means "merge this paragraph into the
-        // following one", and the last paragraph of a body, a cell, a header,
-        // a note or a text box has no following one: a consumer reading such a
-        // mark refuses the package rather than opening it. Read back from the
-        // bytes the comparison produced, so it covers what was written and not
-        // only what was planned.
+        // following one" and an inserted one means the break was added, so
+        // rejecting it closes the paragraph back over the next one. The last
+        // paragraph of a body, a cell, a header, a note or a text box has no
+        // following one, so neither states an edit a reader can carry out: one
+        // makes a consumer refuse the package, the other leaves a revision
+        // standing that neither accepting nor rejecting everything can clear.
+        // Read back from the bytes the comparison produced, so it covers what
+        // was written and not only what was planned.
         await fc.assert(
           fc.asyncProperty(roundTripScriptArb(baseBlocks), async (script) => {
             const scripted = await applyEditScript(base, script);
@@ -678,7 +685,7 @@ describe("compareDocx", () => {
             }
             const { buffer } = await compareOrThrow(base, scripted.value.buffer);
             const written = await FolioDocxReviewer.fromBuffer(buffer);
-            expect(deletedFinalParagraphMarks(written.toDocument())).toEqual([]);
+            expect(revisedFinalParagraphMarks(written.toDocument())).toEqual([]);
           }),
           propertyConfig({ numRuns: 12 }),
         );

--- a/packages/core/src/compare/compare.property.test.ts
+++ b/packages/core/src/compare/compare.property.test.ts
@@ -396,6 +396,67 @@ const distinctByBlock = (steps: readonly EditScriptStep[]): EditScriptStep[] => 
   return distinct;
 };
 
+/** The body-level blocks a story ENDS with, as a contiguous run of indexes. */
+const trailingBodyIndexes = (blocks: readonly FolioAIBlock[]): number[] => {
+  const indexes: number[] = [];
+  for (let index = blocks.length - 1; index >= 0 && blocks[index]?.table === undefined; index--) {
+    indexes.unshift(index);
+  }
+  return indexes;
+};
+
+/**
+ * Scripts that remove the paragraphs a container ENDS with, with and without
+ * new paragraphs written where they were.
+ *
+ * That shape is where the container's final paragraph mark cannot say what
+ * happened: it is deleted nowhere, so the removal has to resolve onto the
+ * paragraph it ends and anything put in its place has to land INSIDE it. The
+ * general step arbitrary reaches the shape only by accident — it would have to
+ * draw the last body block and every block back to the surviving one, and
+ * never draw one twice — so it is generated on purpose here.
+ *
+ * The anchor covers both sides of the run: `"first"` puts the new paragraphs
+ * where the removed ones started, `"last"` after the paragraph the container
+ * ends with.
+ */
+const trailingRewriteScriptArb = (
+  blocks: readonly FolioAIBlock[],
+): fc.Arbitrary<EditScript> | null => {
+  const tail = trailingBodyIndexes(blocks);
+  if (tail.length === 0) {
+    return null;
+  }
+  return fc
+    .record({
+      removed: fc.integer({ min: 1, max: Math.min(tail.length, 4) }),
+      inserted: fc.array(sentenceArb, { minLength: 0, maxLength: 3 }),
+      anchor: fc.constantFrom("first" as const, "last" as const),
+    })
+    .map(({ removed, inserted, anchor }) => {
+      const run = tail.slice(tail.length - removed);
+      const anchorIndex = anchor === "first" ? run[0] : run.at(-1);
+      const steps: EditScriptStep[] = inserted.map((text) => ({
+        type: "insertParagraphAfter" as const,
+        blockIndex: anchorIndex ?? 0,
+        text,
+      }));
+      for (const blockIndex of run) {
+        steps.push({ type: "deleteParagraph", blockIndex });
+      }
+      return steps;
+    });
+};
+
+/**
+ * Every script shape the round trip has to hold for: the general edits, and
+ * the trailing rewrites the general ones do not reach.
+ */
+const roundTripScriptArb = (blocks: readonly FolioAIBlock[]): fc.Arbitrary<EditScript> => {
+  const trailing = trailingRewriteScriptArb(blocks);
+  return trailing ? fc.oneof(editScriptArb(blocks), trailing) : editScriptArb(blocks);
+};
+
 const kindsOf = (changes: readonly CompareChange[]): string[] => changes.map(({ kind }) => kind);
 
 /**
@@ -465,7 +526,7 @@ describe("compareDocx", () => {
       `accepting every change yields the target and rejecting yields the base (${name})`,
       async () => {
         await fc.assert(
-          fc.asyncProperty(editScriptArb(baseBlocks), async (script) => {
+          fc.asyncProperty(roundTripScriptArb(baseBlocks), async (script) => {
             const scripted = await applyEditScript(base, script);
             if (scripted.isErr()) {
               throw scripted.error;
@@ -610,7 +671,7 @@ describe("compareDocx", () => {
         // bytes the comparison produced, so it covers what was written and not
         // only what was planned.
         await fc.assert(
-          fc.asyncProperty(editScriptArb(baseBlocks), async (script) => {
+          fc.asyncProperty(roundTripScriptArb(baseBlocks), async (script) => {
             const scripted = await applyEditScript(base, script);
             if (scripted.isErr()) {
               throw scripted.error;
@@ -712,7 +773,7 @@ describe("compareDocx", () => {
         // from the operation vocabulary, so anything unverified here is a
         // defect in the engine rather than a document it cannot express.
         await fc.assert(
-          fc.asyncProperty(editScriptArb(baseBlocks), async (script) => {
+          fc.asyncProperty(roundTripScriptArb(baseBlocks), async (script) => {
             const scripted = await applyEditScript(base, script);
             if (scripted.isErr()) {
               throw scripted.error;

--- a/packages/core/src/compare/compare.ts
+++ b/packages/core/src/compare/compare.ts
@@ -661,7 +661,7 @@ export const applyComparison = (
  * one within a single run.
  */
 export const serializeComparison = async (
-  { baseBuffer, baseCarriedRevisions, reviewer, packageDate }: ParsedComparison,
+  { baseBuffer, baseCarriedRevisions, reviewer, packageDate, revisionStamp }: ParsedComparison,
   { documentChanged }: AppliedComparison,
 ): Promise<Result<ArrayBuffer, CompareDocxSerializeError | CompareDocxFinalParagraphMarkError>> => {
   if (!baseCarriedRevisions && !documentChanged) {
@@ -673,7 +673,12 @@ export const serializeComparison = async (
   // and neither is an edit that can be carried out. Nothing downstream can
   // recover from that, so it is fatal under either `onUnverified` setting:
   // unlike an unproven redline there is no partial result worth handing back.
-  const revisions = revisedFinalParagraphMarks(document);
+  //
+  // Scoped to the revisions this comparison minted. A base can arrive carrying
+  // one on a paragraph of a part no story mounts, so resolving to its accepted
+  // view does not reach it; folio preserves what it parses, and refusing the
+  // comparison would report the base's own bytes as this call's doing.
+  const revisions = revisedFinalParagraphMarks(document, { since: revisionStamp.idSeed });
   const [first] = revisions;
   if (first !== undefined) {
     return Result.err(

--- a/packages/core/src/compare/compare.ts
+++ b/packages/core/src/compare/compare.ts
@@ -45,7 +45,7 @@ import {
 } from "../ai-edits/headless";
 import { projectTableGeometry } from "../ai-edits/table-geometry";
 import type { FolioTableTemplates } from "../ai-edits/table-template";
-import type { FolioAIBlock, FolioAIEditSnapshot } from "../ai-edits/types";
+import type { FolioAIBlock, FolioAIEditSkipReason, FolioAIEditSnapshot } from "../ai-edits/types";
 import type { WordDiffGranularity } from "../ai-edits/word-diff";
 import { FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION } from "../document-operations";
 import { pairFolioDocumentStories } from "../document-stories";
@@ -302,6 +302,24 @@ export const parseComparison = async (
   const reviewer = baseParse.value;
   const targetReviewer = targetParse.value;
   const existing = existingRevisionsOf(reviewer);
+  // Compare the accepted view of both sides. An input that already carries
+  // revisions otherwise makes the result unreadable: the redline would layer
+  // this comparison's marks on top of someone else's, and rejecting them all
+  // would land on neither document. Accepting first states one question --
+  // how does the base as it stands differ from the target as it stands --
+  // and leaves the answer as the only redline in the package.
+  //
+  // EVERY story, not only the paired ones. A note or a header the other side
+  // does not have is reported rather than compared, but the base's copy of it
+  // still ships in the result, so it ships accepted like the rest -- and an
+  // unresolvable mark it carried, on the paragraph a note ends with, would
+  // otherwise fail the structural guard on bytes this comparison never wrote.
+  for (const { handle } of reviewer.listStories()) {
+    reviewer.resolveReviewedStory({ story: handle, view: "final" });
+  }
+  for (const { handle } of targetReviewer.listStories()) {
+    targetReviewer.resolveReviewedStory({ story: handle, view: "final" });
+  }
   const pairs: ComparedStoryPair[] = [];
   const unsupported: CompareUnsupportedPart[] = [];
 
@@ -317,15 +335,6 @@ export const parseComparison = async (
       unsupported.push({ reason: "story-missing-in-target", baseStory, targetStory: null });
       continue;
     }
-    // Compare the accepted view of both sides. An input that already carries
-    // revisions otherwise makes the result unreadable: the redline would layer
-    // this comparison's marks on top of someone else's, and rejecting them all
-    // would land on neither document. Accepting first states one question --
-    // how does the base as it stands differ from the target as it stands --
-    // and leaves the answer as the only redline in the package.
-    reviewer.resolveReviewedStory({ story: baseStory, view: "final" });
-    targetReviewer.resolveReviewedStory({ story: targetStory, view: "final" });
-
     const baseSnapshot = reviewer.snapshotStory(baseStory);
     const targetSnapshot = targetReviewer.snapshotStory(targetStory);
     if (!baseSnapshot || !targetSnapshot) {
@@ -379,6 +388,38 @@ export const planComparison = ({
   }
   return Result.ok(planned);
 };
+
+/**
+ * What a skipped operation says about the plan that derived it.
+ *
+ * Two different things go wrong at apply time, and only one of them leaves the
+ * result unusable. A reason that says the plan did not match the document it
+ * was planned against is an engine defect — the operations came from this very
+ * snapshot moments earlier, so nothing should have moved under them, and a
+ * redline built on the rest is built on a document the plan no longer
+ * describes. A reason that says the applier had nothing to write, or could not
+ * write that shape THERE, leaves the redline standing and turns the question
+ * into "was anything lost", which is what the round-trip check answers a few
+ * lines below. Refusing on those instead trades a partial answer for none, and
+ * refuses a whole document because one paragraph sits inside a structure the
+ * block snapshot does not model — a text box, a content control — where a
+ * paragraph mark has nowhere to go.
+ */
+const COMPARE_SKIP_DISPOSITION = {
+  missingBlock: "fatal",
+  changedBlock: "fatal",
+  ambiguousFind: "fatal",
+  missingFind: "fatal",
+  unsupportedBlock: "unwritable",
+  unsupportedMode: "fatal",
+  atomicBatchRejected: "fatal",
+  preconditionFailed: "fatal",
+  staleRange: "fatal",
+  emptyOperation: "unwritable",
+  noopOperation: "unwritable",
+  documentVersionMismatch: "fatal",
+  documentNotEditable: "fatal",
+} as const satisfies Record<FolioAIEditSkipReason, "fatal" | "unwritable">;
 
 /** What stage 3 produced: the change list, whether it was proven, and whether it wrote anything. */
 export type AppliedComparison = {
@@ -509,12 +550,13 @@ export const applyComparison = (
       }
       idSeed = nextRevisionId;
       documentChanged = true;
-      if (skipped.length > 0) {
+      const refused = skipped.filter(({ reason }) => COMPARE_SKIP_DISPOSITION[reason] === "fatal");
+      if (refused.length > 0) {
         return Result.err(
           new CompareDocxApplyError({
             message:
               "Some derived operations were refused, so the result would not match the target.",
-            skipped,
+            skipped: refused,
           }),
         );
       }

--- a/packages/core/src/compare/compare.ts
+++ b/packages/core/src/compare/compare.ts
@@ -68,7 +68,7 @@ import {
 import {
   classifyGeometryMismatch,
   classifyProjectionMismatch,
-  deletedFinalParagraphMarks,
+  revisedFinalParagraphMarks,
   projectSupportedInlineFormatting,
   type CompareVerification,
   type CompareVerificationFailure,
@@ -668,21 +668,21 @@ export const serializeComparison = async (
     return Result.ok(baseBuffer);
   }
   const document = reviewer.toDocument();
-  // A deleted mark on the paragraph that ends a container asks a consumer to
-  // merge it with a paragraph that is not there, and the consumer refuses the
-  // whole package rather than opening it. Nothing downstream can recover from
-  // that, so it is fatal under either `onUnverified` setting: unlike an
-  // unproven redline there is no partial result worth handing back.
-  const deletions = deletedFinalParagraphMarks(document);
-  const [firstDeletion] = deletions;
-  if (firstDeletion !== undefined) {
+  // A revision on the paragraph that ends a container asks a consumer to merge
+  // it with a paragraph that is not there, or to close a break back over one,
+  // and neither is an edit that can be carried out. Nothing downstream can
+  // recover from that, so it is fatal under either `onUnverified` setting:
+  // unlike an unproven redline there is no partial result worth handing back.
+  const revisions = revisedFinalParagraphMarks(document);
+  const [first] = revisions;
+  if (first !== undefined) {
     return Result.err(
       new CompareDocxFinalParagraphMarkError({
         message:
-          `A container's final paragraph mark carries a ${firstDeletion.kind}, which no ` +
-          `consumer can resolve: ${firstDeletion.container} paragraph ` +
-          `${String(firstDeletion.paragraphIndex)}.`,
-        deletions,
+          `A container's final paragraph mark carries a ${first.kind}, which no ` +
+          `consumer can resolve: ${first.container} paragraph ` +
+          `${String(first.paragraphIndex)}.`,
+        revisions,
       }),
     );
   }

--- a/packages/core/src/compare/plan.test.ts
+++ b/packages/core/src/compare/plan.test.ts
@@ -196,39 +196,72 @@ describe("document-terminal paragraph carrier", () => {
     }
   });
 
-  test("does not reserve a textless paragraph that contains inline content", () => {
+  test("a carrier the merge chain reaches is removed rather than reserved", () => {
+    // The reservation is a repair for a carrier nothing can reach, not a
+    // preference. Where a paragraph of the same container survives in front of
+    // it, the removal resolves down the chain and the reader is told the last
+    // paragraph went — not that the one before it went and the last was
+    // rewritten into its words, which is what pairing the two ends would say.
     const base = [
-      cell("kept", "Kept row", 0),
-      block("between", ""),
-      cell("removed", "Removed row", 0, 1),
-      block("base-carrier", ""),
+      block("alpha", RELOCATED),
+      block("bravo", UNRELATED),
+      block("charlie", RELOCATED_EDITED),
     ];
-    const target = [cell("kept-target", "Kept row", 0), block("target-content", "")];
-    const targetSnapshot = snapshotOf(target);
-    const targetAnchor = targetSnapshot.anchors["target-content"];
-    if (!targetAnchor) {
-      throw new Error("The target fixture is missing its anchor.");
-    }
-    targetAnchor.to += 1;
+    const target = [block("alpha-target", RELOCATED), block("bravo-target", UNRELATED)];
 
-    const plan = planStoryCompare({
-      story: MAIN_STORY,
-      baseSnapshot: snapshotOf(base),
-      targetSnapshot,
-      maxOperations: 1000,
-    });
-    if (plan === null) {
-      throw new Error("The plan exceeded its operation budget.");
-    }
+    const { changes, operations } = planOf(base, target);
 
-    expect(plan.operations).toContainEqual({
-      id: "compare-2",
-      type: "deleteBlock",
-      blockId: "base-carrier",
-    });
+    expect(changes).toContainEqual(
+      expect.objectContaining({ kind: "delete", baseBlockId: "charlie" }),
+    );
+    expect(changes).not.toContainEqual(expect.objectContaining({ baseBlockId: "bravo" }));
+    expect(operations).toContainEqual(
+      expect.objectContaining({ type: "mergeBlockWithNext", blockId: "bravo" }),
+    );
   });
 
-  test("does not apply the body-only carrier rule to headers", () => {
+  test("insertions placed in a cell's removed run land in the cell's carrier", () => {
+    // The target's first cell grew two paragraphs and its second cell is gone,
+    // so the additions anchor on the paragraph the removed cell ends with —
+    // the one whose mark cannot say it went. The last of them is written INTO
+    // that carrier and the rest go in front of it, which is what makes the
+    // mark count work out without deleting a mark the format keeps.
+    const base = [
+      gridCell("a0", "Alpha clause states the agreed position.", 0, 0, 0),
+      gridCell("b0", "Payment falls due within thirty days of invoice.", 0, 1, 1),
+    ];
+    const target = [
+      gridCell("ta", "Alpha clause states the agreed position.", 0, 0, 0),
+      gridCell("tb", "Notices travel to the address named above.", 0, 0, 0),
+      gridCell("tc", "Governing law is that of the named place.", 0, 0, 0),
+    ];
+
+    const { operations } = planOf(base, target);
+
+    expect(operations).toContainEqual(
+      expect.objectContaining({
+        type: "insertBeforeBlock",
+        blockId: "b0",
+        text: "Notices travel to the address named above.",
+      }),
+    );
+    expect(operations).toContainEqual(
+      expect.objectContaining({
+        type: "replaceBlock",
+        blockId: "b0",
+        text: "Governing law is that of the named place.",
+      }),
+    );
+    expect(operations).not.toContainEqual(
+      expect.objectContaining({ type: "deleteBlock", blockId: "b0" }),
+    );
+  });
+
+  test("reserves a stranded final paragraph in a header story too", () => {
+    // A header ends with a paragraph for the same reason a body does, and its
+    // mark is as unable to say it went. Nothing of the header's own container
+    // survives in front of this carrier — a table sits there — so no merge
+    // chain reaches it and the words the story ends with have to land on it.
     const base = [
       cell("kept", "Kept row", 0),
       block("between", ""),
@@ -246,11 +279,12 @@ describe("document-terminal paragraph carrier", () => {
       throw new Error("The plan exceeded its operation budget.");
     }
 
-    expect(plan.operations).toContainEqual({
-      id: "compare-2",
-      type: "deleteBlock",
-      blockId: "base-carrier",
-    });
+    expect(plan.changes).not.toContainEqual(
+      expect.objectContaining({ kind: "delete", baseBlockId: "base-carrier" }),
+    );
+    expect(plan.operations).not.toContainEqual(
+      expect.objectContaining({ type: "deleteBlock", blockId: "base-carrier" }),
+    );
   });
 });
 

--- a/packages/core/src/compare/plan.ts
+++ b/packages/core/src/compare/plan.ts
@@ -1180,8 +1180,15 @@ const withTrailingDeletionRules = ({
       holdsAnInsertedTable ||= tableAnchorIds.has(block.id);
     }
     // The plan emits operations in target order, so the plan's own order is
-    // the order the inserted paragraphs have to end up in.
-    return { blockIds, chainStart, insertIndexes: insertIndexes.toSorted(), holdsAnInsertedTable };
+    // the order the inserted paragraphs have to end up in. Numerically: the
+    // walk collects them container-block by container-block, and the default
+    // comparator would sort index 10 in front of index 2.
+    return {
+      blockIds,
+      chainStart,
+      insertIndexes: insertIndexes.toSorted((left, right) => left - right),
+      holdsAnInsertedTable,
+    };
   };
 
   const targetLastByContainer = lastBlockByContainer(targetSnapshot.blocks);

--- a/packages/core/src/compare/plan.ts
+++ b/packages/core/src/compare/plan.ts
@@ -640,7 +640,9 @@ const terminalCarrierIsStranded = (
   if (carrier === undefined) {
     return false;
   }
-  const removed = new Set(steps.flatMap((step) => (step.type === "baseOnly" ? [step.block.id] : [])));
+  const removed = new Set(
+    steps.flatMap((step) => (step.type === "baseOnly" ? [step.block.id] : [])),
+  );
   if (!removed.has(carrier.id)) {
     return false;
   }
@@ -1198,8 +1200,7 @@ const withTrailingDeletionRules = ({
       continue;
     }
     const lastInsertIndex = run.insertIndexes.at(-1);
-    const lastInsert = lastInsertIndex === undefined ? undefined : plan[lastInsertIndex];
-    if (lastInsert === undefined) {
+    if (lastInsertIndex === undefined) {
       if (run.chainStart) {
         appended.push({
           id: nextOperationId(),
@@ -1211,7 +1212,9 @@ const withTrailingDeletionRules = ({
         dropped.add(carrierDeletionIndex);
       }
     } else {
+      const lastInsert = plan[lastInsertIndex];
       if (
+        lastInsert === undefined ||
         (lastInsert.type !== "insertBeforeBlock" && lastInsert.type !== "insertAfterBlock") ||
         lastInsert.moveId !== undefined
       ) {

--- a/packages/core/src/compare/plan.ts
+++ b/packages/core/src/compare/plan.ts
@@ -659,6 +659,41 @@ const terminalCarrierIsStranded = (
   return true;
 };
 
+/**
+ * Whether an alignment ADDED the story's last paragraph with something other
+ * than paragraphs between it and the base's.
+ *
+ * An inserted mark at a container's end has the same problem its deletion
+ * does: nothing follows it, so rejecting the addition cannot close the break
+ * back over the next paragraph. The applier rotates instead — the paragraph
+ * the run was appended after takes the inserted mark, and the last one takes
+ * the free mark — and that rotation reaches only across paragraphs. A table
+ * among them stops it, and the words the target ends with have to be written
+ * into the base's own last paragraph instead.
+ */
+const addedTerminalCarrierIsStranded = (
+  steps: readonly CompareStep[],
+  baseBlocks: readonly FolioAIBlock[],
+  targetBlocks: readonly FolioAIBlock[],
+): boolean => {
+  const baseLast = baseBlocks.at(-1);
+  const targetLast = targetBlocks.at(-1);
+  if (baseLast === undefined || targetLast === undefined) {
+    return false;
+  }
+  if (!steps.some((step) => step.type === "targetOnly" && step.block.id === targetLast.id)) {
+    return false;
+  }
+  const baseLastStep = steps.findIndex(
+    (step) =>
+      (step.type === "pair" && step.baseBlock.id === baseLast.id) ||
+      (step.type === "baseOnly" && step.block.id === baseLast.id),
+  );
+  return (
+    baseLastStep === -1 || steps.slice(baseLastStep + 1).some((step) => step.type !== "targetOnly")
+  );
+};
+
 const buildSteps = ({ baseSnapshot, targetSnapshot }: BuildStepsOptions): CompareStep[] => {
   const baseBlocks = baseSnapshot.blocks;
   const targetBlocks = targetSnapshot.blocks;
@@ -681,7 +716,9 @@ const buildSteps = ({ baseSnapshot, targetSnapshot }: BuildStepsOptions): Compar
   // is what says whether it is needed: pairing the two last paragraphs where
   // the ordinary alignment reaches the carrier would trade a plain "this
   // paragraph was removed" for a removal plus a rewrite that reads nothing
-  // like the edit.
+  // like the edit. Both ends can need it, because the mark that ends a
+  // container carries no revision in either direction.
+  //
   // The carrier can only take the target's last paragraph when that paragraph
   // is its opposite number: a story ends with a body paragraph, and a target
   // whose last block sits in a table cell has nothing to hand it.
@@ -689,7 +726,10 @@ const buildSteps = ({ baseSnapshot, targetSnapshot }: BuildStepsOptions): Compar
     carrierPair === null ||
     bothStoriesEndBlank ||
     !shareAContainer(carrierPair.baseBlock, carrierPair.targetBlock) ||
-    !terminalCarrierIsStranded(steps, baseBlocks)
+    !(
+      terminalCarrierIsStranded(steps, baseBlocks) ||
+      addedTerminalCarrierIsStranded(steps, baseBlocks, targetBlocks)
+    )
   ) {
     return steps;
   }

--- a/packages/core/src/compare/plan.ts
+++ b/packages/core/src/compare/plan.ts
@@ -470,7 +470,6 @@ const unpairedSegmentSteps = (segment: DocumentSegment, side: "base" | "target")
 };
 
 type BuildStepsOptions = {
-  story: FolioDocumentStoryHandle;
   baseSnapshot: FolioAIEditSnapshot;
   targetSnapshot: FolioAIEditSnapshot;
 };
@@ -585,23 +584,14 @@ const isEmptyParagraphNode = (block: FolioAIBlock, snapshot: FolioAIEditSnapshot
   return block.text === "" && block.table === undefined && anchor.to - anchor.from === 2;
 };
 
-const buildSteps = ({ story, baseSnapshot, targetSnapshot }: BuildStepsOptions): CompareStep[] => {
-  const baseBlocks = baseSnapshot.blocks;
-  const targetBlocks = targetSnapshot.blocks;
-  // A body's final paragraph mark survives accepting or rejecting a deletion
-  // on it: nothing follows it to merge into. When both sides end in a truly
-  // empty paragraph node, reserve that structural carrier before general
-  // alignment and compare its supported properties normally.
-  const baseLast = baseBlocks.at(-1);
-  const targetLast = targetBlocks.at(-1);
-  const terminalCarrierPair =
-    story.type === "main" &&
-    baseLast !== undefined &&
-    isEmptyParagraphNode(baseLast, baseSnapshot) &&
-    targetLast !== undefined &&
-    isEmptyParagraphNode(targetLast, targetSnapshot)
-      ? { type: "pair" as const, baseBlock: baseLast, targetBlock: targetLast }
-      : null;
+type TerminalCarrierPair = Extract<CompareStep, { type: "pair" }>;
+
+/** Align both stories, optionally holding the two last paragraphs out as a pair. */
+const alignedSteps = (
+  baseBlocks: readonly FolioAIBlock[],
+  targetBlocks: readonly FolioAIBlock[],
+  terminalCarrierPair: TerminalCarrierPair | null,
+): CompareStep[] => {
   const alignedBaseBlocks = terminalCarrierPair ? baseBlocks.slice(0, -1) : baseBlocks;
   const alignedTargetBlocks = terminalCarrierPair ? targetBlocks.slice(0, -1) : targetBlocks;
   const steps: CompareStep[] = [];
@@ -629,6 +619,79 @@ const buildSteps = ({ story, baseSnapshot, targetSnapshot }: BuildStepsOptions):
     steps.push(terminalCarrierPair);
   }
   return steps;
+};
+
+/**
+ * Whether an alignment left the story's last paragraph removed with no
+ * paragraph of its own container surviving in front of it.
+ *
+ * That paragraph's mark is the one a story cannot lose, and a deleted mark
+ * joins two paragraphs of ONE container, so with nothing of that container in
+ * front of it there is no chain a removal could run down. The paragraph then
+ * stays whatever the plan says, and the story ends on a blank line the target
+ * does not have — unless the words the target ends with are written into it,
+ * which is what reserving it for the target's last paragraph does.
+ */
+const terminalCarrierIsStranded = (
+  steps: readonly CompareStep[],
+  baseBlocks: readonly FolioAIBlock[],
+): boolean => {
+  const carrier = baseBlocks.at(-1);
+  if (carrier === undefined) {
+    return false;
+  }
+  const removed = new Set(steps.flatMap((step) => (step.type === "baseOnly" ? [step.block.id] : [])));
+  if (!removed.has(carrier.id)) {
+    return false;
+  }
+  const container = containerKeyOf(carrier);
+  for (let index = baseBlocks.length - 2; index >= 0; index--) {
+    const block = baseBlocks[index];
+    if (block === undefined || containerKeyOf(block) !== container) {
+      return true;
+    }
+    if (!removed.has(block.id)) {
+      return false;
+    }
+  }
+  return true;
+};
+
+const buildSteps = ({ baseSnapshot, targetSnapshot }: BuildStepsOptions): CompareStep[] => {
+  const baseBlocks = baseSnapshot.blocks;
+  const targetBlocks = targetSnapshot.blocks;
+  const baseLast = baseBlocks.at(-1);
+  const targetLast = targetBlocks.at(-1);
+  const carrierPair =
+    baseLast !== undefined && targetLast !== undefined
+      ? ({ type: "pair", baseBlock: baseLast, targetBlock: targetLast } as const)
+      : null;
+  // A body's final paragraph mark survives accepting or rejecting a deletion
+  // on it: nothing follows it to merge into. When both sides end in a truly
+  // empty paragraph node, reserve that structural carrier before general
+  // alignment and compare its supported properties normally.
+  const bothStoriesEndBlank =
+    carrierPair !== null &&
+    isEmptyParagraphNode(carrierPair.baseBlock, baseSnapshot) &&
+    isEmptyParagraphNode(carrierPair.targetBlock, targetSnapshot);
+  const steps = alignedSteps(baseBlocks, targetBlocks, bothStoriesEndBlank ? carrierPair : null);
+  // Otherwise the reservation is a repair, not a preference, and the alignment
+  // is what says whether it is needed: pairing the two last paragraphs where
+  // the ordinary alignment reaches the carrier would trade a plain "this
+  // paragraph was removed" for a removal plus a rewrite that reads nothing
+  // like the edit.
+  // The carrier can only take the target's last paragraph when that paragraph
+  // is its opposite number: a story ends with a body paragraph, and a target
+  // whose last block sits in a table cell has nothing to hand it.
+  if (
+    carrierPair === null ||
+    bothStoriesEndBlank ||
+    !shareAContainer(carrierPair.baseBlock, carrierPair.targetBlock) ||
+    !terminalCarrierIsStranded(steps, baseBlocks)
+  ) {
+    return steps;
+  }
+  return alignedSteps(baseBlocks, targetBlocks, carrierPair);
 };
 
 /**
@@ -986,116 +1049,215 @@ const lastBlockByContainer = (
 type TrailingDeletionOptions = {
   baseSnapshot: FolioAIEditSnapshot;
   targetSnapshot: FolioAIEditSnapshot;
-  /** The plan so far, read for the blocks it deletes and where it inserts. */
+  /** The plan so far, rewritten around each container it empties. */
   operations: readonly FolioAIEditOperation[];
   nextOperationId: () => string;
 };
 
 /**
- * The operations that keep a container's final paragraph mark when the plan
- * deletes the paragraphs that end it.
+ * Where the plan's inserts land for one container's trailing deleted run, and
+ * which paragraph the merge chain starts from.
+ */
+type TrailingRun = {
+  /** The deleted blocks that end the container, carrier first. */
+  blockIds: readonly string[];
+  /** The last SURVIVING paragraph of the container, when its mark is free. */
+  chainStart: FolioAIBlock | null;
+  /** Indexes into the plan of the paragraph insertions placed in the run. */
+  insertIndexes: readonly number[];
+  /** A table the plan places inside the run, which no rule here covers. */
+  holdsAnInsertedTable: boolean;
+};
+
+/**
+ * Rewrite the plan so a container's final paragraph mark survives the removal
+ * of the paragraphs that end it.
  *
  * A deleted paragraph mark means "merge this paragraph into the following
  * one". A container's final paragraph has no following one, so the mark cannot
  * say it: the applier leaves that mark alone, and the removal has to be
- * expressed one paragraph earlier. The chain therefore runs from the last
- * SURVIVING paragraph forward — its mark goes, each removed paragraph's mark
- * goes with it, and the container's final paragraph stays as the carrier the
- * merged text lands in.
+ * expressed one paragraph earlier. The carrier is that final paragraph, and
+ * every trailing removal resolves onto it.
  *
- * The carrier keeps its own mark, and a paragraph's properties live on its
- * mark, so the merged paragraph ends up with the carrier's. Those properties
- * therefore become the target's, written as `w:pPrChange` so rejecting
- * restores what the carrier had. That is bookkeeping for the merge rather than
- * an edit of its own, so it adds no entry to the change list: what the reader
- * is told is that the paragraphs were removed.
+ * Nothing is inserted where the run was: the chain runs from the last
+ * SURVIVING paragraph forward. Its mark goes, each removed paragraph's mark
+ * goes with it, and the carrier loses its words and keeps its mark as the
+ * paragraph the merged text lands in. A carrier that has no words to lose is
+ * not deleted at all: its removal is entirely the marks in front of it, and an
+ * operation that would write no revision belongs nowhere in the plan.
  *
- * Nothing is rotated when the plan puts a block inside or after the run. The
- * carrier is then no longer what ends the container, its mark is deleted like
- * any other, and the count already works out.
+ * Something IS inserted there: the inserted paragraphs stand where the removed
+ * ones did, and the last of them lands INSIDE the carrier as inserted runs
+ * before its kept mark, so the carrier is the target's last paragraph rather
+ * than a blank line after it. The other inserted paragraphs carry inserted
+ * marks of their own and sit before the carrier. The mark count then works out
+ * on its own — one mark deleted for every removed paragraph but the carrier,
+ * one inserted for every added paragraph but the last — so the chain is not
+ * rotated as well.
+ *
+ * The carrier keeps its own mark either way, and a paragraph's properties live
+ * on its mark, so the merged paragraph ends up with the carrier's. Those
+ * properties therefore become the target's, written as `w:pPrChange` so
+ * rejecting restores what the carrier had. That is bookkeeping for the merge
+ * rather than an edit of its own, so it adds no entry to the change list: what
+ * the reader is told is that paragraphs were removed and paragraphs added.
  */
-const trailingDeletionOperations = ({
+const withTrailingDeletionRules = ({
   baseSnapshot,
   targetSnapshot,
   operations,
   nextOperationId,
 }: TrailingDeletionOptions): FolioAIEditOperation[] => {
-  const blocks = baseSnapshot.blocks;
-  const deletedBlockIds = new Set(
-    operations.flatMap((operation) =>
-      operation.type === "deleteBlock" ? [operation.blockId] : [],
-    ),
-  );
-  if (deletedBlockIds.size === 0) {
-    return [];
-  }
-  // Anchors of everything the plan PLACES in a container: a block landing in
-  // the run breaks the merge chain, and one landing after the carrier means
-  // the carrier no longer ends the container.
-  const placedAtBlockIds = new Set(
-    operations.flatMap((operation) =>
-      operation.type === "insertBeforeBlock" ||
-      operation.type === "insertAfterBlock" ||
-      operation.type === "insertTable"
-        ? [operation.blockId]
-        : [],
-    ),
-  );
+  const plan = [...operations];
+  const deletionIndexByBlockId = new Map<string, number>();
+  const insertIndexesByAnchor = new Map<string, number[]>();
+  const tableAnchorIds = new Set<string>();
   // A block whose own mark the plan already moves is not a chain start: a
   // split has put a second paragraph after it, and a merge has spent its mark.
-  const markedBlockIds = new Set(
-    operations.flatMap((operation) =>
-      operation.type === "splitBlock" || operation.type === "mergeBlockWithNext"
-        ? [operation.blockId]
-        : [],
-    ),
-  );
-  const targetLastByContainer = lastBlockByContainer(targetSnapshot.blocks);
-  const indexById = new Map(blocks.map((block, index) => [block.id, index]));
-  const added: FolioAIEditOperation[] = [];
-  for (const [container, carrier] of lastBlockByContainer(blocks)) {
-    if (!deletedBlockIds.has(carrier.id)) {
-      continue;
+  const markedBlockIds = new Set<string>();
+  for (const [index, operation] of plan.entries()) {
+    switch (operation.type) {
+      case "deleteBlock": {
+        deletionIndexByBlockId.set(operation.blockId, index);
+        break;
+      }
+      case "insertBeforeBlock":
+      case "insertAfterBlock": {
+        const placed = insertIndexesByAnchor.get(operation.blockId) ?? [];
+        placed.push(index);
+        insertIndexesByAnchor.set(operation.blockId, placed);
+        break;
+      }
+      case "insertTable": {
+        tableAnchorIds.add(operation.blockId);
+        break;
+      }
+      case "splitBlock":
+      case "mergeBlockWithNext": {
+        markedBlockIds.add(operation.blockId);
+        break;
+      }
+      default: {
+        break;
+      }
     }
+  }
+  if (deletionIndexByBlockId.size === 0) {
+    return plan;
+  }
+
+  const blocks = baseSnapshot.blocks;
+  const indexById = new Map(blocks.map((block, index) => [block.id, index]));
+  /**
+   * Walk back from a container's last block over the run of deleted
+   * paragraphs it ends with. A block of another container in between — a
+   * table between two body paragraphs, a table nested in a cell — ends the
+   * walk: no mark joins across it.
+   */
+  const trailingRunOf = (container: string, carrier: FolioAIBlock): TrailingRun => {
+    const blockIds: string[] = [];
+    const insertIndexes: number[] = [];
+    let chainStart: FolioAIBlock | null = null;
+    let holdsAnInsertedTable = false;
     let index =
       indexById.get(carrier.id) ??
       panic("A container's last block is not in the snapshot it came from", {
         blockId: carrier.id,
       });
-    let chainStart: FolioAIBlock | null = null;
-    let placedInRun = false;
-    // Backwards over the run of deleted paragraphs this container ends with. A
-    // block of another container in between — a table between two body
-    // paragraphs, a table nested in a cell — ends the walk: no mark joins
-    // across it.
     for (; index >= 0; index--) {
       const block = blocks[index];
       if (block === undefined || containerKeyOf(block) !== container) {
         break;
       }
-      if (!deletedBlockIds.has(block.id)) {
+      if (!deletionIndexByBlockId.has(block.id)) {
         chainStart = markedBlockIds.has(block.id) ? null : block;
         break;
       }
-      placedInRun ||= placedAtBlockIds.has(block.id);
+      blockIds.push(block.id);
+      insertIndexes.push(...(insertIndexesByAnchor.get(block.id) ?? []));
+      holdsAnInsertedTable ||= tableAnchorIds.has(block.id);
     }
-    if (placedInRun) {
+    // The plan emits operations in target order, so the plan's own order is
+    // the order the inserted paragraphs have to end up in.
+    return { blockIds, chainStart, insertIndexes: insertIndexes.toSorted(), holdsAnInsertedTable };
+  };
+
+  const targetLastByContainer = lastBlockByContainer(targetSnapshot.blocks);
+  const dropped = new Set<number>();
+  const appended: FolioAIEditOperation[] = [];
+  for (const [container, carrier] of lastBlockByContainer(blocks)) {
+    const carrierDeletionIndex = deletionIndexByBlockId.get(carrier.id);
+    if (carrierDeletionIndex === undefined) {
       continue;
     }
-    if (chainStart) {
-      added.push({
-        id: nextOperationId(),
-        type: "mergeBlockWithNext",
-        blockId: chainStart.id,
-      });
+    const run = trailingRunOf(container, carrier);
+    if (run.holdsAnInsertedTable) {
+      // A table between the chain and the carrier leaves a deleted mark with
+      // no paragraph to join, and the self-check reports what it could not
+      // prove rather than the plan guessing at a shape.
+      continue;
     }
-    // The merged paragraph is the target's last one in this container, and it
-    // ends on the carrier's mark, so the carrier is where its properties have
-    // to be.
+    const lastInsertIndex = run.insertIndexes.at(-1);
+    const lastInsert = lastInsertIndex === undefined ? undefined : plan[lastInsertIndex];
+    if (lastInsert === undefined) {
+      if (run.chainStart) {
+        appended.push({
+          id: nextOperationId(),
+          type: "mergeBlockWithNext",
+          blockId: run.chainStart.id,
+        });
+      }
+      if (isEmptyParagraphNode(carrier, baseSnapshot)) {
+        dropped.add(carrierDeletionIndex);
+      }
+    } else {
+      if (
+        (lastInsert.type !== "insertBeforeBlock" && lastInsert.type !== "insertAfterBlock") ||
+        lastInsert.moveId !== undefined
+      ) {
+        // A relocation's destination has to stay an insertion for its source
+        // to stay a `w:moveFrom`, so this run keeps the shape it has.
+        continue;
+      }
+      const carrierDeletion = plan[carrierDeletionIndex];
+      if (carrierDeletion?.type !== "deleteBlock" || carrierDeletion.moveId !== undefined) {
+        continue;
+      }
+      dropped.add(lastInsertIndex);
+      if (carrier.text === lastInsert.text) {
+        // The carrier already holds the words the last inserted paragraph
+        // brings, so neither half of the exchange is a revision.
+        dropped.add(carrierDeletionIndex);
+      } else {
+        plan[carrierDeletionIndex] = {
+          id: carrierDeletion.id,
+          type: "replaceBlock",
+          blockId: carrier.id,
+          text: lastInsert.text,
+        };
+      }
+      for (const index of run.insertIndexes.slice(0, -1)) {
+        const insert = plan[index];
+        if (insert?.type !== "insertBeforeBlock" && insert?.type !== "insertAfterBlock") {
+          continue;
+        }
+        plan[index] = {
+          id: insert.id,
+          type: "insertBeforeBlock",
+          blockId: carrier.id,
+          text: insert.text,
+          ...(insert.moveId !== undefined && { moveId: insert.moveId }),
+          styleId: insert.styleId ?? null,
+          listLevel: insert.listLevel ?? null,
+        };
+      }
+    }
+    // The paragraph the carrier's mark now ends is the target's last one in
+    // this container, so the carrier is where its properties have to be.
     const targetCarrier = targetLastByContainer.get(container);
     const properties = targetCarrier && changedParagraphProperties(carrier, targetCarrier);
     if (properties) {
-      added.push({
+      appended.push({
         id: nextOperationId(),
         type: "setBlockParagraphProperties",
         blockId: carrier.id,
@@ -1103,7 +1265,7 @@ const trailingDeletionOperations = ({
       });
     }
   }
-  return added;
+  return [...plan.filter((_, index) => !dropped.has(index)), ...appended];
 };
 
 /**
@@ -1192,7 +1354,7 @@ export const planStoryCompare = ({
   targetSnapshot,
   maxOperations,
 }: PlanStoryCompareOptions): CompareStoryPlan | null => {
-  const steps = buildSteps({ story, baseSnapshot, targetSnapshot });
+  const steps = buildSteps({ baseSnapshot, targetSnapshot });
   const paragraphMarkPlans = detectParagraphMarkEdits(steps);
   // The step after each paragraph-mark plan is part of it, so neither the move
   // pass nor the main loop may claim it again.
@@ -1556,20 +1718,18 @@ export const planStoryCompare = ({
     }
   }
 
-  operations.push(
-    ...trailingDeletionOperations({
-      baseSnapshot,
-      targetSnapshot,
-      operations,
-      nextOperationId,
-    }),
-  );
+  const planned = withTrailingDeletionRules({
+    baseSnapshot,
+    targetSnapshot,
+    operations,
+    nextOperationId,
+  });
 
-  return operations.length > maxOperations
+  return planned.length > maxOperations
     ? null
     : {
         changes,
-        operations,
+        operations: planned,
         tableTemplates,
         tableGeometryPairings: tableGeometryPairingsOf(steps),
       };

--- a/packages/core/src/compare/probes.test.ts
+++ b/packages/core/src/compare/probes.test.ts
@@ -855,6 +855,43 @@ describe("single-mutation probes", () => {
     expect(rejected).toEqual(original);
   });
 
+  test("closing_paragraph_after_a_table: the target's last words land in the carrier", async () => {
+    // A body may not end with a table, so a document that ends in one carries
+    // a blank paragraph after it whose mark the format keeps. Nothing of the
+    // body sits between that carrier and the table, so no merge chain reaches
+    // it: the paragraph the target ends with is written INTO the carrier as
+    // inserted runs before its kept mark, and the story ends where the target
+    // ends instead of on a blank line the target does not have.
+    const base = await buildBodySequenceDocx([
+      { kind: "paragraph", text: TRAILING_CLAUSES[0] },
+      { kind: "paragraph", text: TRAILING_CLAUSES[1] },
+      { kind: "table", rows: [["Service", "Fee"]] },
+      { kind: "paragraph", text: "" },
+    ]);
+    const target = await buildBodySequenceDocx([
+      { kind: "paragraph", text: TRAILING_CLAUSES[0] },
+      { kind: "paragraph", text: "The agreement closes on the words below." },
+    ]);
+
+    const result = await compareDocx(base, target, OPTIONS);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    const paragraphs = paragraphsOf(await documentPartOf(result.value.buffer));
+    const carrier = paragraphs.at(-1) ?? "";
+    expect(markIsDeleted(carrier)).toBe(false);
+    expect(carrier).toContain("<w:ins ");
+    expect(carrier).toContain("The agreement closes on the words below.");
+
+    expect(await projectView(result.value.buffer, "final")).toEqual(
+      await projectView(target, "final"),
+    );
+    expect(await projectView(result.value.buffer, "original")).toEqual(
+      await projectView(base, "final"),
+    );
+  });
+
   test("unrepresentable_difference: refused by default, emitted and named on request", async () => {
     // Every column is empty, so there is no evidence for which of the three
     // target columns is new. Guessing would produce a plausible but misleading

--- a/packages/core/src/compare/probes.test.ts
+++ b/packages/core/src/compare/probes.test.ts
@@ -103,6 +103,11 @@ const markIsDeleted = (paragraph: string): boolean => {
 const marksDeletedIn = (partXml: string): string[] =>
   paragraphsOf(partXml).filter((paragraph) => markIsDeleted(paragraph));
 
+const markIsInserted = (paragraph: string): boolean => {
+  const properties = /^<w:p\b[^>]*><w:pPr>([\s\S]*?)<\/w:pPr>/u.exec(paragraph)?.[1] ?? "";
+  return /<w:rPr>[\s\S]*?<w:(?:ins|moveTo)\b/u.test(properties);
+};
+
 const blocksOf = async (buffer: ArrayBuffer): Promise<FolioAIBlock[]> =>
   (await FolioDocxReviewer.fromBuffer(buffer)).getContent();
 
@@ -883,6 +888,47 @@ describe("single-mutation probes", () => {
     expect(markIsDeleted(carrier)).toBe(false);
     expect(carrier).toContain("<w:ins ");
     expect(carrier).toContain("The agreement closes on the words below.");
+
+    expect(await projectView(result.value.buffer, "final")).toEqual(
+      await projectView(target, "final"),
+    );
+    expect(await projectView(result.value.buffer, "original")).toEqual(
+      await projectView(base, "final"),
+    );
+  });
+
+  test("append_paragraphs: the ADDED break lands one paragraph back", async () => {
+    // The mirror of the trailing removal. An inserted mark says the break was
+    // added, so rejecting it closes the paragraph it ends back over the next
+    // one — which the paragraph a container ENDS with does not have. The break
+    // therefore sits between the paragraph the run was appended after and the
+    // first appended one: that paragraph's mark is the inserted one, and the
+    // paragraph the container now ends with takes the free mark it had.
+    const base = await buildBodySequenceDocx([
+      { kind: "paragraph", text: TRAILING_CLAUSES[0] },
+      { kind: "paragraph", text: TRAILING_CLAUSES[1] },
+    ]);
+    const target = await buildBodySequenceDocx([
+      { kind: "paragraph", text: TRAILING_CLAUSES[0] },
+      { kind: "paragraph", text: TRAILING_CLAUSES[1] },
+      { kind: "paragraph", text: TRAILING_CLAUSES[2] },
+      { kind: "paragraph", text: TRAILING_CLAUSES[3] },
+    ]);
+
+    const result = await compareDocx(base, target, OPTIONS);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value.changes.map(({ kind }) => kind)).toEqual(["insert", "insert"]);
+
+    const paragraphs = paragraphsOf(await documentPartOf(result.value.buffer));
+    expect(paragraphs).toHaveLength(4);
+    expect(paragraphs.map((paragraph) => markIsInserted(paragraph))).toEqual([
+      false,
+      true,
+      true,
+      false,
+    ]);
 
     expect(await projectView(result.value.buffer, "final")).toEqual(
       await projectView(target, "final"),

--- a/packages/core/src/compare/types.ts
+++ b/packages/core/src/compare/types.ts
@@ -18,7 +18,7 @@ import type {
   CompareVerificationCause,
   CompareVerificationFailure,
   CompareVerificationInvariant,
-  FinalParagraphMarkDeletion,
+  FinalParagraphMarkRevision,
 } from "./verification";
 
 /** Everything {@link compareDocx} needs; nothing it reads from the ambient clock. */
@@ -320,20 +320,22 @@ export class CompareDocxSerializeError extends TaggedError("CompareDocxSerialize
 }> {}
 
 /**
- * A container's final paragraph mark carries a deletion, so the package would
- * not open.
+ * A container's final paragraph mark carries a revision, so the package would
+ * not open, or would open carrying one no reader can resolve.
  *
  * A deleted paragraph mark means "merge this paragraph into the following
- * one", and a container's last paragraph has no following one. Checked before
- * the package is written, and fatal under either `onUnverified` setting: there
- * is no redline to emit when a consumer refuses the file.
+ * one", an inserted one means the break was added and rejecting it closes the
+ * paragraph back over the next one, and a container's last paragraph has no
+ * following one either way. Checked before the package is written, and fatal
+ * under either `onUnverified` setting: there is no redline to emit when a
+ * consumer refuses the file.
  */
 export class CompareDocxFinalParagraphMarkError extends TaggedError(
   "CompareDocxFinalParagraphMarkError",
 )<{
   message: string;
   /** Every container that carries one, each named structurally. */
-  deletions: readonly FinalParagraphMarkDeletion[];
+  revisions: readonly FinalParagraphMarkRevision[];
 }> {}
 
 export type CompareDocxError =

--- a/packages/core/src/compare/verification.test.ts
+++ b/packages/core/src/compare/verification.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { deletedFinalParagraphMarks } from "./verification";
+import { revisedFinalParagraphMarks } from "./verification";
 
 const revision = { id: 1, author: "compare", date: "2024-03-01T00:00:00.000Z" };
 
@@ -26,10 +26,10 @@ const table = (cells: unknown[][]) => ({
   rows: [{ type: "tableRow", cells: cells.map((content) => cell(content)) }],
 });
 
-describe("deletedFinalParagraphMarks", () => {
+describe("revisedFinalParagraphMarks", () => {
   test("a body whose last paragraph mark is deleted is named", () => {
     expect(
-      deletedFinalParagraphMarks({
+      revisedFinalParagraphMarks({
         document: { content: [paragraph("first"), paragraph("last", { kind: "del" })] },
       }),
     ).toEqual([{ container: "package.document.content", paragraphIndex: 1, kind: "del" }]);
@@ -37,7 +37,7 @@ describe("deletedFinalParagraphMarks", () => {
 
   test("a relocation's source break counts, because it resolves the same way", () => {
     expect(
-      deletedFinalParagraphMarks({
+      revisedFinalParagraphMarks({
         document: { content: [paragraph("first"), paragraph("last", { kind: "moveFrom" })] },
       }),
     ).toEqual([{ container: "package.document.content", paragraphIndex: 1, kind: "moveFrom" }]);
@@ -45,7 +45,7 @@ describe("deletedFinalParagraphMarks", () => {
 
   test("a mark deleted on a paragraph that something follows is not a finding", () => {
     expect(
-      deletedFinalParagraphMarks({
+      revisedFinalParagraphMarks({
         document: {
           content: [paragraph("first", { kind: "del" }), paragraph("last")],
         },
@@ -53,16 +53,28 @@ describe("deletedFinalParagraphMarks", () => {
     ).toEqual([]);
   });
 
-  test("an inserted final mark is not a finding: rejecting it removes the paragraph it added", () => {
+  test("an inserted final mark is a finding too: nothing follows it to close over", () => {
+    // The break was ADDED, and rejecting an added break closes the paragraph
+    // it ends back over the NEXT one. A container's last paragraph has none,
+    // so the mark states an edit no reader can carry out in either direction:
+    // it survives accepting everything and rejecting everything alike.
     expect(
-      deletedFinalParagraphMarks({
+      revisedFinalParagraphMarks({
         document: { content: [paragraph("first"), paragraph("added", { kind: "ins" })] },
       }),
-    ).toEqual([]);
+    ).toEqual([{ container: "package.document.content", paragraphIndex: 1, kind: "ins" }]);
+  });
+
+  test("a relocation's destination break counts for the same reason", () => {
+    expect(
+      revisedFinalParagraphMarks({
+        document: { content: [paragraph("first"), paragraph("moved", { kind: "moveTo" })] },
+      }),
+    ).toEqual([{ container: "package.document.content", paragraphIndex: 1, kind: "moveTo" }]);
   });
 
   test("a cell, a header and a note are containers too", () => {
-    const found = deletedFinalParagraphMarks({
+    const found = revisedFinalParagraphMarks({
       document: {
         content: [table([[paragraph("cell", { kind: "del" })]]), paragraph("last")],
       },
@@ -78,7 +90,7 @@ describe("deletedFinalParagraphMarks", () => {
 
   test("a package with nothing on any final mark reports nothing", () => {
     expect(
-      deletedFinalParagraphMarks({
+      revisedFinalParagraphMarks({
         document: { content: [table([[paragraph("cell")]]), paragraph("last")] },
       }),
     ).toEqual([]);

--- a/packages/core/src/compare/verification.test.ts
+++ b/packages/core/src/compare/verification.test.ts
@@ -88,6 +88,19 @@ describe("revisedFinalParagraphMarks", () => {
     ]);
   });
 
+  test("a mark the base arrived with is not this comparison's to report", () => {
+    // A base can carry one on a paragraph of a part no story mounts, so
+    // resolving it to its accepted view does not reach it. `since` is one past
+    // the highest id the base already used, so what is left is what this
+    // comparison wrote.
+    expect(
+      revisedFinalParagraphMarks(
+        { document: { content: [paragraph("first"), paragraph("last", { kind: "del" })] } },
+        { since: revision.id + 1 },
+      ),
+    ).toEqual([]);
+  });
+
   test("a package with nothing on any final mark reports nothing", () => {
     expect(
       revisedFinalParagraphMarks({

--- a/packages/core/src/compare/verification.ts
+++ b/packages/core/src/compare/verification.ts
@@ -343,12 +343,26 @@ const isParagraph = (value: unknown): value is Record<string, unknown> =>
   isRecord(value) && value["type"] === "paragraph";
 
 /**
+ * A row the package marks deleted, whose cells' marks go with it.
+ *
+ * A deleted table row is written as `w:trPr/w:del` PLUS a deletion on every
+ * mark the row's cells end with: accepting takes the whole row away, so those
+ * marks never have to join anything and are the shape the format asks for.
+ */
+const isADeletedTableRow = (value: Record<string, unknown>): boolean => {
+  const change = value["structuralChange"];
+  return isRecord(change) && change["type"] === "tableRowDeletion";
+};
+
+/**
  * Every container in a package whose final paragraph mark carries a deletion.
  *
  * A deleted paragraph mark says "join this paragraph with the one after it".
  * The last paragraph of a body, a table cell, a header or footer, a note or a
  * text box has no paragraph after it, so the mark states an edit that cannot
  * be carried out, and a consumer refuses the package rather than opening it.
+ * The exception is a cell of a row the package is DELETING: there the mark
+ * leaves with its row.
  *
  * The walk is over the package model rather than over a list of the containers
  * known today: a container is any sequence that ends in a paragraph, so a part
@@ -357,32 +371,33 @@ const isParagraph = (value: unknown): value is Record<string, unknown> =>
  */
 export const deletedFinalParagraphMarks = (packageModel: unknown): FinalParagraphMarkDeletion[] => {
   const found: FinalParagraphMarkDeletion[] = [];
-  const visit = (value: unknown, path: string): void => {
+  const visit = (value: unknown, path: string, insideADeletedRow: boolean): void => {
     if (Array.isArray(value)) {
       const last: unknown = value.at(-1);
       const mark = isParagraph(last) ? last["pPrMark"] : undefined;
       const kind = isRecord(mark) ? mark["kind"] : undefined;
-      if (joinsForwardOnAccept(kind)) {
+      if (joinsForwardOnAccept(kind) && !insideADeletedRow) {
         found.push({ container: path, paragraphIndex: value.length - 1, kind });
       }
       for (const [index, item] of value.entries()) {
-        visit(item, `${path}[${String(index)}]`);
+        visit(item, `${path}[${String(index)}]`, insideADeletedRow);
       }
       return;
     }
     if (value instanceof Map) {
       for (const [key, item] of value) {
-        visit(item, `${path}.${String(key)}`);
+        visit(item, `${path}.${String(key)}`, insideADeletedRow);
       }
       return;
     }
     if (!isRecord(value) || value instanceof Date || ArrayBuffer.isView(value)) {
       return;
     }
+    const inADeletedRow = insideADeletedRow || isADeletedTableRow(value);
     for (const [key, item] of Object.entries(value)) {
-      visit(item, `${path}.${key}`);
+      visit(item, `${path}.${key}`, inADeletedRow);
     }
   };
-  visit(packageModel, "package");
+  visit(packageModel, "package", false);
   return found;
 };

--- a/packages/core/src/compare/verification.ts
+++ b/packages/core/src/compare/verification.ts
@@ -369,15 +369,26 @@ const isADeletedTableRow = (value: Record<string, unknown>): boolean => {
  * known today: a container is any sequence that ends in a paragraph, so a part
  * the model grows later is covered the day it arrives instead of the day
  * someone remembers this function.
+ *
+ * `since` scopes it to the revisions a comparison MINTED: a base may arrive
+ * carrying one of these on a paragraph in a part no story mounts, which folio
+ * preserves the way it preserves everything else it parses. What this proves
+ * is that the comparison writes none of its own.
  */
-export const revisedFinalParagraphMarks = (packageModel: unknown): FinalParagraphMarkRevision[] => {
+export const revisedFinalParagraphMarks = (
+  packageModel: unknown,
+  { since = 0 }: { since?: number } = {},
+): FinalParagraphMarkRevision[] => {
   const found: FinalParagraphMarkRevision[] = [];
   const visit = (value: unknown, path: string, insideADeletedRow: boolean): void => {
     if (Array.isArray(value)) {
       const last: unknown = value.at(-1);
       const mark = isParagraph(last) ? last["pPrMark"] : undefined;
       const kind = isRecord(mark) ? mark["kind"] : undefined;
-      if (isAParagraphMarkChangeKind(kind) && !insideADeletedRow) {
+      const info = isRecord(mark) ? mark["info"] : undefined;
+      const revisionId = isRecord(info) ? info["id"] : undefined;
+      const isOurs = typeof revisionId === "number" ? revisionId >= since : true;
+      if (isAParagraphMarkChangeKind(kind) && isOurs && !insideADeletedRow) {
         found.push({ container: path, paragraphIndex: value.length - 1, kind });
       }
       for (const [index, item] of value.entries()) {

--- a/packages/core/src/compare/verification.ts
+++ b/packages/core/src/compare/verification.ts
@@ -13,6 +13,8 @@
  * report, or quote it in a review.
  */
 
+import { PARAGRAPH_MARK_CHANGE_KINDS, type ParagraphMarkChangeKind } from "@stll/docx-core/model";
+
 import type { FolioDocumentStoryHandle } from "../ai-edits/headless";
 import type { FolioAIBlock, FolioAIBlockPreviewRun } from "../ai-edits/types";
 
@@ -316,25 +318,22 @@ export const classifyProjectionMismatch = ({
 };
 
 /**
- * A container whose last paragraph carries a deletion on its mark.
+ * A container whose last paragraph carries a revision on its mark.
  *
  * Structural facts only — a path through the package model and an index — so
  * the finding is safe to log, report or quote.
  */
-export type FinalParagraphMarkDeletion = {
+export type FinalParagraphMarkRevision = {
   /** Where the container sits in the package model, e.g. `package.document.content`. */
   container: string;
   /** The paragraph's index among its container's children. */
   paragraphIndex: number;
-  /** The mark kind found there: `del`, or `moveFrom` for a relocation's source. */
-  kind: "del" | "moveFrom";
+  /** The mark kind found there, `moveFrom` / `moveTo` for a relocation's ends. */
+  kind: ParagraphMarkChangeKind;
 };
 
-/** The mark kinds that resolve by joining the paragraph with the one after it. */
-const JOINS_FORWARD_ON_ACCEPT = Object.freeze(["del", "moveFrom"] as const);
-
-const joinsForwardOnAccept = (value: unknown): value is FinalParagraphMarkDeletion["kind"] =>
-  JOINS_FORWARD_ON_ACCEPT.some((kind) => kind === value);
+const isAParagraphMarkChangeKind = (value: unknown): value is ParagraphMarkChangeKind =>
+  PARAGRAPH_MARK_CHANGE_KINDS.some((kind) => kind === value);
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
@@ -355,28 +354,30 @@ const isADeletedTableRow = (value: Record<string, unknown>): boolean => {
 };
 
 /**
- * Every container in a package whose final paragraph mark carries a deletion.
+ * Every container in a package whose final paragraph mark carries a revision.
  *
- * A deleted paragraph mark says "join this paragraph with the one after it".
- * The last paragraph of a body, a table cell, a header or footer, a note or a
- * text box has no paragraph after it, so the mark states an edit that cannot
- * be carried out, and a consumer refuses the package rather than opening it.
- * The exception is a cell of a row the package is DELETING: there the mark
- * leaves with its row.
+ * A deleted paragraph mark says "join this paragraph with the one after it",
+ * and an inserted one says that break was ADDED, so rejecting it closes the
+ * paragraph back over the next one. The last paragraph of a body, a table
+ * cell, a header or footer, a note or a text box has no paragraph after it, so
+ * neither direction states an edit that can be carried out: a consumer refuses
+ * the package, or opens it and leaves a revision standing that neither
+ * accepting nor rejecting everything can clear. The exception is a cell of a
+ * row the package is DELETING: there the mark leaves with its row.
  *
  * The walk is over the package model rather than over a list of the containers
  * known today: a container is any sequence that ends in a paragraph, so a part
  * the model grows later is covered the day it arrives instead of the day
  * someone remembers this function.
  */
-export const deletedFinalParagraphMarks = (packageModel: unknown): FinalParagraphMarkDeletion[] => {
-  const found: FinalParagraphMarkDeletion[] = [];
+export const revisedFinalParagraphMarks = (packageModel: unknown): FinalParagraphMarkRevision[] => {
+  const found: FinalParagraphMarkRevision[] = [];
   const visit = (value: unknown, path: string, insideADeletedRow: boolean): void => {
     if (Array.isArray(value)) {
       const last: unknown = value.at(-1);
       const mark = isParagraph(last) ? last["pPrMark"] : undefined;
       const kind = isRecord(mark) ? mark["kind"] : undefined;
-      if (joinsForwardOnAccept(kind) && !insideADeletedRow) {
+      if (isAParagraphMarkChangeKind(kind) && !insideADeletedRow) {
         found.push({ container: path, paragraphIndex: value.length - 1, kind });
       }
       for (const [index, item] of value.entries()) {

--- a/packages/core/src/docx/serializer/paragraphSerializer.test.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer.test.ts
@@ -495,3 +495,44 @@ describe("serializeParagraph revision nesting around a hyperlink", () => {
     expect(xml).not.toContain("<w:t>");
   });
 });
+
+describe("pPr children follow the schema's sequence", () => {
+  const NAMESPACES =
+    'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" ' +
+    'xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"';
+
+  const parseProperties = (inner: string): Paragraph => {
+    const element = parseXmlDocument(`<w:p ${NAMESPACES}><w:pPr>${inner}</w:pPr></w:p>`);
+    if (!element) {
+      throw new Error("failed to parse the paragraph-properties fixture");
+    }
+    return parseParagraph(element, null, null, null, null, null);
+  };
+
+  // `CT_PPrBase` is a sequence, so a consumer that validates reports the NEXT
+  // element as unexpected when one arrives out of order and refuses the part.
+  // `contextualSpacing` and `snapToGrid` both sit AFTER the indentation and
+  // the spacing, several elements past `numPr` — which is what an early one
+  // made unexpected.
+  test("numbering precedes the children the schema puts after it", () => {
+    const paragraph = parseProperties(
+      `<w:pStyle w:val="ListParagraph"/><w:contextualSpacing/><w:snapToGrid/>` +
+        `<w:numPr><w:ilvl w:val="0"/><w:numId w:val="5"/></w:numPr>` +
+        `<w:spacing w:after="0"/><w:ind w:left="360"/><w:jc w:val="both"/>`,
+    );
+
+    const xml = serializeParagraph(paragraph);
+    const order = [
+      "<w:pStyle",
+      "<w:numPr>",
+      "<w:snapToGrid",
+      "<w:spacing",
+      "<w:ind",
+      "<w:contextualSpacing",
+      "<w:jc",
+    ].map((element) => xml.indexOf(element));
+
+    expect(order).not.toContain(-1);
+    expect(order).toEqual([...order].toSorted((left, right) => left - right));
+  });
+});

--- a/packages/core/src/docx/serializer/paragraphSerializer.test.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer.test.ts
@@ -518,13 +518,14 @@ describe("pPr children follow the schema's sequence", () => {
     const paragraph = parseProperties(
       `<w:pStyle w:val="ListParagraph"/><w:contextualSpacing/><w:snapToGrid/>` +
         `<w:numPr><w:ilvl w:val="0"/><w:numId w:val="5"/></w:numPr>` +
-        `<w:spacing w:after="0"/><w:ind w:left="360"/><w:jc w:val="both"/>`,
+        `<w:spacing w:after="0"/><w:ind w:left="360"/><w:bidi/><w:jc w:val="both"/>`,
     );
 
     const xml = serializeParagraph(paragraph);
     const order = [
       "<w:pStyle",
       "<w:numPr>",
+      "<w:bidi",
       "<w:snapToGrid",
       "<w:spacing",
       "<w:ind",

--- a/packages/core/src/docx/serializer/paragraphSerializer.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer.ts
@@ -413,10 +413,14 @@ export function serializeParagraphFormatting(
       parts.push(`<w:pStyle w:val="${escapeXml(formatting.styleId)}"/>`);
     }
 
-    // Keep next/lines, contextual spacing, page break before.
+    // `CT_PPrBase` is a SEQUENCE, so every child below is written where that
+    // sequence puts it, not where it reads best: a validating consumer that
+    // meets one out of order reports the NEXT element as unexpected and
+    // refuses the part. `contextualSpacing` and `snapToGrid` sit after the
+    // indentation and the spacing, several elements past `numPr`, which is
+    // what an early one made unexpected.
     pushToggle("keepNext", formatting.keepNext);
     pushToggle("keepLines", formatting.keepLines);
-    pushToggle("contextualSpacing", formatting.contextualSpacing);
     pushToggle("pageBreakBefore", formatting.pageBreakBefore);
 
     // Frame properties
@@ -427,7 +431,6 @@ export function serializeParagraphFormatting(
 
     // Widow control
     pushToggle("widowControl", formatting.widowControl);
-    pushToggle("snapToGrid", formatting.snapToGrid);
 
     // Numbering. Skip numPr that still equals its style-sourced value (see
     // ParagraphFormatting.numPrFromStyle) — the parser materialized it from
@@ -466,6 +469,11 @@ export function serializeParagraphFormatting(
     pushToggle("kinsoku", formatting.kinsoku);
     pushToggle("overflowPunct", formatting.overflowPunctuation);
 
+    // Text direction (bidi)
+    pushToggle("bidi", formatting.bidi);
+
+    pushToggle("snapToGrid", formatting.snapToGrid);
+
     // Spacing
     const spacingXml = serializeSpacing(formatting);
     if (spacingXml) {
@@ -478,8 +486,7 @@ export function serializeParagraphFormatting(
       parts.push(indXml);
     }
 
-    // Text direction (bidi)
-    pushToggle("bidi", formatting.bidi);
+    pushToggle("contextualSpacing", formatting.contextualSpacing);
 
     // Justification
     if (formatting.alignment) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -56,7 +56,7 @@ export {
   type CompareVerificationCause,
   type CompareVerificationFailure,
   type CompareVerificationInvariant,
-  type FinalParagraphMarkDeletion,
+  type FinalParagraphMarkRevision,
 } from "./compare/verification";
 export { createDocx } from "./docx/rezip";
 export { DOCX_CONFORMANCE_CLASSES } from "@stll/docx-core/model";

--- a/packages/core/src/prosemirror/commands/comments.ts
+++ b/packages/core/src/prosemirror/commands/comments.ts
@@ -20,6 +20,7 @@ import { PARAGRAPH_MARK_CHANGE_KINDS, type ParagraphMarkChangeKind } from "@stll
 import { expectParagraphAttrs, expectRunPropertyChangeMarkAttrs } from "../attrs";
 import { textFormattingToMarks } from "../conversion/toProseDoc";
 import { markStructuralChange } from "../extensions/features/ParagraphChangeTrackerExtension";
+import { paragraphEndsItsContainer } from "../containerFinalParagraph";
 import { holdsNoContent } from "../zeroWidthAnchors";
 import { getFolioNodeRevisionCarriers } from "../revisionCarriers";
 import { RUN_FORMATTING_MARK_NAMES } from "../runFormattingMarkNames";
@@ -343,7 +344,7 @@ function resolveChange(
           const sectionCanMoveBack =
             !carriesSection(paragraph) ||
             (previous?.type.name === paragraph.type.name && !carriesSection(previous));
-          const endsItsContainer = resolved.index() === resolved.parent.childCount - 1;
+          const endsItsContainer = paragraphEndsItsContainer(resolved, paragraph.type.name);
           const canGo = op.markWasAdded || !endsItsContainer;
           if (
             sectionCanMoveBack &&

--- a/packages/core/src/prosemirror/containerFinalParagraph.ts
+++ b/packages/core/src/prosemirror/containerFinalParagraph.ts
@@ -1,0 +1,33 @@
+import type { Node as PMNode, ResolvedPos } from "prosemirror-model";
+
+/**
+ * A node the FILE holds as a child of the container it appears in.
+ *
+ * The editor keeps a text box as a block-level sibling of the paragraph that
+ * anchors it; the file hangs it off that paragraph's own run, so it is not a
+ * child of the container at all. A paragraph and a table are children in both.
+ */
+const isAContainerChild = (node: PMNode, paragraphTypeName: string): boolean =>
+  node.type.name === paragraphTypeName || node.type.spec["tableRole"] === "table";
+
+/**
+ * Whether the paragraph starting at `at` is the one its container ENDS with,
+ * which is the one place a deleted paragraph mark cannot say what it means.
+ *
+ * A deleted mark asks a reader to join the paragraph it ends with the one
+ * after it. A body, a table cell, a header or footer, a note and a text box
+ * each end with a paragraph that nothing follows, so the ask cannot be carried
+ * out and a consumer refuses the whole package rather than opening it.
+ *
+ * A paragraph before a TABLE is not one of those: the table is a following
+ * sibling, so the paragraph does not end anything and carries its own mark
+ * like any other.
+ */
+export const paragraphEndsItsContainer = (at: ResolvedPos, paragraphTypeName: string): boolean => {
+  for (let index = at.index() + 1; index < at.parent.childCount; index++) {
+    if (isAContainerChild(at.parent.child(index), paragraphTypeName)) {
+      return false;
+    }
+  }
+  return true;
+};

--- a/packages/core/src/prosemirror/containerFinalParagraph.ts
+++ b/packages/core/src/prosemirror/containerFinalParagraph.ts
@@ -10,24 +10,114 @@ import type { Node as PMNode, ResolvedPos } from "prosemirror-model";
 const isAContainerChild = (node: PMNode, paragraphTypeName: string): boolean =>
   node.type.name === paragraphTypeName || node.type.spec["tableRole"] === "table";
 
+/** Whether every child from `fromIndex` on is one the file does not hold here. */
+const nothingFollowsIn = (
+  parent: PMNode,
+  fromIndex: number,
+  paragraphTypeName: string,
+): boolean => {
+  for (let index = fromIndex; index < parent.childCount; index++) {
+    if (isAContainerChild(parent.child(index), paragraphTypeName)) {
+      return false;
+    }
+  }
+  return true;
+};
+
 /**
  * Whether the paragraph starting at `at` is the one its container ENDS with,
- * which is the one place a deleted paragraph mark cannot say what it means.
+ * which is the one place a paragraph mark cannot carry a revision.
  *
  * A deleted mark asks a reader to join the paragraph it ends with the one
- * after it. A body, a table cell, a header or footer, a note and a text box
- * each end with a paragraph that nothing follows, so the ask cannot be carried
- * out and a consumer refuses the whole package rather than opening it.
+ * after it, and an inserted mark says that break was added, so rejecting it
+ * closes the paragraph back over the next one. A body, a table cell, a header
+ * or footer, a note and a text box each end with a paragraph that nothing
+ * follows, so neither direction can be resolved there: a consumer is left with
+ * a revision it can only ignore, and the redline no longer resolves to the two
+ * documents it was written from.
  *
  * A paragraph before a TABLE is not one of those: the table is a following
  * sibling, so the paragraph does not end anything and carries its own mark
  * like any other.
  */
-export const paragraphEndsItsContainer = (at: ResolvedPos, paragraphTypeName: string): boolean => {
-  for (let index = at.index() + 1; index < at.parent.childCount; index++) {
-    if (isAContainerChild(at.parent.child(index), paragraphTypeName)) {
-      return false;
+export const paragraphEndsItsContainer = (at: ResolvedPos, paragraphTypeName: string): boolean =>
+  nothingFollowsIn(at.parent, at.index() + 1, paragraphTypeName);
+
+/**
+ * Every paragraph a container ENDS with in `doc`, with its position.
+ *
+ * One walk for the whole document: asking the question of each paragraph in
+ * turn costs a scan of its siblings each time, which is quadratic in a body
+ * whose paragraphs a batch has just filled.
+ */
+export const finalParagraphsOf = (
+  doc: PMNode,
+  paragraphTypeName: string,
+): { position: number; node: PMNode }[] => {
+  const found: { position: number; node: PMNode }[] = [];
+  const collect = (node: PMNode, contentStart: number): void => {
+    let last: { position: number; node: PMNode } | null = null;
+    node.forEach((child, offset) => {
+      const position = contentStart + offset;
+      if (child.type.name === paragraphTypeName) {
+        last = { position, node: child };
+      } else if (isAContainerChild(child, paragraphTypeName)) {
+        last = null;
+      }
+      if (!child.isTextblock && child.childCount > 0) {
+        collect(child, position + 1);
+      }
+    });
+    if (last !== null) {
+      found.push(last);
+    }
+  };
+  collect(doc, 0);
+  return found;
+};
+
+/** A paragraph's mark, when it says the break was ADDED. */
+const marksAnAddedBreak = (node: PMNode): boolean => {
+  const mark: unknown = node.attrs["pPrMark"];
+  if (typeof mark !== "object" || mark === null || !("kind" in mark)) {
+    return false;
+  }
+  return mark.kind === "ins" || mark.kind === "moveTo";
+};
+
+/**
+ * The paragraph an added break can rotate BACK onto from the one at `at`: the
+ * paragraph the run of inserted ones was appended after.
+ *
+ * The walk crosses the inserted paragraphs — their own marks stay where they
+ * are, and only which paragraph is left markless changes — and stops at the
+ * first one whose mark is free. `null` when there is none: a table in between,
+ * which no mark joins across; a paragraph whose mark says something else,
+ * which the rotation must not overwrite; or a container whose every paragraph
+ * is new.
+ */
+export const addedBreakCarrierBefore = (
+  at: ResolvedPos,
+  paragraphTypeName: string,
+): { position: number; node: PMNode } | null => {
+  let position = at.pos;
+  for (let index = at.index() - 1; index >= 0; index--) {
+    const sibling = at.parent.child(index);
+    position -= sibling.nodeSize;
+    if (sibling.type.name !== paragraphTypeName) {
+      // A table stops the walk; a node the file does not hold here at all — a
+      // text box — is not between the two paragraphs in the first place.
+      if (isAContainerChild(sibling, paragraphTypeName)) {
+        return null;
+      }
+      continue;
+    }
+    if (sibling.attrs["pPrMark"] == null) {
+      return { position, node: sibling };
+    }
+    if (!marksAnAddedBreak(sibling)) {
+      return null;
     }
   }
-  return true;
+  return null;
 };


### PR DESCRIPTION
A container's final paragraph mark carries no revision in either direction. Nothing follows it, so "join this paragraph with the one after it" and "close this break back over the one after it" both state an edit no reader can carry out: one makes a consumer refuse the package, the other leaves a revision standing that neither accepting nor rejecting everything can clear. Four shapes broke that rule, and a comparison either refused an operation it had itself derived or wrote a story ending on a paragraph the target does not have. This restores the coverage that cost.

## The rules

**Paragraphs ADDED where a removed trailing run was land in the carrier.** The last of them is written INTO the paragraph the container ends with, as inserted runs before its kept mark; the rest become inserted paragraphs, marks and all, in front of it:

```
[del A ¶del][del B][ins A'] ¶kept              accepts to A'        rejects to A ¶ B
[del A ¶del][del B][ins P1 ¶ins][ins P2] ¶kept accepts to P1 ¶ P2   rejects to A ¶ B
```

The mark count then works out on its own — one deleted for every removed paragraph but the carrier, one inserted for every added paragraph but the last — so the merge chain is not rotated as well. The same rule holds for table cells, headers and footers, and notes. The change list is unchanged: the reader is told that paragraphs were removed and paragraphs added.

**An ADDED break at a container's end rotates one paragraph back.** The break sits between the paragraph the run was appended after and the first appended one, so that paragraph's mark is the inserted one, each appended paragraph but the last keeps an inserted mark of its own, and the paragraph the container now ends with takes the free mark — recording the other's properties as `w:pPrChange`. Only which paragraph is left markless changes, so `[A][B ¶ins][C ¶kept]` accepts to `A ¶ B ¶ C` and rejects to `A ¶ B`. The rotation runs once over the finished document rather than at each insertion: which paragraph ends a container is settled only when the batch is, and an insertion that looked final is not one after the next operation writes a table past it.

**A carrier no chain can reach is reserved for the target's last paragraph.** A mark joins two paragraphs of ONE container, so with nothing of that container in front of the carrier there is nothing to start from: an empty body, or the blank paragraph a body ending in a table has to carry because a table may not be a body's last child. The same holds at the other end when a table sits among the appended blocks, where the rotation cannot reach. The words the story ends with are then written into the carrier, and the alignment is told to hold the two last paragraphs out as a pair before it runs. The alignment is what says whether that is needed — it is a repair rather than a preference, because pairing the two ends where the ordinary alignment reaches the carrier would trade a plain "this paragraph was removed" for a removal plus a rewrite that reads nothing like the edit. It applies to every story, not only the body.

**A carrier with no words to strike is left out of the plan**, and a skipped operation is no longer automatically a refusal. One the applier had nothing to write for, or could not write in that place — a paragraph inside a text box or a content control, where a paragraph mark has nowhere to go — leaves the redline standing, and whether anything was lost by it is the question the round trip already answers. A skip that says the plan did not match the document it was planned against stays fatal: the operations came from that very snapshot, so nothing should have moved under them. The disposition is a total map over the skip reasons, so a new reason has to state which kind it is.

## Supporting corrections

- `setBlockParagraphProperties` rebuilt a paragraph's attributes from the values read at resolution time, which silently dropped a paragraph mark another operation of the same batch had already written — the batch runs right to left, so a merge's deleted mark lands first. It reads the node as it stands.
- "The paragraph a container ends with" is a question about the document, not about the editor tree: a text box is a block-level sibling in the editor and hangs off its anchoring paragraph in the file, so a paragraph followed only by one still ends its container. The applier and the accept/reject resolution share one helper for it.
- A row the package is deleting is written as `w:trPr/w:del` plus a deletion on every mark its cells end with, which is the shape the format asks for; the structural guard no longer reads those as marks with nowhere to go.
- The guard is scoped to the revisions the comparison minted. A base can arrive carrying one on a paragraph of a part no story mounts, which folio preserves the way it preserves everything else it parses; refusing there reported the base's own bytes as the call's doing.
- Every story is resolved to its accepted view, not only the paired ones. A note the other side does not have is reported rather than compared, but the base's copy of it still ships in the result, so it ships accepted like the rest.
- `w:pPr` children are written in `CT_PPrBase` order (separate commit): `contextualSpacing` and `snapToGrid` sat near the top, and the schema puts both after the indentation and the spacing — several elements past `numPr`, which a list paragraph carrying either then made unexpected to a validating consumer.

## Guards

- `revisedFinalParagraphMarks` reports ANY revision on a container's final mark, `ins` and `moveTo` included, and `CompareDocxFinalParagraphMarkError` carries them as `revisions`.
- A fast-check arbitrary now generates the shape on purpose: the paragraphs a container ends with removed, with and without new ones written where they were, plus a plain append past the end, anchored at either end of the run. It feeds the round-trip property, the property that no container's final paragraph mark carries any revision in the bytes written, and the property that every scripted difference is representable. The general step arbitrary reached that shape only by accident.
- Probes pin the OOXML both ways: the words a target ends with landing in a carrier a table precedes, and an appended run's break sitting one paragraph back, each with the round trip exact in both directions.
- Plan tests pin a cell run that receives insertions, a carrier the chain reaches being removed rather than reserved, and a stranded carrier in a header story.
- A `w:pPr` ordering test pins that `numPr` precedes every child the schema puts after it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of inserted and removed paragraphs at the ends of document containers.
  - Preserved paragraph formatting and revision marks more reliably during edits.
  - Improved handling of tables, deleted rows, text boxes, and multiple document stories.
  - Added detection of table-geometry differences during verification.
  - Ensured paragraph properties are serialised in the correct order.

- **Documentation**
  - Expanded guidance on paragraph marks, tables, verification, and comparison limitations.

- **API Updates**
  - Final-paragraph-mark errors now report revisions, including inserted and moved marks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->