### PR TITLE
fix(core): an inserted table carries its grid, row and cell properties

### DIFF
--- a/.changeset/lucky-tables-remember.md
+++ b/.changeset/lucky-tables-remember.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Carry a table's own properties through `compareDocx`: an inserted table brings the target's `w:tblPr`, `w:tblGrid` widths, `w:trPr` and `w:tcPr` (spans, merges, shading, borders, margins, alignment) and its nested tables; a removed table keeps them under the deletion marks, with the runs inside a deleted row marked too; a paired table, row or cell whose properties changed records `w:tblPrChange` / `w:trPrChange` / `w:tcPrChange`. The round-trip self-check now compares the table model as well as the blocks, with a `table-geometry` cause. `w:tblPr` children are written in the order `CT_TblPrBase` declares, so a table carrying both `w:tblLayout` and `w:tblCellMar` validates.

--- a/api-reports/core/ai-edits.api.md
+++ b/api-reports/core/ai-edits.api.md
@@ -26,6 +26,7 @@ export type ApplyFolioDocumentOperationsOptions = {
     createUndoHandle?: () => FolioDocumentOperationUndoHandle;
     revisionStamp?: FolioRevisionStamp;
     wordDiff?: FolioWordDiffOptions;
+    tableTemplates?: FolioTableTemplates;
 };
 
 // @public (undocumented)
@@ -460,6 +461,7 @@ export type FolioAITextRangeHandle = {
 export type FolioApplyDocumentOperationsToStoryOptions = FolioApplyDocumentOperationsOptions & {
     story: FolioEditableDocumentStoryHandle;
     batch: FolioDocumentOperationBatch;
+    tableTemplates?: FolioTableTemplates;
 };
 
 // @public

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -168,6 +168,7 @@ export type ApplyFolioDocumentOperationsOptions = {
     createUndoHandle?: () => FolioDocumentOperationUndoHandle;
     revisionStamp?: FolioRevisionStamp;
     wordDiff?: FolioWordDiffOptions;
+    tableTemplates?: FolioTableTemplates;
 };
 
 // @public (undocumented)
@@ -253,7 +254,7 @@ export const clearTemplateSlashMenu: (tr: Transaction) => Transaction;
 export const COMPARE_UNSUPPORTED_REASONS: readonly ["story-missing-in-base", "story-missing-in-target", "story-not-editable"];
 
 // @public
-export const COMPARE_VERIFICATION_CAUSES: readonly ["invisible-structure", "block-count", "container", "style", "list-level", "inline-formatting", "whitespace", "text"];
+export const COMPARE_VERIFICATION_CAUSES: readonly ["invisible-structure", "block-count", "container", "table-geometry", "style", "list-level", "inline-formatting", "whitespace", "text"];
 
 // @public
 export const COMPARE_VERIFICATION_INVARIANTS: readonly ["accept-reproduces-target", "reject-reproduces-base"];

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -168,6 +168,7 @@ export type ApplyFolioDocumentOperationsOptions = {
     createUndoHandle?: () => FolioDocumentOperationUndoHandle;
     revisionStamp?: FolioRevisionStamp;
     wordDiff?: FolioWordDiffOptions;
+    tableTemplates?: FolioTableTemplates;
 };
 
 // @public (undocumented)
@@ -253,7 +254,7 @@ export const clearTemplateSlashMenu: (tr: Transaction) => Transaction;
 export const COMPARE_UNSUPPORTED_REASONS: readonly ["story-missing-in-base", "story-missing-in-target", "story-not-editable"];
 
 // @public
-export const COMPARE_VERIFICATION_CAUSES: readonly ["invisible-structure", "block-count", "container", "style", "list-level", "inline-formatting", "whitespace", "text"];
+export const COMPARE_VERIFICATION_CAUSES: readonly ["invisible-structure", "block-count", "container", "table-geometry", "style", "list-level", "inline-formatting", "whitespace", "text"];
 
 // @public
 export const COMPARE_VERIFICATION_INVARIANTS: readonly ["accept-reproduces-target", "reject-reproduces-base"];

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -6,6 +6,7 @@
 
 import { Hyperlink } from '@stll/docx-core/model';
 import * as import__stll_docx_core_model from '@stll/docx-core/model';
+import { Node as Node_2 } from 'prosemirror-model';
 import { Paragraph } from '@stll/docx-core/model';
 import { ParagraphContent } from '@stll/docx-core/model';
 import { ParagraphFormatting } from '@stll/docx-core/model';
@@ -760,6 +761,7 @@ export type FolioApplyDocumentOperationsOptions = Omit<FolioApplyOperationsOptio
 export type FolioApplyDocumentOperationsToStoryOptions = FolioApplyDocumentOperationsOptions & {
     story: FolioEditableDocumentStoryHandle;
     batch: FolioDocumentOperationBatch;
+    tableTemplates?: FolioTableTemplates;
 };
 
 // @public
@@ -1211,6 +1213,7 @@ export class FolioDocxReviewer {
     getDocumentProperties(): Readonly<NonNullable<import__stll_docx_core_model.Document["package"]["properties"]>> | null;
     getNotesAsText(): string;
     listStories(): FolioDocumentStory[];
+    matchStoryTableGeometry(input: FolioMatchStoryTableGeometryOptions): number;
     readNumberingDefinitions(): FolioNumberingLevel[];
     readReviewedStory(options?: FolioReadReviewedStoryOptions): FolioReviewedStory | null;
     readStory(handle: FolioDocumentStoryHandle): FolioDocumentStory | null;
@@ -1223,6 +1226,7 @@ export class FolioDocxReviewer {
     resolveReviewedStory(input: FolioResolveReviewedStoryOptions): boolean;
     snapshot(): FolioAIEditSnapshot;
     snapshotStory(story: FolioEditableDocumentStoryHandle): FolioAIEditSnapshot | null;
+    storyTables(input?: FolioReadReviewedStoryOptions): readonly FolioStoryTable[];
     toBuffer(): Promise<ArrayBuffer>;
     toDocument(): import__stll_docx_core_model.Document;
     undoDocumentOperations(undoHandle: FolioDocumentOperationUndoHandle): FolioDocumentOperationUndoResult;

--- a/benchmarks/compare/refusals.ts
+++ b/benchmarks/compare/refusals.ts
@@ -17,15 +17,23 @@
 import type { CompareDocxError, CompareUnsupportedPart } from "@stll/folio-core/compare/types";
 import type {
   CompareVerification,
+  CompareVerificationCause,
   CompareVerificationFailure,
 } from "@stll/folio-core/compare/verification";
+
+/**
+ * A bucket per verification cause, so a cause the engine gains cannot land in
+ * the report without a description. The prefix is what tells a reader that the
+ * self-check produced the refusal rather than the parser or the serializer.
+ */
+type RoundTripBuckets = { [Cause in CompareVerificationCause as `round-trip-${Cause}`]: string };
 
 /**
  * Why one comparison produced nothing under the strict default.
  *
  * The round-trip buckets are the engine's verification causes, prefixed so a
  * reader can tell a refusal the self-check produced from one the parser or the
- * serializer did.
+ * serializer did, and checked against them so neither side can gain one alone.
  */
 export const REFUSAL_BUCKETS = Object.freeze({
   "parse-base": "The base package could not be read into an editor model.",
@@ -40,12 +48,14 @@ export const REFUSAL_BUCKETS = Object.freeze({
     "Every block is there, in order, at coordinates the block model cannot reach.",
   "round-trip-block-count": "The result holds a different number of blocks than expected.",
   "round-trip-container": "Every block's text matched, but one sits in the wrong container.",
+  "round-trip-table-geometry":
+    "Every block is where it should be, and a table's own properties are not.",
   "round-trip-style": "A block kept a paragraph style the other side changed.",
   "round-trip-list-level": "A block kept a list level the other side changed.",
   "round-trip-inline-formatting": "A planned formatting change did not round-trip.",
   "round-trip-whitespace": "A block's text differs only in whitespace.",
   "round-trip-text": "A block's text does not match.",
-} as const);
+} as const satisfies Record<string, string> & RoundTripBuckets);
 
 export type RefusalBucket = keyof typeof REFUSAL_BUCKETS;
 

--- a/benchmarks/compare/stages.ts
+++ b/benchmarks/compare/stages.ts
@@ -86,7 +86,7 @@ export const runStagedCompare = async (
   }
 
   const serializeStart = performance.now();
-  const serialized = await serializeComparison(parsed.value, planned.value);
+  const serialized = await serializeComparison(parsed.value, applied.value);
   const serialize = performance.now() - serializeStart;
   if (serialized.isErr()) {
     return { status: "failed", stage: "serialize", error: describe(serialized.error) };

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -45,8 +45,13 @@ import {
   type TableColumnInsertion,
   type TableRowDeletion,
   type TableRowInsertion,
-  type TableStructureRevision,
+  markTableRowContent,
 } from "./table-row-column-mutations";
+import {
+  tableFromTemplate,
+  type FolioTableTemplates,
+  type TableStructureRevision,
+} from "./table-template";
 import {
   findOutermostTableBoundary,
   findEnclosingTableCell,
@@ -109,6 +114,20 @@ type ApplyFolioAIEditOperationsOptions = {
   revisionStamp?: FolioRevisionStamp;
   /** How a replacement's redline is cut. */
   wordDiff?: FolioWordDiffOptions;
+  /**
+   * Tables and rows an `insertTable` / `insertTableRow` operation should place
+   * verbatim, by operation id.
+   *
+   * The operations describe their content as cell texts, which is what a
+   * caller writing a table from nothing has. A caller copying one it already
+   * holds — a comparison placing the target document's table — has the whole
+   * thing: `w:tblPr`, the `w:tblGrid` widths, `w:trPr`, `w:tcPr` with its
+   * spans and merges, and cell paragraphs with their own properties. Rebuilt
+   * from text, none of that survives. Kept out of the operation payload
+   * because it is a document node rather than JSON: the serialized contract
+   * still describes a table by its cell texts.
+   */
+  tableTemplates?: FolioTableTemplates;
 };
 
 type ApplyFolioAIEditOperationsInternalOptions = ApplyFolioAIEditOperationsOptions & {
@@ -720,9 +739,11 @@ type BuildTableNodeOptions = {
 
 /**
  * A plain table from a grid of cell texts, `null` when the schema has no
- * tables. In tracked mode every row carries `trIns`, which is how Word says
- * "this table is new": there is no whole-table insertion element, only rows
- * that were inserted.
+ * tables. In tracked mode every row carries `trIns` and every run inside it
+ * carries `w:ins`, which is how the format says "this table is new": there is
+ * no whole-table insertion element, only rows that were inserted, and a
+ * consumer that reads only run-level revisions keeps the text of a rejected
+ * insertion when the row marker stands alone.
  */
 const buildTableNode = ({ schema, rows, revision }: BuildTableNodeOptions): PMNode | null => {
   const paragraphType = schema.nodes["paragraph"];
@@ -732,6 +753,20 @@ const buildTableNode = ({ schema, rows, revision }: BuildTableNodeOptions): PMNo
   if (!paragraphType || !cellType || !rowType || !tableType || rows.length === 0) {
     return null;
   }
+  const insertionType = schema.marks["insertion"];
+  const marks =
+    revision && insertionType
+      ? [
+          insertionType.create({
+            revisionId: revision.revisionId,
+            author: revision.author,
+            date: revision.date,
+            ...(revision.initials != null && { initials: revision.initials }),
+            ...(revision.provenance != null && { provenance: revision.provenance }),
+            ...(revision.suggestionId != null && { suggestionId: revision.suggestionId }),
+          }),
+        ]
+      : undefined;
   const rowNodes = rows.map((cells) =>
     rowType.create(
       revision ? { trIns: revision } : null,
@@ -739,7 +774,7 @@ const buildTableNode = ({ schema, rows, revision }: BuildTableNodeOptions): PMNo
         cellType.create(
           null,
           splitCellParagraphTexts(text).map((line) =>
-            paragraphType.create(null, line.length > 0 ? schema.text(line) : null),
+            paragraphType.create(null, line.length > 0 ? schema.text(line, marks) : null),
           ),
         ),
       ),
@@ -1032,6 +1067,7 @@ const applyFolioAIEditOperationsInternal = ({
   revisionStamp,
   revisionIdSeed,
   wordDiff,
+  tableTemplates,
 }: ApplyFolioAIEditOperationsInternalOptions): FolioAIEditApplyOutcome => {
   const applied: FolioAIEditAppliedOperation[] = [];
   const skipped: FolioAIEditSkippedOperation[] = [];
@@ -1614,11 +1650,13 @@ const applyFolioAIEditOperationsInternal = ({
           continue;
         }
         const revision: TableStructureRevision | null = structuralRevision;
+        const template = tableTemplates?.get(item.operation.id);
         const result = applyTableRowInsertion({
           tr,
           insertion,
           cellTexts: item.operation.cellTexts,
           revision,
+          ...(template !== undefined && { template }),
         });
         if (result.type === "unsupported") {
           skipped.push({
@@ -1894,13 +1932,21 @@ const applyFolioAIEditOperationsInternal = ({
         break;
       }
       case "insertTable": {
-        const table = buildTableNode({
-          schema: view.state.schema,
-          rows: item.operation.rows,
-          ...(producesTrackedChanges && {
-            revision: { revisionId: revisionSeed, author, date, ...trackedRevisionExtras },
-          }),
-        });
+        const revision = { revisionId: revisionSeed, author, date, ...trackedRevisionExtras };
+        const template = tableTemplates?.get(item.operation.id);
+        const table =
+          (template === undefined
+            ? null
+            : tableFromTemplate({
+                schema: view.state.schema,
+                template,
+                ...(producesTrackedChanges && { revision }),
+              })) ??
+          buildTableNode({
+            schema: view.state.schema,
+            rows: item.operation.rows,
+            ...(producesTrackedChanges && { revision }),
+          });
         if (!table) {
           skipped.push({ id: item.operation.id, reason: "unsupportedBlock" });
           continue;
@@ -1954,6 +2000,10 @@ const applyFolioAIEditOperationsInternal = ({
         }
         for (const rowPosition of rowPositions.toReversed()) {
           tr = tr.setNodeAttribute(rowPosition, "trDel", revision);
+          // The row marker alone is not the deletion: a consumer reading only
+          // run-level revisions keeps the text on accept. Same rule the
+          // row-level deletion follows.
+          markTableRowContent({ tr, rowPosition, kind: "deletion", revision });
         }
         appliedRevisionIds = [revision.revisionId];
         markStructuralChange(tr);

--- a/packages/core/src/ai-edits/headless.ts
+++ b/packages/core/src/ai-edits/headless.ts
@@ -77,9 +77,13 @@ import {
 } from "./read";
 import {
   createFolioAIEditSnapshot,
+  folioStoryTables,
   isFolioAIContentBlock,
   normalizeFolioAIBlockText,
+  type FolioStoryTable,
 } from "./snapshot";
+import { matchTableGeometry, type TableGeometryPairing } from "./table-geometry";
+import type { FolioTableTemplates } from "./table-template";
 import type {
   FolioAIBlock,
   FolioAIEditApplyMode,
@@ -266,6 +270,16 @@ export type FolioReadReviewedStoryOptions = {
   view?: FolioReviewedView;
 };
 
+/** What {@link FolioDocxReviewer.matchStoryTableGeometry} needs to move a table's properties. */
+export type FolioMatchStoryTableGeometryOptions = {
+  story?: FolioEditableDocumentStoryHandle;
+  /** The other document's tables, by the index its snapshot numbers them with. */
+  targetTables: ReadonlyMap<number, PMNode>;
+  /** Base cells and the target cells they were aligned with. */
+  pairings: readonly TableGeometryPairing[];
+  revisionStamp: FolioRevisionStamp;
+};
+
 export type FolioResolveReviewedStoryOptions = {
   story?: FolioEditableDocumentStoryHandle;
   view: FolioResolvedReviewedView;
@@ -306,6 +320,14 @@ class FolioResolvedStorySerializationError extends TaggedError(
 export type FolioApplyDocumentOperationsToStoryOptions = FolioApplyDocumentOperationsOptions & {
   story: FolioEditableDocumentStoryHandle;
   batch: FolioDocumentOperationBatch;
+  /**
+   * Tables and rows an `insertTable` / `insertTableRow` in the batch places
+   * verbatim, by operation id. A caller copying a table it already holds —
+   * `compareDocx` placing the target document's table — hands it over whole
+   * instead of letting the operation rebuild it from its cell texts and lose
+   * every table, row and cell property on the way.
+   */
+  tableTemplates?: FolioTableTemplates;
 };
 
 export type { FolioRevisionStamp };
@@ -340,6 +362,7 @@ type ApplyDocumentOperationsInternalOptions = {
   snapshot?: FolioAIEditSnapshot;
   revisionStamp?: FolioRevisionStamp;
   wordDiff?: FolioWordDiffOptions;
+  tableTemplates?: FolioTableTemplates;
   createUndoEntry: boolean;
 };
 
@@ -673,6 +696,69 @@ export class FolioDocxReviewer {
     return state ? createFolioAIEditSnapshot(state.doc) : null;
   }
 
+  /**
+   * One story's tables, in the document order {@link snapshotStory} numbers
+   * them with, read through a reviewed view.
+   *
+   * A block snapshot says which table a paragraph sits in and nothing about
+   * the table itself. A caller that has to reproduce one — a comparison
+   * copying the target's table into the base, or checking that accepting its
+   * own redline reproduced it — needs the node: its `w:tblPr`, its `w:tblGrid`
+   * widths, and every row's and cell's properties.
+   */
+  storyTables({
+    story = MAIN_STORY,
+    view = "final",
+  }: FolioReadReviewedStoryOptions = {}): readonly FolioStoryTable[] {
+    if (!isFolioReviewedView(view)) {
+      throw new UnsupportedFolioReviewedViewError({
+        message: "Unsupported reviewed document view.",
+        receivedView: view,
+      });
+    }
+    const sourceState = this.getEditableStoryState(story);
+    return sourceState ? folioStoryTables(resolveReviewedState(sourceState, view).doc) : [];
+  }
+
+  /**
+   * Move the paired tables' own properties onto this story's tables, as
+   * tracked property changes.
+   *
+   * `w:tblPr`, `w:trPr` and `w:tcPr` belong to no block, so no block operation
+   * can carry them: a table that stayed in place while its widths, shading,
+   * borders or header row changed reads as unedited. Each difference is
+   * written as the target's property set plus a `w:tblPrChange` /
+   * `w:trPrChange` / `w:tcPrChange` holding the previous one, which is what a
+   * reject restores. A set that already agrees produces no revision.
+   */
+  matchStoryTableGeometry({
+    story = MAIN_STORY,
+    targetTables,
+    pairings,
+    revisionStamp,
+  }: FolioMatchStoryTableGeometryOptions): number {
+    const state = this.getEditableStoryState(story);
+    if (!state || pairings.length === 0) {
+      return revisionStamp.idSeed;
+    }
+    const transaction = state.tr;
+    const { nextRevisionId } = matchTableGeometry({
+      tr: transaction,
+      baseTables: folioStoryTables(state.doc),
+      targetTables,
+      pairings,
+      revision: {
+        author: this.author,
+        date: revisionStamp.date,
+        idSeed: revisionStamp.idSeed,
+      },
+    });
+    if (transaction.docChanged) {
+      this.setEditableStoryState(story, state.apply(transaction));
+    }
+    return nextRevisionId;
+  }
+
   /** Read one story through an immutable reviewed-view projection. */
   readReviewedStory(options: FolioReadReviewedStoryOptions = {}): FolioReviewedStory | null {
     const story = options.story ?? MAIN_STORY;
@@ -768,6 +854,7 @@ export class FolioDocxReviewer {
     snapshot,
     revisionStamp,
     wordDiff,
+    tableTemplates,
   }: FolioApplyDocumentOperationsToStoryOptions): FolioDocumentOperationResult {
     return this.applyDocumentOperationsInternal({
       story,
@@ -775,6 +862,7 @@ export class FolioDocxReviewer {
       ...(snapshot !== undefined && { snapshot }),
       ...(revisionStamp !== undefined && { revisionStamp }),
       ...(wordDiff !== undefined && { wordDiff }),
+      ...(tableTemplates !== undefined && { tableTemplates }),
       createUndoEntry: true,
     });
   }
@@ -785,6 +873,7 @@ export class FolioDocxReviewer {
     snapshot,
     revisionStamp,
     wordDiff,
+    tableTemplates,
     createUndoEntry,
   }: ApplyDocumentOperationsInternalOptions): FolioDocumentOperationResult {
     const beforeState = this.requireEditableStoryState(story);
@@ -804,6 +893,7 @@ export class FolioDocxReviewer {
       author: this.author,
       ...(revisionStamp !== undefined && { revisionStamp }),
       ...(wordDiff !== undefined && { wordDiff }),
+      ...(tableTemplates !== undefined && { tableTemplates }),
       createCommentId: (text) => {
         const comment = createReviewerComment(this.nextCommentId(), text, this.author);
         this.createdComments.push(comment);

--- a/packages/core/src/ai-edits/snapshot.ts
+++ b/packages/core/src/ai-edits/snapshot.ts
@@ -128,6 +128,41 @@ type AncestorPathEntry = { node: PMNode; start: number; end: number; index: numb
 export const isHiddenTableRow = (node: PMNode): boolean =>
   node.type.name === TABLE_ROW_NODE_NAME && node.attrs["hidden"] === true;
 
+/** One table of a story, numbered the way {@link createFolioAIEditSnapshot} numbers it. */
+export type FolioStoryTable = {
+  /** Document-order index over every table, nested ones included. */
+  index: number;
+  /** The table node's position in the story document. */
+  start: number;
+  node: PMNode;
+};
+
+/**
+ * Every table of one story in document order, nested tables included and
+ * hidden rows' subtrees excluded.
+ *
+ * The single place a story's tables are numbered. `table.tableIndex` on a
+ * block, the geometry a comparison copies out of the target and the geometry
+ * it checks its own work against all read this list, so no second walk can
+ * number the same document differently.
+ */
+export const folioStoryTables = (doc: PMNode): FolioStoryTable[] => {
+  const tables: FolioStoryTable[] = [];
+  doc.descendants((node, pos) => {
+    if (node.isTextblock) {
+      return false;
+    }
+    if (isHiddenTableRow(node)) {
+      return false;
+    }
+    if (node.type.spec["tableRole"] === TABLE_ROLE_TABLE) {
+      tables.push({ index: tables.length, start: pos, node });
+    }
+    return true;
+  });
+  return tables;
+};
+
 type TableLocationOptions = {
   path: readonly AncestorPathEntry[];
   /** The visited block's index in its own parent. */
@@ -192,10 +227,9 @@ export const createFolioAIEditSnapshot = (doc: PMNode): FolioAIEditSnapshot => {
   }[] = [];
   const hashCounts = new Map<string, number>();
   const usedBlockIds = new Set<string>();
-  // Table start position -> document-order index, filled by the walk below.
-  // `descendants` reaches a table before any textblock inside it, so a nested
-  // block's lookup always finds its table already numbered.
-  const tableIndexByStart = new Map<number, number>();
+  const tableIndexByStart = new Map(
+    folioStoryTables(doc).map(({ start, index }) => [start, index] as const),
+  );
   // The containers enclosing the node being visited, innermost last. Kept in
   // step with the walk so no block has to resolve its own position.
   const path: AncestorPathEntry[] = [];
@@ -209,9 +243,6 @@ export const createFolioAIEditSnapshot = (doc: PMNode): FolioAIEditSnapshot => {
     if (!node.isTextblock) {
       if (isHiddenTableRow(node)) {
         return false;
-      }
-      if (node.type.spec["tableRole"] === TABLE_ROLE_TABLE) {
-        tableIndexByStart.set(pos, tableIndexByStart.size);
       }
       if (!node.isLeaf) {
         path.push({ node, start: pos, end: pos + node.nodeSize, index });

--- a/packages/core/src/ai-edits/table-geometry.ts
+++ b/packages/core/src/ai-edits/table-geometry.ts
@@ -1,0 +1,381 @@
+/**
+ * A table's own properties, read and matched across two documents.
+ *
+ * `w:tblPr`, `w:trPr` and `w:tcPr` are the part of a table no block carries: a
+ * paragraph snapshot says which cell it sits in and nothing about the cell's
+ * width, span, shading, borders or margins, nor about the row's height or
+ * header flag, nor about the table's own width, indent, justification,
+ * borders, cell margins, look or style. A comparison that reproduces every
+ * word and none of that hands back a table that is not the one it was compared
+ * to.
+ *
+ * Two things happen here. {@link projectTableGeometry} renders those
+ * properties as text, so the round-trip self-check sees a lost property the
+ * same way it sees a lost paragraph. {@link matchTableGeometry} moves them:
+ * where a paired table, row or cell differs from the one it pairs with, the
+ * target's properties are written and the previous set is recorded as
+ * `w:tblPrChange` / `w:trPrChange` / `w:tcPrChange`, which is what a reject
+ * restores.
+ *
+ * The scope of each is not a hand-kept list. It is exactly the attrs a reject
+ * of the matching change element restores, read off the reject patches
+ * themselves — so a property that reject can restore is a property the
+ * comparison carries and checks, and the three can never drift apart.
+ */
+
+import type { Node as PMNode } from "prosemirror-model";
+import type { Transaction } from "prosemirror-state";
+
+import { markStructuralChange } from "../prosemirror/extensions/features/ParagraphChangeTrackerExtension";
+
+import {
+  tableCellRejectAttrPatch,
+  tableRejectAttrPatch,
+  tableRowRejectAttrPatch,
+} from "../prosemirror/commands/propertyChangeScope";
+import {
+  tableAttrsToFormatting,
+  tableCellAttrsToFormatting,
+  tableRowAttrsToFormatting,
+} from "../prosemirror/conversion/fromProseDoc";
+import type { TableCellAttrs } from "../prosemirror/schema/nodes";
+import type { TableCellFormatting, TableFormatting, TableRowFormatting } from "../types/document";
+import type { FolioStoryTable } from "./snapshot";
+
+const ORIGINAL_FORMATTING = "_originalFormatting";
+
+/**
+ * The formatting a parser stored verbatim for the save path. It is deliberately
+ * outside every projection below: a document saved by an editor materializes
+ * style-resolved properties into its own `w:tcPr`, so two packages that render
+ * the same table can store different formatting for it, and comparing what was
+ * stored would report a difference no redline can or should represent. What is
+ * compared is the effective set the properties resolve to.
+ */
+const withoutOriginalFormatting = (keys: readonly string[]): string[] =>
+  keys.filter((key) => key !== ORIGINAL_FORMATTING);
+
+/**
+ * Attrs a `w:tblPrChange` reject restores, and therefore the attrs a match
+ * writes and the projection reads. `columnWidths` is deliberately outside
+ * them: the grid is `w:tblGrid`, not `w:tblPr`, and the editable model has no
+ * `w:tblGridChange` to record a change of it against.
+ */
+const TABLE_SCOPED_ATTRS = withoutOriginalFormatting(Object.keys(tableRejectAttrPatch(undefined)));
+const ROW_SCOPED_ATTRS = withoutOriginalFormatting(Object.keys(tableRowRejectAttrPatch(undefined)));
+const CELL_SCOPED_ATTRS = withoutOriginalFormatting(
+  Object.keys(tableCellRejectAttrPatch(undefined, undefined)),
+);
+
+/**
+ * Key-ordered JSON, so two values that differ only in the order their parser
+ * happened to write them read as equal.
+ */
+const canonical = (value: unknown): string => {
+  if (value === null || value === undefined) {
+    return "null";
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonical).join(",")}]`;
+  }
+  if (typeof value !== "object") {
+    return JSON.stringify(value) ?? "null";
+  }
+  const entries = Object.entries(value)
+    .filter(([, entry]) => entry !== undefined)
+    .toSorted(([left], [right]) => left.localeCompare(right));
+  return `{${entries.map(([key, entry]) => `${JSON.stringify(key)}:${canonical(entry)}`).join(",")}}`;
+};
+
+/**
+ * `false` and absent are the same thing for every property in scope here: they
+ * are all presence flags (`w:tblHeader`, `w:hidden`, `w:noWrap`), and a parser
+ * that materializes an absent one as `false` must not read as a difference
+ * from one that leaves it unset.
+ */
+const scopedAttrs = (
+  attrs: Record<string, unknown>,
+  keys: readonly string[],
+): Record<string, unknown> => {
+  const scoped: Record<string, unknown> = {};
+  for (const key of keys) {
+    const value = attrs[key];
+    scoped[key] = value === false ? null : (value ?? null);
+  }
+  return scoped;
+};
+
+const cellProjection = (cell: PMNode): string =>
+  canonical({
+    colspan: cell.attrs["colspan"],
+    rowspan: cell.attrs["rowspan"],
+    ...scopedAttrs(cell.attrs, CELL_SCOPED_ATTRS),
+  });
+
+const rowProjection = (row: PMNode): string => {
+  const cells: string[] = [];
+  row.forEach((cell) => {
+    cells.push(cellProjection(cell));
+  });
+  return `${canonical(scopedAttrs(row.attrs, ROW_SCOPED_ATTRS))}|${cells.join("|")}`;
+};
+
+/**
+ * One line per table, in the document order tables are numbered in: the
+ * table's own properties, then each row's and each cell's. Nested tables get
+ * their own lines rather than being folded into their parent's, so a
+ * difference names the table it is in.
+ */
+export const projectTableGeometry = (tables: readonly FolioStoryTable[]): string[] =>
+  tables.map(({ node }) => {
+    const rows: string[] = [];
+    node.forEach((row) => {
+      rows.push(rowProjection(row));
+    });
+    return `${canonical(scopedAttrs(node.attrs, TABLE_SCOPED_ATTRS))}#${rows.join("#")}`;
+  });
+
+/** Where a cell sits: which table, which row of it, which cell of that row. */
+export type TableCellCoordinate = {
+  tableIndex: number;
+  rowIndex: number;
+  cellIndex: number;
+};
+
+/** One base cell and the target cell it was aligned with. */
+export type TableGeometryPairing = {
+  base: TableCellCoordinate;
+  target: TableCellCoordinate;
+};
+
+type MatchTableGeometryOptions = {
+  tr: Transaction;
+  /** The base story's tables, with the positions the transaction will write at. */
+  baseTables: readonly FolioStoryTable[];
+  /** The target story's tables, by the same index the pairings name. */
+  targetTables: ReadonlyMap<number, PMNode>;
+  pairings: readonly TableGeometryPairing[];
+  revision: { author: string; date: string; idSeed: number };
+};
+
+export type MatchTableGeometryResult = {
+  /** First revision id a following batch may allocate. */
+  nextRevisionId: number;
+  /** Tables, rows and cells whose properties the match moved. */
+  matched: number;
+};
+
+type PropertyChangeTarget = {
+  position: number;
+  attrs: Record<string, unknown>;
+  changeAttr: "tblPrChange" | "trPrChange" | "tcPrChange";
+  changeType: "tablePropertyChange" | "tableRowPropertyChange" | "tableCellPropertyChange";
+  previousFormatting: unknown;
+};
+
+const childPositions = (node: PMNode, start: number): number[] => {
+  const positions: number[] = [];
+  let offset = start + 1;
+  node.forEach((child) => {
+    positions.push(offset);
+    offset += child.nodeSize;
+  });
+  return positions;
+};
+
+type PropertyScope<TFormatting> = {
+  keys: readonly string[];
+  /**
+   * The property set a node's attrs serialize to — what its `w:tblPr` /
+   * `w:trPr` / `w:tcPr` would say. It is the record a change element has to
+   * store, because it holds the EFFECTIVE properties: some of a cell's come
+   * from the table or a table style rather than from its own element, and a
+   * record built from what the parser stored would not restore them.
+   */
+  formattingOf: (node: PMNode) => TFormatting | undefined;
+  /** What a reject of this change element restores, from a stored property set. */
+  rejectPatch: (
+    previousFormatting: TFormatting | undefined,
+    liveFormatting: TFormatting | undefined,
+  ) => Record<string, unknown>;
+  changeAttr: PropertyChangeTarget["changeAttr"];
+  changeType: PropertyChangeTarget["changeType"];
+};
+
+/**
+ * `Node["attrs"]` is an open record, and the converters below want the node
+ * type's own shape. The two span counts are the only members the schema always
+ * carries a value for, so naming them is what turns the record into one.
+ */
+const cellAttrsOf = (node: PMNode): TableCellAttrs => ({
+  ...node.attrs,
+  colspan: typeof node.attrs["colspan"] === "number" ? node.attrs["colspan"] : 1,
+  rowspan: typeof node.attrs["rowspan"] === "number" ? node.attrs["rowspan"] : 1,
+});
+
+const TABLE_SCOPE = {
+  keys: TABLE_SCOPED_ATTRS,
+  formattingOf: (node) => tableAttrsToFormatting(node.attrs),
+  rejectPatch: (previousFormatting) => tableRejectAttrPatch(previousFormatting),
+  changeAttr: "tblPrChange",
+  changeType: "tablePropertyChange",
+} as const satisfies PropertyScope<TableFormatting>;
+
+const ROW_SCOPE = {
+  keys: ROW_SCOPED_ATTRS,
+  formattingOf: (node) => tableRowAttrsToFormatting(node.attrs),
+  rejectPatch: (previousFormatting) => tableRowRejectAttrPatch(previousFormatting),
+  changeAttr: "trPrChange",
+  changeType: "tableRowPropertyChange",
+} as const satisfies PropertyScope<TableRowFormatting>;
+
+const CELL_SCOPE = {
+  keys: CELL_SCOPED_ATTRS,
+  formattingOf: (node) => tableCellAttrsToFormatting(cellAttrsOf(node)),
+  rejectPatch: (previousFormatting, liveFormatting) =>
+    tableCellRejectAttrPatch(previousFormatting, liveFormatting),
+  changeAttr: "tcPrChange",
+  changeType: "tableCellPropertyChange",
+} as const satisfies PropertyScope<TableCellFormatting>;
+
+const scopedValues = (attrs: Record<string, unknown>, keys: readonly string[]): string =>
+  canonical(scopedAttrs(attrs, keys));
+
+/**
+ * One node's properties, matched to the node it was paired with, or `null`
+ * when the difference cannot be recorded.
+ *
+ * A change element stores the COMPLETE previous property set, and rejecting it
+ * rebuilds the live properties from that record alone. So the record is built
+ * from what the node would SERIALIZE, not from what its parser stored: a cell
+ * inherits borders and margins from the table and from a table style, and a
+ * record that omitted them would reject to a third document.
+ *
+ * The check is direct, and it is what keeps the round trip exact: rebuild the
+ * live values from the record and see whether they come back. Where they do
+ * not, the difference is left alone rather than written as a revision that
+ * cannot be undone.
+ */
+const propertyChangeFor = <TFormatting>(
+  base: PMNode,
+  target: PMNode,
+  position: number,
+  scope: PropertyScope<TFormatting>,
+): PropertyChangeTarget | null => {
+  const live = scopedValues(base.attrs, scope.keys);
+  if (live === scopedValues(target.attrs, scope.keys)) {
+    return null;
+  }
+  const previousFormatting = scope.formattingOf(base);
+  if (
+    scopedValues(scope.rejectPatch(previousFormatting, previousFormatting), scope.keys) !== live
+  ) {
+    return null;
+  }
+  return {
+    position,
+    // The target's effective values, and the formatting THEY serialize to, so
+    // the two stay consistent: a document saved by an editor materializes
+    // style-resolved properties into its own element, and only the effective
+    // set is comparable across two packages.
+    attrs: {
+      ...scopedAttrs(target.attrs, scope.keys),
+      [ORIGINAL_FORMATTING]: scope.formattingOf(target) ?? null,
+    },
+    changeAttr: scope.changeAttr,
+    changeType: scope.changeType,
+    previousFormatting,
+  };
+};
+
+/**
+ * Copy a paired table's, row's and cell's properties from the document it was
+ * compared against, recording the previous set so a reject restores it.
+ *
+ * Pairings name cells, because that is what the block alignment resolves; the
+ * row and the table each cell sits in are matched with it. A property set that
+ * already agrees is left alone, so an unchanged table produces no revision.
+ *
+ * `colspan` / `rowspan` never move: they shape the table map, and changing one
+ * without restructuring the rows around it leaves the map inconsistent with
+ * its own grid. That is the rule a reject of a `w:tcPrChange` follows too.
+ */
+export const matchTableGeometry = ({
+  tr,
+  baseTables,
+  targetTables,
+  pairings,
+  revision,
+}: MatchTableGeometryOptions): MatchTableGeometryResult => {
+  const baseByIndex = new Map(baseTables.map((table) => [table.index, table]));
+  const targets: PropertyChangeTarget[] = [];
+  const claimed = new Set<number>();
+
+  const consider = <TFormatting>(
+    base: PMNode,
+    target: PMNode,
+    position: number,
+    scope: PropertyScope<TFormatting>,
+  ): void => {
+    if (claimed.has(position)) {
+      return;
+    }
+    claimed.add(position);
+    const change = propertyChangeFor(base, target, position, scope);
+    if (change) {
+      targets.push(change);
+    }
+  };
+
+  for (const { base, target } of pairings) {
+    const baseTable = baseByIndex.get(base.tableIndex);
+    const targetTable = targetTables.get(target.tableIndex);
+    if (!baseTable || !targetTable) {
+      continue;
+    }
+    const baseRow = baseTable.node.maybeChild(base.rowIndex);
+    const targetRow = targetTable.maybeChild(target.rowIndex);
+    const rowPosition = childPositions(baseTable.node, baseTable.start)[base.rowIndex];
+    if (!baseRow || !targetRow || rowPosition === undefined) {
+      continue;
+    }
+    const baseCell = baseRow.maybeChild(base.cellIndex);
+    const targetCell = targetRow.maybeChild(target.cellIndex);
+    const cellPosition = childPositions(baseRow, rowPosition)[base.cellIndex];
+    if (!baseCell || !targetCell || cellPosition === undefined) {
+      continue;
+    }
+    consider(baseTable.node, targetTable, baseTable.start, TABLE_SCOPE);
+    consider(baseRow, targetRow, rowPosition, ROW_SCOPE);
+    consider(baseCell, targetCell, cellPosition, CELL_SCOPE);
+  }
+
+  let revisionId = revision.idSeed;
+  for (const target of targets) {
+    const node = tr.doc.nodeAt(target.position);
+    if (!node) {
+      continue;
+    }
+    tr.setNodeMarkup(target.position, undefined, {
+      ...node.attrs,
+      ...target.attrs,
+      [target.changeAttr]: [
+        {
+          type: target.changeType,
+          info: { id: revisionId, author: revision.author, date: revision.date },
+          ...(target.previousFormatting != null && {
+            previousFormatting: target.previousFormatting,
+          }),
+        },
+      ],
+    });
+    revisionId += 1;
+  }
+  if (revisionId > revision.idSeed) {
+    // A property change writes no paragraph, and the incremental save reuses
+    // a part whose paragraphs did not change. Saying the table's structure
+    // moved is what makes the save rewrite it.
+    markStructuralChange(tr);
+  }
+  return { nextRevisionId: revisionId, matched: targets.length };
+};

--- a/packages/core/src/ai-edits/table-row-column-mutations.ts
+++ b/packages/core/src/ai-edits/table-row-column-mutations.ts
@@ -10,8 +10,8 @@ import {
 } from "prosemirror-tables";
 
 import { markStructuralChange } from "../prosemirror/extensions/features/ParagraphChangeTrackerExtension";
-import type { TrackedChangeProvenance } from "../prosemirror/schema/marks";
 import { stripBlockIdentityAttrs } from "./block-identity";
+import { tableRowFromTemplate, type TableStructureRevision } from "./table-template";
 import {
   findEnclosingTableCell,
   findEnclosingTableRow,
@@ -45,20 +45,6 @@ export type TableColumnInsertion = {
 };
 
 export type TableColumnDeletion = TableColumnInsertion;
-
-export type TableStructureRevision = {
-  revisionId: number;
-  author: string;
-  date: string;
-  /** Optional author initials (w:initials), carried for round-trip. */
-  initials?: string;
-  /**
-   * `"suggested"` marks the produced `trIns`/`trDel`/`cellMarker` as an AI
-   * proposal that is stripped from serialized DOCX until accepted.
-   */
-  provenance?: TrackedChangeProvenance;
-  suggestionId?: string;
-};
 
 type TableRowColumnMutationResult =
   | { type: "applied"; transaction: Transaction; revisionId: number | null }
@@ -121,6 +107,13 @@ type ApplyTableRowInsertionOptions = {
   insertion: TableRowInsertion;
   cellTexts: readonly string[] | undefined;
   revision: TableStructureRevision | null;
+  /**
+   * The row to place, when the caller has one — a comparison adding a row the
+   * target document already holds. Its `w:trPr` and per-cell `w:tcPr` travel
+   * with it; `cellTexts` builds the row from the neighbouring one when it is
+   * absent or does not fit this table's grid.
+   */
+  template?: PMNode;
 };
 
 export const applyTableRowInsertion = ({
@@ -128,6 +121,7 @@ export const applyTableRowInsertion = ({
   insertion,
   cellTexts,
   revision,
+  template,
 }: ApplyTableRowInsertionOptions): TableRowColumnMutationResult => {
   if (revision && insertion.rowspanUpdates.length > 0) {
     return { type: "unsupported" };
@@ -156,15 +150,21 @@ export const applyTableRowInsertion = ({
         trIns: revision,
       }
     : null;
-  const row = insertion.rowType.create(rowAttrs, insertion.cells);
-  tr.insert(insertion.rowPosition, populateTableRow(row, cellTexts));
+  const templated =
+    template === undefined
+      ? null
+      : tableRowFromTemplate({ template, columnCount: insertion.columnCount });
+  const row = templated
+    ? templated.type.create({ ...templated.attrs, ...rowAttrs }, templated.content)
+    : populateTableRow(insertion.rowType.create(rowAttrs, insertion.cells), cellTexts);
+  tr.insert(insertion.rowPosition, row);
   if (revision) {
     markTableRowContent({ tr, rowPosition: insertion.rowPosition, kind: "insertion", revision });
   }
   return applied(tr, revision);
 };
 
-type MarkTableRowContentOptions = {
+export type MarkTableRowContentOptions = {
   tr: Transaction;
   rowPosition: number;
   kind: "insertion" | "deletion";
@@ -188,7 +188,7 @@ type MarkTableRowContentOptions = {
  * and shortens its span — so marking its text would delete content the
  * accepted document must still hold.
  */
-const markTableRowContent = ({
+export const markTableRowContent = ({
   tr,
   rowPosition,
   kind,

--- a/packages/core/src/ai-edits/table-template.ts
+++ b/packages/core/src/ai-edits/table-template.ts
@@ -1,0 +1,258 @@
+/**
+ * Building a table from another document's table rather than from a grid of
+ * strings.
+ *
+ * `insertTable` and `insertTableRow` describe their content as cell texts,
+ * which is the right shape for a caller that writes a table from nothing. A
+ * comparison is not that caller: the table it adds already exists in the
+ * document it is comparing against, complete with its `w:tblPr`, its
+ * `w:tblGrid` widths, per-row `w:trPr`, per-cell `w:tcPr` — spans, vertical
+ * merges, shading, borders, margins, alignment — and cell paragraphs carrying
+ * their own properties. Rebuilding that from text loses every one of them, and
+ * a consumer accepting the redline then gets a table that is not the one it
+ * was compared to.
+ *
+ * So the operation may be handed the node it should place. The copy is
+ * structural and keeps everything by default; what it cannot bring is what
+ * only the package it came from can resolve — a relationship id (a drawing, a
+ * hyperlink), a note or comment id, a bookmark, a paragraph identity, or a
+ * tracked change belonging to the other document's history. Everything that
+ * describes the table itself travels.
+ */
+
+import { Fragment, type Mark, type Node as PMNode, type Schema } from "prosemirror-model";
+
+import type { TrackedChangeProvenance } from "../prosemirror/schema/marks";
+import { stripBlockIdentityAttrs } from "./block-identity";
+
+/** The node an operation should place, by the id of the operation placing it. */
+export type FolioTableTemplates = ReadonlyMap<string, PMNode>;
+
+/**
+ * Nodes that name something the other package owns: a drawing's relationship,
+ * an anchored frame's, a bookmark's id. They resolve to nothing once the table
+ * has crossed, so they are dropped rather than copied into a dangling
+ * reference.
+ */
+const PACKAGE_BOUND_NODE_NAMES: ReadonlySet<string> = new Set([
+  "image",
+  "textBox",
+  "textBoxAnchor",
+  "shape",
+  "bookmarkBoundary",
+]);
+
+/**
+ * Marks that name something the other package owns. Run properties are the
+ * point of copying the runs at all, so the denial is narrow: a relationship, a
+ * note, a comment, and the other document's revisions.
+ */
+const PACKAGE_BOUND_MARK_NAMES: ReadonlySet<string> = new Set([
+  "hyperlink",
+  "footnoteRef",
+  "comment",
+  "insertion",
+  "deletion",
+  "runPropertyChange",
+]);
+
+/**
+ * Paragraph attrs cleared on a copied paragraph: its identity, the bookmarks
+ * and empty hyperlinks that name package-scoped ids, the section it ended, and
+ * the tracked-change history of the document it came from. Its formatting —
+ * style, alignment, spacing, indentation, borders, shading, tabs — is what the
+ * copy exists to carry, and stays.
+ */
+const CLEARED_PARAGRAPH_ATTRS = [
+  "bookmarks",
+  "_emptyHyperlinks",
+  "_propertyChanges",
+  "pPrMark",
+  "_suggestedInsert",
+  "_sectionProperties",
+  "sectionBreakType",
+  "renderedPageBreakBefore",
+] as const;
+
+/** Table, row and cell attrs that record the other document's revisions. */
+const CLEARED_TABLE_ATTRS = ["tblPrChange", "_suggestedInsert"] as const;
+const CLEARED_ROW_ATTRS = ["trIns", "trDel", "trPrChange"] as const;
+const CLEARED_CELL_ATTRS = ["cellMarker", "tcPrChange"] as const;
+
+const withoutAttrs = (
+  attrs: Record<string, unknown>,
+  cleared: readonly string[],
+): Record<string, unknown> => {
+  const next = { ...attrs };
+  for (const key of cleared) {
+    next[key] = null;
+  }
+  return next;
+};
+
+/**
+ * A structural tracked change on a table row.
+ *
+ * A whole-table insertion has no element of its own in the format: every row
+ * carries `w:trPr/w:ins`, and every run inside it carries `w:ins` as well. A
+ * consumer that reads only run-level revisions keeps the text of a rejected
+ * insertion when the row marker stands alone, so the two are always written
+ * together.
+ */
+export type TableStructureRevision = {
+  revisionId: number;
+  author: string;
+  date: string;
+  /** Optional author initials (w:initials), carried for round-trip. */
+  initials?: string;
+  /**
+   * `"suggested"` marks the produced `trIns`/`trDel`/`cellMarker` as an AI
+   * proposal that is stripped from serialized DOCX until accepted.
+   */
+  provenance?: TrackedChangeProvenance;
+  suggestionId?: string;
+};
+
+type TemplateContext = {
+  /** Present when the copy is an insertion; absent when it only supplies shape. */
+  revision: TableStructureRevision | null;
+  insertion: Mark | null;
+  /**
+   * Clamp a vertical merge on the copied row's own cells. A cell that merged
+   * downwards in the document it came from reached rows that are not the
+   * receiving table's.
+   */
+  clampRowSpan: boolean;
+};
+
+const insertionMarkOf = (schema: Schema, revision: TableStructureRevision | null): Mark | null => {
+  const markType = schema.marks["insertion"];
+  if (!revision || !markType) {
+    return null;
+  }
+  const { revisionId, author, date, initials, provenance, suggestionId } = revision;
+  return markType.create({
+    revisionId,
+    author,
+    date,
+    ...(initials !== undefined && { initials }),
+    ...(provenance !== undefined && { provenance }),
+    ...(suggestionId !== undefined && { suggestionId }),
+  });
+};
+
+const copiedAttrs = (node: PMNode, context: TemplateContext): Record<string, unknown> => {
+  switch (node.type.spec["tableRole"]) {
+    case "table":
+      return withoutAttrs(node.attrs, CLEARED_TABLE_ATTRS);
+    case "row": {
+      const attrs = withoutAttrs(node.attrs, CLEARED_ROW_ATTRS);
+      return context.revision ? { ...attrs, trIns: context.revision } : attrs;
+    }
+    case "cell":
+    case "header_cell": {
+      const attrs = withoutAttrs(node.attrs, CLEARED_CELL_ATTRS);
+      return context.clampRowSpan ? { ...attrs, rowspan: 1 } : attrs;
+    }
+    default:
+      return node.isTextblock
+        ? withoutAttrs(stripBlockIdentityAttrs(node.attrs), CLEARED_PARAGRAPH_ATTRS)
+        : node.attrs;
+  }
+};
+
+/**
+ * One node of the template, or `null` when it names something the package it
+ * came from owns. Inline content carries the insertion mark; a nested table is
+ * copied by the same rules as the one holding it.
+ */
+const copyNode = (node: PMNode, context: TemplateContext): PMNode | null => {
+  if (PACKAGE_BOUND_NODE_NAMES.has(node.type.name)) {
+    return null;
+  }
+  const marks = node.marks.filter(({ type }) => !PACKAGE_BOUND_MARK_NAMES.has(type.name));
+  if (node.isLeaf) {
+    // A revision belongs on the run, which is a leaf. Putting one on an inline
+    // container as well would mark the same characters twice, and resolving
+    // the revision would then delete the container's range and its children's.
+    return node.mark(node.isInline && context.insertion ? [...marks, context.insertion] : marks);
+  }
+  // A cell's rowspan is only clamped on the row being placed. A nested table's
+  // rows are its own, and their merges reach rows that travel with them.
+  const inner =
+    node.type.spec["tableRole"] === "table" ? { ...context, clampRowSpan: false } : context;
+  const content: PMNode[] = [];
+  node.forEach((child) => {
+    const copied = copyNode(child, inner);
+    if (copied) {
+      content.push(copied);
+    }
+  });
+  return node.type.create(copiedAttrs(node, context), Fragment.fromArray(content), marks);
+};
+
+type TableFromTemplateOptions = {
+  schema: Schema;
+  template: PMNode;
+  /** Present in tracked mode: the whole table is stamped as one insertion. */
+  revision?: TableStructureRevision;
+};
+
+/**
+ * The template table, ready to insert: its properties, grid, rows and cells
+ * carried verbatim, nested tables included, and every row plus every run
+ * stamped as an insertion when the caller is tracking changes.
+ *
+ * `null` when the template is not a table or holds no rows, so the caller can
+ * fall back to the operation's own cell texts rather than place something that
+ * is not one.
+ */
+export const tableFromTemplate = ({
+  schema,
+  template,
+  revision,
+}: TableFromTemplateOptions): PMNode | null => {
+  if (template.type.spec["tableRole"] !== "table" || template.childCount === 0) {
+    return null;
+  }
+  return copyNode(template, {
+    revision: revision ?? null,
+    insertion: insertionMarkOf(schema, revision ?? null),
+    clampRowSpan: false,
+  });
+};
+
+type TableRowFromTemplateOptions = {
+  template: PMNode;
+  /** Grid columns the row has to occupy, from the table receiving it. */
+  columnCount: number;
+};
+
+/**
+ * The template row, ready to insert into an existing table.
+ *
+ * Refused — `null`, so the caller falls back to the operation's cell texts —
+ * when the row's cells do not span exactly the receiving table's grid: a row
+ * of a different width would leave the table's map inconsistent with its own
+ * grid. A cell that merged vertically in the document it came from is placed
+ * unmerged, because the rows it reached into are not this table's.
+ */
+export const tableRowFromTemplate = ({
+  template,
+  columnCount,
+}: TableRowFromTemplateOptions): PMNode | null => {
+  if (template.type.spec["tableRole"] !== "row" || template.childCount === 0) {
+    return null;
+  }
+  let spanned = 0;
+  template.forEach((cell) => {
+    const colspan: unknown = cell.attrs["colspan"];
+    spanned += typeof colspan === "number" ? colspan : 1;
+  });
+  if (spanned !== columnCount) {
+    return null;
+  }
+  // The caller stamps the row's own insertion and marks its runs, so the copy
+  // carries neither.
+  return copyNode(template, { revision: null, insertion: null, clampRowSpan: true });
+};

--- a/packages/core/src/compare/README.md
+++ b/packages/core/src/compare/README.md
@@ -176,7 +176,7 @@ list item at the wrong level fails instead of passing.
 `compareDocx` checks its own work before returning, in both directions:
 accepting the generated revisions must reproduce the target, and rejecting
 them must reproduce the base they were written against — table cell
-coordinates included.
+coordinates and the tables' own properties included.
 
 A difference the operation vocabulary cannot express fails with
 `CompareDocxRoundTripError` rather than returning a redline that reads
@@ -202,9 +202,13 @@ if (result.isOk() && result.value.verification.status === "unverified") {
 
 `verification` is on every successful result, so a caller that never passes the
 option still sees `{ status: "verified" }` and can assert on it. `cause` is one
-of `invisible-structure`, `block-count`, `container`, `style`, `list-level`,
-`whitespace`, `text` — the projection field that diverged, which is what names
-the part of the pipeline that lost the difference. `invisible-structure` is the
+of `invisible-structure`, `block-count`, `container`, `table-geometry`,
+`style`, `list-level`, `whitespace`, `text` — the projection field that
+diverged, which is what names the part of the pipeline that lost the
+difference. `table-geometry` is the one that no block carries: a second
+projection reads each table's `w:tblPr`, `w:trPr` and `w:tcPr` so a redline
+that reproduces every word and none of the widths, spans, merges, shading or
+borders fails instead of passing. `invisible-structure` is the
 one cause that is not a lost difference: every block is present, in order, at
 coordinates the block model cannot reach, because the snapshot carries no block
 for an empty paragraph.
@@ -233,6 +237,35 @@ the base's accepted view, accepting returns the target's.
 
 A caller who wants the earlier revisions preserved should resolve them
 deliberately before comparing.
+
+## Tables
+
+A table the comparison adds is the target's table, not a grid of its cell
+texts: `w:tblPr` with its style, width, indent, justification, borders, cell
+margins, layout and look; `w:tblGrid` with the target's column widths; each
+row's `w:trPr`; each cell's `w:tcPr` with `w:tcW`, `w:gridSpan`, `w:vMerge`,
+`w:shd`, `w:tcBorders`, `w:tcMar` and `w:vAlign`; cell paragraphs with their
+own properties and runs; and tables nested in cells, recursively. The operation
+vocabulary is unchanged — `insertTable` and `insertTableRow` still describe
+their content as cell texts, because that is what a caller writing a table from
+nothing has — and the node travels beside the batch instead, since a document
+node is not JSON.
+
+A table crossing from one package into the other cannot bring what only the
+first package can resolve, so a copied table drops hyperlink, note and comment
+marks, paragraph identities, and any inline content that names a relationship.
+Everything that describes the table itself travels.
+
+A table or row the comparison removes keeps every property it had, under the
+deletion marks: the row carries `w:trPr/w:del` and every run inside it carries
+`w:del`, so rejecting restores the table exactly and a consumer that reads only
+one of the two marks still resolves the deletion.
+
+A table that stayed in place while its properties changed moves no block, so no
+block operation carries the difference. Each paired table, row and cell whose
+properties differ is rewritten to the target's and records the previous set as
+`w:tblPrChange` / `w:trPrChange` / `w:tcPrChange`, which is what a reject
+restores.
 
 ## Limitations
 
@@ -266,7 +299,25 @@ carries the current numbers and the failing cases.
 - **A table nested inside a cell cannot be added or removed** (2026-09-06). A
   whole table added or removed at document level is `table-insert` /
   `table-delete`; the same edit inside a cell would need `insertTable` to
-  place a table in a cell rather than as a document-level peer.
+  place a table in a cell rather than as a document-level peer. A nested table
+  travels with the table that holds it, so one added or removed alongside its
+  parent keeps its own grid and properties.
+- **A paired table's grid is not moved** (2026-09-07). `w:tblGrid` changes are
+  recorded with `w:tblGridChange`, which the editable model does not carry, so
+  a table whose columns kept their text and changed their widths keeps the
+  base's. A table the comparison ADDS carries the target's grid, because there
+  is no previous one to record.
+- **A property a table style resolves is not moved** (2026-09-07). A change
+  element stores the complete previous property set, and rejecting it rebuilds
+  the live properties from that record alone. Where the base's effective
+  properties cannot be rebuilt from what would be written for it — a value a
+  style resolves that no `w:tcPr` of the document states — the difference is
+  left alone rather than written as a revision that rejects to a third
+  document.
+- **`colspan` and `rowspan` are not moved on a paired cell** (2026-09-07). They
+  shape the table's map, and changing one without restructuring the rows around
+  it leaves the map inconsistent with its own grid. A span that changed is a
+  row or column edit, not a property change.
 - **A numbering definition is reported, not represented** (2026-09-06). A list
   whose format, level template or start changed is a `numbering` change, and
   the redline cannot carry it: OOXML has no tracked-change grammar for
@@ -277,7 +328,13 @@ carries the current numbers and the failing cases.
 
 - `compare.ts` — the four stages (parse, align, apply, serialize), story
   pairing, and the round-trip self-check. `compareDocx` composes them.
-- `plan.ts` — alignment and operation derivation. Pure.
+- `plan.ts` — alignment and operation derivation, including which table each
+  `insertTable` / `insertTableRow` should place and which cells were paired.
+  Pure.
+- `../ai-edits/table-template.ts` — copying a table out of one package into the
+  other: what travels, what cannot, and how an insertion is stamped.
+- `../ai-edits/table-geometry.ts` — the table-property projection the
+  self-check compares, and the matching that moves a paired table's properties.
 - `verification.ts` — the round-trip verdict: the invariants, the causes, and
   the safe-to-quote detail each failure carries, plus the structural guard on a
   container's final paragraph mark. Pure.

--- a/packages/core/src/compare/__fixtures__/body-sequence.ts
+++ b/packages/core/src/compare/__fixtures__/body-sequence.ts
@@ -34,6 +34,76 @@ const ZIP_ENTRY_OPTIONS = { date: FIXED_ZIP_DATE, createFolders: false } as cons
  */
 export type CellContent = string | readonly BodyItem[];
 
+/** `w:tcPr` children a fixture can author, each named after the element. */
+export type CellProperties = {
+  /** `w:gridSpan`: grid columns this cell occupies. */
+  gridSpan?: number;
+  /** `w:vMerge`: the cell starts a vertical merge, or continues one. */
+  verticalMerge?: "restart" | "continue";
+  /** `w:tcW` in twips. */
+  width?: number;
+  /** `w:shd` fill colour, as six hex digits. */
+  shadingFill?: string;
+  /** `w:vAlign`. */
+  verticalAlign?: "top" | "center" | "bottom";
+  /** `w:tcBorders`, single style on all four sides, in eighths of a point. */
+  borderSize?: number;
+  /** `w:tcMar`, the same margin on all four sides, in twips. */
+  margin?: number;
+};
+
+/** A cell: its content alone, or its content and its own `w:tcPr`. */
+export type Cell = CellContent | ({ content: CellContent } & CellProperties);
+
+/** A row: its cells alone, or its cells and its own `w:trPr`. */
+export type TableRow =
+  | readonly Cell[]
+  | {
+      cells: readonly Cell[];
+      /** `w:trHeight` in twips. */
+      height?: number;
+      /** `w:tblHeader`: the row repeats at the top of every page. */
+      header?: boolean;
+      /** `w:jc` on the row. */
+      justification?: "left" | "center" | "right";
+    };
+
+/** `w:tblPr` children a fixture can author, each named after the element. */
+export type TableProperties = {
+  /** `w:tblStyle`. */
+  styleId?: string;
+  /** `w:tblW`. */
+  width?: { value: number; type: "auto" | "dxa" | "pct" };
+  /** `w:jc` on the table. */
+  justification?: "left" | "center" | "right";
+  /** `w:tblInd` in twips. */
+  indent?: number;
+  /** `w:tblBorders`, single style on every side, in eighths of a point. */
+  borderSize?: number;
+  /** `w:shd` fill colour on the table, as six hex digits. */
+  shadingFill?: string;
+  /** `w:tblLayout`. */
+  layout?: "fixed" | "autofit";
+  /** `w:tblCellMar`, the same margin on all four sides, in twips. */
+  cellMargin?: number;
+  /** `w:tblLook` value, as four hex digits. */
+  look?: string;
+};
+
+type RowOptions = Exclude<TableRow, readonly Cell[]>;
+type CellSpec = Exclude<Cell, CellContent>;
+
+const isRowOptions = (row: TableRow): row is RowOptions => "cells" in row;
+const isCellSpec = (cell: Cell): cell is CellSpec => typeof cell === "object" && "content" in cell;
+
+const rowCells = (row: TableRow): readonly Cell[] => (isRowOptions(row) ? row.cells : row);
+
+const rowOptions = (row: TableRow): Omit<RowOptions, "cells"> => (isRowOptions(row) ? row : {});
+
+const cellContent = (cell: Cell): CellContent => (isCellSpec(cell) ? cell.content : cell);
+
+const cellProperties = (cell: Cell): CellProperties => (isCellSpec(cell) ? cell : {});
+
 /**
  * One inline of a paragraph: plain text, or text carrying an external
  * hyperlink. A link is the case where a revision wrapper and the linked runs
@@ -56,7 +126,11 @@ export type BodyItem =
     }
   | {
       kind: "table";
-      rows: readonly (readonly CellContent[])[];
+      rows: readonly TableRow[];
+      /** `w:tblPr` children, written in the order the schema requires. */
+      properties?: TableProperties;
+      /** `w:tblGrid` column widths, in twips. One per grid column. */
+      columnWidths?: readonly number[];
       /**
        * Rows a package hides with `w:hidden`. The snapshot skips their whole
        * subtree, so a document that has one is the case where the snapshot
@@ -156,9 +230,10 @@ const collectHrefs = (items: readonly BodyItem[], hrefs: string[]): void => {
       continue;
     }
     for (const row of item.rows) {
-      for (const cell of row) {
-        if (typeof cell !== "string") {
-          collectHrefs(cell, hrefs);
+      for (const cell of rowCells(row)) {
+        const content = cellContent(cell);
+        if (typeof content !== "string") {
+          collectHrefs(content, hrefs);
         }
       }
     }
@@ -185,26 +260,118 @@ const cellXml = (content: CellContent, context: BodyContext): string =>
     : itemsXml(closedSequence(content), context);
 
 /** `w:tbl` is `w:tblPr, w:tblGrid, rows`: a fixture without the grid is not one. */
-const tableGrid = (rows: readonly (readonly CellContent[])[]): string => {
+const tableGrid = (item: Extract<BodyItem, { kind: "table" }>): string => {
+  if (item.columnWidths) {
+    return `<w:tblGrid>${item.columnWidths.map((width) => `<w:gridCol w:w="${String(width)}"/>`).join("")}</w:tblGrid>`;
+  }
   let columns = 0;
-  for (const cells of rows) {
-    columns = Math.max(columns, cells.length);
+  for (const row of item.rows) {
+    let spanned = 0;
+    for (const cell of rowCells(row)) {
+      spanned += cellProperties(cell).gridSpan ?? 1;
+    }
+    columns = Math.max(columns, spanned);
   }
   return `<w:tblGrid>${`<w:gridCol w:w="2000"/>`.repeat(columns)}</w:tblGrid>`;
+};
+
+const BORDER_SIDES = ["top", "left", "bottom", "right", "insideH", "insideV"] as const;
+const CELL_BORDER_SIDES = ["top", "left", "bottom", "right"] as const;
+const MARGIN_SIDES = ["top", "left", "bottom", "right"] as const;
+
+const borders = (element: string, sides: readonly string[], size: number): string =>
+  `<w:${element}>${sides
+    .map(
+      (side) => `<w:${side} w:val="single" w:sz="${String(size)}" w:space="0" w:color="000000"/>`,
+    )
+    .join("")}</w:${element}>`;
+
+const margins = (element: string, value: number): string =>
+  `<w:${element}>${MARGIN_SIDES.map(
+    (side) => `<w:${side} w:w="${String(value)}" w:type="dxa"/>`,
+  ).join("")}</w:${element}>`;
+
+/**
+ * `w:tblPr` children in the order CT_TblPrBase declares: tblStyle, tblW, jc,
+ * tblInd, tblBorders, shd, tblLayout, tblCellMar, tblLook. `w:tblW` is always
+ * written.
+ */
+const tableProperties = ({ properties }: Extract<BodyItem, { kind: "table" }>): string => {
+  const width = properties?.width ?? { value: 0, type: "auto" };
+  const parts = [
+    ...(properties?.styleId === undefined ? [] : [`<w:tblStyle w:val="${properties.styleId}"/>`]),
+    `<w:tblW w:w="${String(width.value)}" w:type="${width.type}"/>`,
+    ...(properties?.justification === undefined
+      ? []
+      : [`<w:jc w:val="${properties.justification}"/>`]),
+    ...(properties?.indent === undefined
+      ? []
+      : [`<w:tblInd w:w="${String(properties.indent)}" w:type="dxa"/>`]),
+    ...(properties?.borderSize === undefined
+      ? []
+      : [borders("tblBorders", BORDER_SIDES, properties.borderSize)]),
+    ...(properties?.shadingFill === undefined
+      ? []
+      : [`<w:shd w:val="clear" w:color="auto" w:fill="${properties.shadingFill}"/>`]),
+    ...(properties?.layout === undefined ? [] : [`<w:tblLayout w:type="${properties.layout}"/>`]),
+    ...(properties?.cellMargin === undefined ? [] : [margins("tblCellMar", properties.cellMargin)]),
+    ...(properties?.look === undefined ? [] : [`<w:tblLook w:val="${properties.look}"/>`]),
+  ];
+  return `<w:tblPr>${parts.join("")}</w:tblPr>`;
+};
+
+/**
+ * `w:trPr` children. `CT_TrPrBase` is a repeated choice rather than a
+ * sequence, so the order here is the readable one rather than a required one.
+ */
+const rowProperties = (row: TableRow, hidden: boolean): string => {
+  const { header, height, justification } = rowOptions(row);
+  const parts = [
+    ...(height === undefined ? [] : [`<w:trHeight w:val="${String(height)}"/>`]),
+    ...(header === true ? ["<w:tblHeader/>"] : []),
+    ...(justification === undefined ? [] : [`<w:jc w:val="${justification}"/>`]),
+    ...(hidden ? ["<w:hidden/>"] : []),
+  ];
+  return parts.length === 0 ? "" : `<w:trPr>${parts.join("")}</w:trPr>`;
+};
+
+/** `w:tcPr` children in schema order; `w:tcW` is always written. */
+const cellPropertiesXml = (cell: Cell): string => {
+  const properties = cellProperties(cell);
+  const parts = [
+    `<w:tcW w:w="${String(properties.width ?? 2000)}" w:type="dxa"/>`,
+    ...(properties.gridSpan === undefined
+      ? []
+      : [`<w:gridSpan w:val="${String(properties.gridSpan)}"/>`]),
+    ...(properties.verticalMerge === undefined
+      ? []
+      : [properties.verticalMerge === "restart" ? `<w:vMerge w:val="restart"/>` : `<w:vMerge/>`]),
+    ...(properties.borderSize === undefined
+      ? []
+      : [borders("tcBorders", CELL_BORDER_SIDES, properties.borderSize)]),
+    ...(properties.shadingFill === undefined
+      ? []
+      : [`<w:shd w:val="clear" w:color="auto" w:fill="${properties.shadingFill}"/>`]),
+    ...(properties.margin === undefined ? [] : [margins("tcMar", properties.margin)]),
+    ...(properties.verticalAlign === undefined
+      ? []
+      : [`<w:vAlign w:val="${properties.verticalAlign}"/>`]),
+  ];
+  return `<w:tcPr>${parts.join("")}</w:tcPr>`;
 };
 
 const table = (item: Extract<BodyItem, { kind: "table" }>, context: BodyContext): string => {
   const hidden = new Set(item.hiddenRows ?? []);
   return (
-    `<w:tbl><w:tblPr><w:tblW w:w="0" w:type="auto"/></w:tblPr>` +
-    tableGrid(item.rows) +
+    `<w:tbl>${tableProperties(item)}` +
+    tableGrid(item) +
     item.rows
       .map(
-        (cells, rowIndex) =>
-          `<w:tr>${hidden.has(rowIndex) ? `<w:trPr><w:hidden/></w:trPr>` : ""}${cells
+        (row, rowIndex) =>
+          `<w:tr>${rowProperties(row, hidden.has(rowIndex))}${rowCells(row)
             .map(
-              (content) =>
-                `<w:tc><w:tcPr><w:tcW w:w="2000" w:type="dxa"/></w:tcPr>${cellXml(content, context)}</w:tc>`,
+              (cell) =>
+                `<w:tc>${cellPropertiesXml(cell)}${cellXml(cellContent(cell), context)}</w:tc>`,
             )
             .join("")}</w:tr>`,
       )

--- a/packages/core/src/compare/compare.ts
+++ b/packages/core/src/compare/compare.ts
@@ -35,6 +35,7 @@
  */
 
 import { panic, Result } from "better-result";
+import type { Node as PMNode } from "prosemirror-model";
 
 import {
   FolioDocxReviewer,
@@ -42,11 +43,13 @@ import {
   type FolioNumberingLevel,
   type FolioRevisionStamp,
 } from "../ai-edits/headless";
+import { projectTableGeometry } from "../ai-edits/table-geometry";
+import type { FolioTableTemplates } from "../ai-edits/table-template";
 import type { FolioAIBlock, FolioAIEditSnapshot } from "../ai-edits/types";
 import type { WordDiffGranularity } from "../ai-edits/word-diff";
 import { FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION } from "../document-operations";
 import { pairFolioDocumentStories } from "../document-stories";
-import { planStoryCompare, type CompareStoryPlan } from "./plan";
+import { planStoryCompare, type CompareStoryPlan, type CompareTableTemplateRequest } from "./plan";
 import { withFixedPackageDates } from "./reproducible-package";
 import {
   CompareDocxApplyError,
@@ -63,6 +66,7 @@ import {
   type CompareUnsupportedPart,
 } from "./types";
 import {
+  classifyGeometryMismatch,
   classifyProjectionMismatch,
   deletedFinalParagraphMarks,
   projectSupportedInlineFormatting,
@@ -376,19 +380,57 @@ export const planComparison = ({
   return Result.ok(planned);
 };
 
-/** What stage 3 produced: the change list, and whether it was proven. */
+/** What stage 3 produced: the change list, whether it was proven, and whether it wrote anything. */
 export type AppliedComparison = {
   changes: readonly CompareChange[];
   verification: CompareVerification;
+  /**
+   * Whether the stage wrote into the base document at all. A comparison that
+   * found nothing writes nothing, and the serialize stage then hands the
+   * arriving bytes back rather than reproducing them.
+   */
+  documentChanged: boolean;
+};
+
+/**
+ * The table each `insertTable` / `insertTableRow` in the plan should place,
+ * resolved against the target document the plan named it in.
+ *
+ * The plan is pure and names a table by index; the node lives in the other
+ * package, which only this stage holds. A request naming a table the target
+ * does not have resolves to nothing and the operation falls back to its cell
+ * texts, which is the same redline the comparison produced before.
+ */
+const resolveTableTemplates = (
+  targetTables: ReadonlyMap<number, PMNode>,
+  requests: readonly CompareTableTemplateRequest[],
+): FolioTableTemplates => {
+  const templates = new Map<string, PMNode>();
+  for (const { operationId, targetTableIndex, targetRowIndex } of requests) {
+    const table = targetTables.get(targetTableIndex);
+    if (!table) {
+      continue;
+    }
+    if (targetRowIndex === undefined) {
+      templates.set(operationId, table);
+      continue;
+    }
+    const row = table.maybeChild(targetRowIndex);
+    if (row) {
+      templates.set(operationId, row);
+    }
+  }
+  return templates;
 };
 
 /**
  * Stage 3: write the planned operations into the base document as tracked
  * changes, then check the work rather than trust it. Both directions of the
- * round trip are checked, structure included: accepting the story's generated
- * revisions must reproduce the target, and rejecting them must reproduce the
- * base it was compared from. A difference the operation vocabulary cannot
- * express would otherwise leave a redline that reads plausibly and is wrong.
+ * round trip are checked, structure and table geometry included: accepting the
+ * story's generated revisions must reproduce the target, and rejecting them
+ * must reproduce the base it was compared from. A difference the operation
+ * vocabulary cannot express would otherwise leave a redline that reads
+ * plausibly and is wrong.
  *
  * The check reports rather than throws. {@link compareDocx} decides what to do
  * with an unverified result, because "give me your best attempt and tell me
@@ -396,7 +438,7 @@ export type AppliedComparison = {
  * are both legitimate asks and only the caller knows which one it is making.
  */
 export const applyComparison = (
-  { reviewer, revisionStamp, granularity, numberingChanges }: ParsedComparison,
+  { reviewer, targetReviewer, revisionStamp, granularity, numberingChanges }: ParsedComparison,
   planned: readonly PlannedStoryComparison[],
 ): Result<AppliedComparison, CompareDocxApplyError> => {
   const changes: CompareChange[] = [...numberingChanges];
@@ -406,45 +448,76 @@ export const applyComparison = (
   // seeded alike would let a reader resolving a header revision resolve a
   // body revision with it.
   let idSeed = revisionStamp.idSeed;
+  let documentChanged = false;
   for (const { pair, plan } of planned) {
     changes.push(...plan.changes);
-    if (plan.operations.length === 0) {
+    if (plan.operations.length === 0 && plan.tableGeometryPairings.length === 0) {
       continue;
     }
 
-    // Read before the operations land: this is the document the redline is
-    // written against, and rejecting every revision has to return to it.
+    // Read before anything lands: this is the document the redline is written
+    // against, and rejecting every revision has to return to it.
     const baseBeforeBlocks =
       reviewer.readReviewedStory({ story: pair.baseStory, view: "final" })?.snapshot.blocks ?? [];
     const baseBefore = projectBlocks(baseBeforeBlocks);
+    const baseBeforeGeometry = projectTableGeometry(
+      reviewer.storyTables({ story: pair.baseStory }),
+    );
+    const targetTables = new Map(
+      targetReviewer
+        .storyTables({ story: pair.targetStory })
+        .map(({ index, node }) => [index, node] as const),
+    );
 
-    const { skipped, nextRevisionId } = reviewer.applyDocumentOperationsToStory({
+    // Table properties first, while the base's table indices still describe
+    // the document the plan was written against: the operations below add and
+    // remove tables, and every index past the first one would then name a
+    // different table.
+    const afterGeometry = reviewer.matchStoryTableGeometry({
       story: pair.baseStory,
-      snapshot: pair.baseSnapshot,
+      targetTables,
+      pairings: plan.tableGeometryPairings,
       revisionStamp: { date: revisionStamp.date, idSeed },
-      wordDiff: { granularity },
-      batch: {
-        version: FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
-        mode: "tracked-changes",
-        operations: plan.operations,
-      },
     });
-    if (nextRevisionId === undefined) {
-      // Only a host bridge that does not allocate ids itself omits this, and
-      // the comparison drives the in-process applier.
-      panic("The applier did not report where it left the revision-id counter", {
-        story: pair.baseStory,
-      });
+    const geometryChanged = afterGeometry > idSeed;
+    documentChanged ||= geometryChanged;
+    idSeed = afterGeometry;
+
+    if (plan.operations.length === 0 && !geometryChanged) {
+      continue;
     }
-    idSeed = nextRevisionId;
-    if (skipped.length > 0) {
-      return Result.err(
-        new CompareDocxApplyError({
-          message:
-            "Some derived operations were refused, so the result would not match the target.",
-          skipped,
-        }),
-      );
+
+    if (plan.operations.length > 0) {
+      const { skipped, nextRevisionId } = reviewer.applyDocumentOperationsToStory({
+        story: pair.baseStory,
+        snapshot: pair.baseSnapshot,
+        revisionStamp: { date: revisionStamp.date, idSeed },
+        wordDiff: { granularity },
+        batch: {
+          version: FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
+          mode: "tracked-changes",
+          operations: plan.operations,
+        },
+        tableTemplates: resolveTableTemplates(targetTables, plan.tableTemplates),
+      });
+      if (nextRevisionId === undefined) {
+        // Only a host bridge that does not allocate ids itself omits this, and
+        // the comparison drives the in-process applier.
+        panic("The applier did not report where it left the revision-id counter", {
+          story: pair.baseStory,
+        });
+      }
+      idSeed = nextRevisionId;
+      documentChanged = true;
+      if (skipped.length > 0) {
+        return Result.err(
+          new CompareDocxApplyError({
+            message:
+              "Some derived operations were refused, so the result would not match the target.",
+            skipped,
+          }),
+        );
+      }
     }
 
     const acceptedStory = reviewer.readReviewedStory({ story: pair.baseStory, view: "final" });
@@ -491,11 +564,38 @@ export const applyComparison = (
         failures.push(formattingFailure);
       }
     }
+    // The block projection says which cell every paragraph landed in and
+    // nothing about the cell. A table's own properties need their own
+    // comparison, or a redline that reproduces every word and none of the
+    // widths, spans, shading or borders passes the self-check. Checked after
+    // the blocks, because a block in the wrong container is the finding a
+    // reader needs first and a geometry difference follows from it.
+    const geometryAcceptFailure = classifyGeometryMismatch({
+      invariant: "accept-reproduces-target",
+      story: pair.baseStory,
+      actual: projectTableGeometry(reviewer.storyTables({ story: pair.baseStory, view: "final" })),
+      expected: projectTableGeometry(targetReviewer.storyTables({ story: pair.targetStory })),
+    });
+    if (geometryAcceptFailure) {
+      failures.push(geometryAcceptFailure);
+    }
+    const geometryRejectFailure = classifyGeometryMismatch({
+      invariant: "reject-reproduces-base",
+      story: pair.baseStory,
+      actual: projectTableGeometry(
+        reviewer.storyTables({ story: pair.baseStory, view: "original" }),
+      ),
+      expected: baseBeforeGeometry,
+    });
+    if (geometryRejectFailure) {
+      failures.push(geometryRejectFailure);
+    }
   }
   return Result.ok({
     changes,
     verification:
       failures.length === 0 ? { status: "verified" } : { status: "unverified", failures },
+    documentChanged,
   });
 };
 
@@ -520,9 +620,9 @@ export const applyComparison = (
  */
 export const serializeComparison = async (
   { baseBuffer, baseCarriedRevisions, reviewer, packageDate }: ParsedComparison,
-  planned: readonly PlannedStoryComparison[],
+  { documentChanged }: AppliedComparison,
 ): Promise<Result<ArrayBuffer, CompareDocxSerializeError | CompareDocxFinalParagraphMarkError>> => {
-  if (!baseCarriedRevisions && planned.every(({ plan }) => plan.operations.length === 0)) {
+  if (!baseCarriedRevisions && !documentChanged) {
     return Result.ok(baseBuffer);
   }
   const document = reviewer.toDocument();
@@ -599,7 +699,7 @@ export const compareDocx = async (
       }),
     );
   }
-  const serialized = await serializeComparison(parsed.value, planned.value);
+  const serialized = await serializeComparison(parsed.value, applied.value);
   if (serialized.isErr()) {
     return Result.err(serialized.error);
   }

--- a/packages/core/src/compare/plan.ts
+++ b/packages/core/src/compare/plan.ts
@@ -47,6 +47,7 @@ import type {
   FolioAIEditOperation,
   FolioAIEditSnapshot,
 } from "../ai-edits/types";
+import type { TableCellCoordinate, TableGeometryPairing } from "../ai-edits/table-geometry";
 import { alignFolioBlocks } from "../version-comparison";
 import { inlineFormattingSegments } from "./formatting";
 import { alignTableColumns, type TableColumnAlignmentStep } from "./column-alignment";
@@ -1105,9 +1106,72 @@ const trailingDeletionOperations = ({
   return added;
 };
 
+/**
+ * A table the target document already holds, which the operation naming it
+ * should place verbatim instead of rebuilding from its cell texts.
+ *
+ * The plan is pure and sees only block snapshots, so it names the table by the
+ * index the snapshot numbers tables with; the caller, which has both
+ * documents, resolves the index to the node.
+ */
+export type CompareTableTemplateRequest = {
+  /** The `insertTable` or `insertTableRow` operation this table belongs to. */
+  operationId: string;
+  /** Index of the table in the TARGET story. */
+  targetTableIndex: number;
+  /** Set for a row insertion: which of that table's rows to place. */
+  targetRowIndex?: number;
+};
+
 export type CompareStoryPlan = {
   changes: CompareChange[];
   operations: FolioAIEditOperation[];
+  /**
+   * Where an operation's table comes from. Kept beside the operations rather
+   * than inside them because a table node is not JSON, and the serialized
+   * operation contract describes a table by its cell texts.
+   */
+  tableTemplates: CompareTableTemplateRequest[];
+  /**
+   * Base cells the alignment put opposite a target cell. Their tables, rows
+   * and cells are the ones whose `w:tblPr` / `w:trPr` / `w:tcPr` the caller
+   * matches: a table that stayed in place while its widths, shading or header
+   * row changed moves no block, so no operation carries the difference.
+   */
+  tableGeometryPairings: TableGeometryPairing[];
+};
+
+const cellCoordinate = ({
+  tableIndex,
+  rowIndex,
+  cellIndex,
+}: FolioAIBlockTableLocation): TableCellCoordinate => ({ tableIndex, rowIndex, cellIndex });
+
+/**
+ * The cells the alignment paired, one entry each. A cell holds several
+ * paragraphs and each pairs on its own, so the first pairing of a cell is the
+ * one kept: later ones would name the same two cells.
+ */
+const tableGeometryPairingsOf = (steps: readonly CompareStep[]): TableGeometryPairing[] => {
+  const pairings: TableGeometryPairing[] = [];
+  const seen = new Set<string>();
+  for (const step of steps) {
+    if (step.type !== "pair") {
+      continue;
+    }
+    const base = step.baseBlock.table;
+    const target = step.targetBlock.table;
+    if (!base || !target) {
+      continue;
+    }
+    const key = `${String(base.tableIndex)}:${String(base.rowIndex)}:${String(base.cellIndex)}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    pairings.push({ base: cellCoordinate(base), target: cellCoordinate(target) });
+  }
+  return pairings;
 };
 
 export type PlanStoryCompareOptions = {
@@ -1142,6 +1206,7 @@ export const planStoryCompare = ({
   const anchorIds = nextBaseBlockIdByStep(steps);
   const changes: CompareChange[] = [];
   const operations: FolioAIEditOperation[] = [];
+  const tableTemplates: CompareTableTemplateRequest[] = [];
   /**
    * The anchor everything past the base document's content hangs from: its
    * last BODY-LEVEL paragraph, which the format guarantees exists because a
@@ -1412,25 +1477,21 @@ export const planStoryCompare = ({
           targetBlockIds: step.blocks.map(({ id }) => id),
         });
         const before = anchorIds[stepIndex] ?? null;
-        if (before !== null) {
-          operations.push({
-            id: nextOperationId(),
-            type: "insertTable",
-            blockId: before,
-            position: "before",
-            rows,
-          });
+        const anchorBlockId = before ?? tailAnchorId;
+        if (anchorBlockId === null) {
           break;
         }
-        if (tailAnchorId !== null) {
-          operations.push({
-            id: nextOperationId(),
-            type: "insertTable",
-            blockId: tailAnchorId,
-            position: "after",
-            rows,
-          });
-        }
+        const operationId = nextOperationId();
+        operations.push({
+          id: operationId,
+          type: "insertTable",
+          blockId: anchorBlockId,
+          position: before === null ? "after" : "before",
+          rows,
+        });
+        // The rows above are the change list's summary; the table itself comes
+        // from the target, so its grid, row and cell properties survive.
+        tableTemplates.push({ operationId, targetTableIndex: step.location.tableIndex });
         break;
       }
       case "targetRow": {
@@ -1452,12 +1513,18 @@ export const planStoryCompare = ({
           }
           break;
         }
+        const rowOperationId = nextOperationId();
         operations.push({
-          id: nextOperationId(),
+          id: rowOperationId,
           type: "insertTableRow",
           blockId: anchor.blockId,
           position: anchor.position,
           cellTexts: cells,
+        });
+        tableTemplates.push({
+          operationId: rowOperationId,
+          targetTableIndex: step.location.tableIndex,
+          targetRowIndex: step.location.rowIndex,
         });
         break;
       }
@@ -1498,5 +1565,12 @@ export const planStoryCompare = ({
     }),
   );
 
-  return operations.length > maxOperations ? null : { changes, operations };
+  return operations.length > maxOperations
+    ? null
+    : {
+        changes,
+        operations,
+        tableTemplates,
+        tableGeometryPairings: tableGeometryPairingsOf(steps),
+      };
 };

--- a/packages/core/src/compare/tableGeometry.test.ts
+++ b/packages/core/src/compare/tableGeometry.test.ts
@@ -1,0 +1,457 @@
+/**
+ * A comparison that adds, removes or edits a table has to carry the table, not
+ * a grid of strings.
+ *
+ * The round-trip properties the rest of the suite pins are about words: every
+ * block present, in the right container, with the right text. A table is more
+ * than its words — `w:tblPr`, the `w:tblGrid` widths, `w:trPr`, and per-cell
+ * `w:tcPr` with its spans, merges, shading, borders and margins — and none of
+ * that appears in a block projection. So these cases compare the parsed table
+ * model on both sides of the round trip, and read the serialized XML where the
+ * point is that a specific element was written.
+ */
+
+import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+import JSZip from "jszip";
+
+import { propertyConfig, propertyTestTimeout } from "../../../../test/property-testing";
+
+import { FolioDocxReviewer } from "../ai-edits/headless";
+import { projectTableGeometry } from "../ai-edits/table-geometry";
+import { buildBodySequenceDocx, type BodyItem, type TableRow } from "./__fixtures__/body-sequence";
+import { compareDocx } from "./compare";
+
+const OPTIONS = { author: "compare", timestamp: "2024-03-01T00:00:00.000Z" } as const;
+
+const documentXml = async (buffer: ArrayBuffer): Promise<string> => {
+  const entry = (await JSZip.loadAsync(buffer)).file("word/document.xml");
+  if (!entry) {
+    throw new Error("The compared package has no main document part.");
+  }
+  return await entry.async("string");
+};
+
+type RoundTrip = {
+  /** The redlined package's main document part. */
+  xml: string;
+  /** Table models on each side of the round trip, one line per table. */
+  accepted: readonly string[];
+  target: readonly string[];
+  rejected: readonly string[];
+  base: readonly string[];
+};
+
+/**
+ * Compare, then read the table model back out of the package on both sides.
+ *
+ * Read from the SERIALIZED result rather than from the in-memory document, so
+ * a property that survives the redline and is lost on the way to `w:tcPr` is
+ * caught here rather than passing.
+ */
+const roundTrip = async (base: ArrayBuffer, target: ArrayBuffer): Promise<RoundTrip> => {
+  const result = await compareDocx(base, target, { ...OPTIONS, onUnverified: "emit" });
+  if (result.isErr()) {
+    throw result.error;
+  }
+  const compared = await FolioDocxReviewer.fromBuffer(result.value.buffer);
+  return {
+    xml: await documentXml(result.value.buffer),
+    accepted: projectTableGeometry(compared.storyTables({ view: "final" })),
+    target: projectTableGeometry((await FolioDocxReviewer.fromBuffer(target)).storyTables()),
+    rejected: projectTableGeometry(compared.storyTables({ view: "original" })),
+    base: projectTableGeometry((await FolioDocxReviewer.fromBuffer(base)).storyTables()),
+  };
+};
+
+const INTRO = { kind: "paragraph", text: "This agreement is made between the parties." } as const;
+/**
+ * A body-level paragraph after the table, so both sides of a comparison end
+ * with the same one. A container may not end with a table, so a sequence that
+ * does gets a blank paragraph — and a base that has one where the target does
+ * not turns "the table went away" into "the table and a paragraph went away".
+ */
+const OUTRO = { kind: "paragraph", text: "Signed by the parties above." } as const;
+
+/**
+ * A table using every property class the comparison claims to carry: a table
+ * style and look, explicit widths and a grid, borders and cell margins, a
+ * repeating header row, a horizontal span, a vertical merge, cell shading and
+ * alignment, and a nested table.
+ */
+const RICH_TABLE = {
+  kind: "table",
+  columnWidths: [3200, 2400, 2400],
+  properties: {
+    styleId: "TableGrid",
+    width: { value: 8000, type: "dxa" },
+    justification: "center",
+    indent: 120,
+    borderSize: 8,
+    layout: "fixed",
+    cellMargin: 80,
+    look: "04A0",
+  },
+  rows: [
+    {
+      header: true,
+      height: 480,
+      justification: "center",
+      cells: [
+        { content: "Obligation", gridSpan: 2, width: 5600, shadingFill: "D9D9D9" },
+        { content: "Owner", width: 2400, verticalAlign: "center" },
+      ],
+    },
+    {
+      cells: [
+        {
+          content: "Deliver the goods to the named place.",
+          width: 3200,
+          verticalMerge: "restart",
+          borderSize: 4,
+        },
+        { content: "Before the agreed date.", width: 2400, margin: 40 },
+        { content: "Supplier", width: 2400, shadingFill: "FFF2CC" },
+      ],
+    },
+    {
+      cells: [
+        { content: "", width: 3200, verticalMerge: "continue" },
+        {
+          content: [
+            { kind: "paragraph", text: "The schedule below lists the dates." },
+            {
+              kind: "table",
+              columnWidths: [1200, 1200],
+              properties: { width: { value: 2400, type: "dxa" }, borderSize: 4 },
+              rows: [
+                [
+                  { content: "First", width: 1200 },
+                  { content: "Second", width: 1200 },
+                ],
+              ],
+            },
+          ],
+          width: 2400,
+        },
+        { content: "Buyer", width: 2400, verticalAlign: "bottom" },
+      ],
+    },
+  ],
+} as const satisfies BodyItem;
+
+describe("a table the comparison adds", () => {
+  test("carries its grid, table, row and cell properties into the redline", async () => {
+    const base = await buildBodySequenceDocx([INTRO, OUTRO]);
+    const target = await buildBodySequenceDocx([INTRO, RICH_TABLE, OUTRO]);
+
+    const {
+      xml,
+      accepted,
+      target: expected,
+      rejected,
+      base: expectedBase,
+    } = await roundTrip(base, target);
+
+    // The grid, not a column count: an inserted table used to arrive with
+    // `w:gridCol` elements carrying no width at all.
+    expect(xml).toContain('<w:gridCol w:w="3200"/>');
+    expect(xml).toContain('<w:tblStyle w:val="TableGrid"/>');
+    expect(xml).toContain('<w:tblW w:w="8000" w:type="dxa"/>');
+    // `w:tblLook` round-trips through the flag attributes, not the packed value.
+    expect(xml).toContain('<w:tblLook w:firstRow="1"');
+    expect(xml).toContain("<w:tblHeader/>");
+    expect(xml).toContain('<w:gridSpan w:val="2"/>');
+    expect(xml).toContain('<w:vMerge w:val="restart"/>');
+    expect(xml).toContain('w:fill="D9D9D9"');
+    expect(xml).toContain('<w:vAlign w:val="center"/>');
+    expect(xml).toContain('<w:tcW w:w="3200" w:type="dxa"/>');
+    // Every row of an inserted table is an insertion; there is no whole-table
+    // insertion element in the format.
+    expect(xml).toContain("<w:ins ");
+
+    expect(accepted).toEqual(expected);
+    expect(rejected).toEqual(expectedBase);
+  });
+
+  test("keeps a nested table nested instead of flattening it", async () => {
+    const base = await buildBodySequenceDocx([INTRO, OUTRO]);
+    const target = await buildBodySequenceDocx([INTRO, RICH_TABLE, OUTRO]);
+
+    const { accepted, target: expected } = await roundTrip(base, target);
+
+    // Two tables: the outer one and the one nested in a cell.
+    expect(expected).toHaveLength(2);
+    expect(accepted).toEqual(expected);
+  });
+});
+
+describe("a table the comparison removes", () => {
+  test("keeps its geometry under the deletion marks, so a reject restores it", async () => {
+    const base = await buildBodySequenceDocx([INTRO, RICH_TABLE, OUTRO]);
+    const target = await buildBodySequenceDocx([INTRO, OUTRO]);
+
+    const { xml, rejected, base: expectedBase } = await roundTrip(base, target);
+
+    // A removed table keeps every row, cell and property it had, under
+    // deletion marks: the row carries `w:trPr/w:del` and every run in it
+    // carries `w:del`, so a consumer that reads only one of the two still
+    // resolves the deletion.
+    expect(xml).toContain("<w:del ");
+    expect(xml).toContain("<w:delText");
+    expect(xml).toContain('<w:gridCol w:w="3200"/>');
+    expect(xml).toContain('<w:gridSpan w:val="2"/>');
+    expect(xml).toContain('<w:vMerge w:val="restart"/>');
+    expect(xml).toContain('<w:tblLook w:firstRow="1"');
+
+    expect(rejected).toEqual(expectedBase);
+  });
+});
+
+const TWO_ROW_TABLE = {
+  kind: "table",
+  columnWidths: [2400, 2400],
+  properties: { width: { value: 4800, type: "dxa" }, borderSize: 4 },
+  rows: [
+    {
+      header: true,
+      cells: [
+        { content: "Clause", width: 2400, shadingFill: "D9D9D9" },
+        { content: "Owner", width: 2400, shadingFill: "D9D9D9" },
+      ],
+    },
+    {
+      cells: [
+        { content: "Delivery", width: 2400 },
+        { content: "Supplier", width: 2400 },
+      ],
+    },
+  ],
+} as const satisfies BodyItem;
+
+const withRow = (row: TableRow): BodyItem => ({
+  ...TWO_ROW_TABLE,
+  rows: [TWO_ROW_TABLE.rows[0], row, TWO_ROW_TABLE.rows[1]],
+});
+
+const INSERTED_ROW = {
+  height: 620,
+  cells: [
+    { content: "Payment", width: 2400, shadingFill: "FFF2CC", verticalAlign: "bottom" },
+    { content: "Buyer", width: 2400, margin: 60 },
+  ],
+} as const satisfies TableRow;
+
+describe("a row the comparison adds or removes mid-table", () => {
+  test("an inserted row carries its own row and cell properties", async () => {
+    const base = await buildBodySequenceDocx([INTRO, TWO_ROW_TABLE, OUTRO]);
+    const target = await buildBodySequenceDocx([INTRO, withRow(INSERTED_ROW), OUTRO]);
+
+    const {
+      xml,
+      accepted,
+      target: expected,
+      rejected,
+      base: expectedBase,
+    } = await roundTrip(base, target);
+
+    expect(xml).toContain('<w:trHeight w:val="620"');
+    expect(xml).toContain('w:fill="FFF2CC"');
+    expect(xml).toContain('<w:vAlign w:val="bottom"/>');
+    expect(accepted).toEqual(expected);
+    expect(rejected).toEqual(expectedBase);
+  });
+
+  test("a deleted row keeps its properties, so a reject restores it", async () => {
+    const base = await buildBodySequenceDocx([INTRO, withRow(INSERTED_ROW), OUTRO]);
+    const target = await buildBodySequenceDocx([INTRO, TWO_ROW_TABLE, OUTRO]);
+
+    const {
+      accepted,
+      target: expected,
+      rejected,
+      base: expectedBase,
+    } = await roundTrip(base, target);
+
+    expect(rejected).toEqual(expectedBase);
+    expect(accepted).toEqual(expected);
+  });
+});
+
+describe("a table whose properties changed and whose words did not", () => {
+  test("a changed cell property is written as w:tcPrChange", async () => {
+    const shaded = {
+      ...TWO_ROW_TABLE,
+      rows: [
+        TWO_ROW_TABLE.rows[0],
+        {
+          cells: [
+            { content: "Delivery", width: 2400, shadingFill: "C6E0B4" },
+            { content: "Supplier", width: 2400 },
+          ],
+        },
+      ],
+    } as const satisfies BodyItem;
+    const base = await buildBodySequenceDocx([INTRO, TWO_ROW_TABLE, OUTRO]);
+    const target = await buildBodySequenceDocx([INTRO, shaded, OUTRO]);
+
+    const {
+      xml,
+      accepted,
+      target: expected,
+      rejected,
+      base: expectedBase,
+    } = await roundTrip(base, target);
+
+    expect(xml).toContain("<w:tcPrChange ");
+    expect(xml).toContain('w:fill="C6E0B4"');
+    expect(accepted).toEqual(expected);
+    expect(rejected).toEqual(expectedBase);
+  });
+
+  test("a changed row property is written as w:trPrChange", async () => {
+    const taller = {
+      ...TWO_ROW_TABLE,
+      rows: [{ ...TWO_ROW_TABLE.rows[0], height: 900 }, TWO_ROW_TABLE.rows[1]],
+    } as const satisfies BodyItem;
+    const base = await buildBodySequenceDocx([INTRO, TWO_ROW_TABLE, OUTRO]);
+    const target = await buildBodySequenceDocx([INTRO, taller, OUTRO]);
+
+    const {
+      xml,
+      accepted,
+      target: expected,
+      rejected,
+      base: expectedBase,
+    } = await roundTrip(base, target);
+
+    expect(xml).toContain("<w:trPrChange ");
+    expect(accepted).toEqual(expected);
+    expect(rejected).toEqual(expectedBase);
+  });
+
+  test("a changed table property is written as w:tblPrChange", async () => {
+    const wider = {
+      ...TWO_ROW_TABLE,
+      properties: { width: { value: 7200, type: "dxa" }, borderSize: 4, justification: "center" },
+    } as const satisfies BodyItem;
+    const base = await buildBodySequenceDocx([INTRO, TWO_ROW_TABLE, OUTRO]);
+    const target = await buildBodySequenceDocx([INTRO, wider, OUTRO]);
+
+    const {
+      xml,
+      accepted,
+      target: expected,
+      rejected,
+      base: expectedBase,
+    } = await roundTrip(base, target);
+
+    expect(xml).toContain("<w:tblPrChange ");
+    expect(accepted).toEqual(expected);
+    expect(rejected).toEqual(expectedBase);
+  });
+});
+
+const COLUMN_WIDTHS = [2400, 2000, 1600] as const;
+
+type GeneratedCell = {
+  content: string;
+  width: number;
+  gridSpan?: number;
+  shadingFill?: string;
+};
+
+const buildCell = (column: number, gridSpan: number, content: string, shaded: boolean) => {
+  const cell: GeneratedCell = {
+    content,
+    width: COLUMN_WIDTHS.slice(column, column + gridSpan).reduce((sum, width) => sum + width, 0),
+  };
+  if (gridSpan > 1) {
+    cell.gridSpan = gridSpan;
+  }
+  if (shaded) {
+    cell.shadingFill = "D9D9D9";
+  }
+  return cell;
+};
+
+const cellArbitrary = (column: number, spanAllowance: number): fc.Arbitrary<GeneratedCell> =>
+  fc
+    .record({
+      content: fc.constantFrom("Alpha", "Beta", "Gamma", "Delta"),
+      gridSpan: fc.integer({ min: 1, max: Math.max(1, spanAllowance) }),
+      shaded: fc.boolean(),
+    })
+    .map(({ content, gridSpan, shaded }) => buildCell(column, gridSpan, content, shaded));
+
+const buildRow = (cells: readonly GeneratedCell[], header: boolean, height: number | null) => {
+  const row: { cells: readonly GeneratedCell[]; header?: boolean; height?: number } = { cells };
+  if (header) {
+    row.header = header;
+  }
+  if (height !== null) {
+    row.height = height;
+  }
+  return row;
+};
+
+/** A row that spans the grid exactly, so the table stays well formed. */
+const rowArbitrary = (): fc.Arbitrary<TableRow> =>
+  fc
+    .record({ header: fc.boolean(), height: fc.option(fc.integer({ min: 240, max: 900 })) })
+    .chain(({ header, height }) =>
+      cellArbitrary(0, COLUMN_WIDTHS.length).chain((first) => {
+        const used = first.gridSpan ?? 1;
+        const rest =
+          used >= COLUMN_WIDTHS.length
+            ? fc.constant<GeneratedCell[]>([])
+            : fc.tuple(
+                ...COLUMN_WIDTHS.slice(used).map((_width, index) => cellArbitrary(used + index, 1)),
+              );
+        return rest.map((cells) => buildRow([first, ...cells], header, height));
+      }),
+    );
+
+const tableArbitrary = (): fc.Arbitrary<BodyItem> =>
+  fc.array(rowArbitrary(), { minLength: 1, maxLength: 4 }).map((rows) => ({
+    kind: "table",
+    columnWidths: [...COLUMN_WIDTHS],
+    properties: { width: { value: 6000, type: "dxa" }, borderSize: 4 },
+    rows,
+  }));
+
+describe("table geometry round trip", () => {
+  test(
+    "accepting reproduces the target's table model and rejecting reproduces the base's",
+    async () => {
+      await fc.assert(
+        fc.asyncProperty(tableArbitrary(), tableArbitrary(), async (baseTable, targetTable) => {
+          const base = await buildBodySequenceDocx([INTRO, baseTable, OUTRO]);
+          const target = await buildBodySequenceDocx([INTRO, targetTable, OUTRO]);
+          const result = await compareDocx(base, target, {
+            ...OPTIONS,
+            onUnverified: "emit",
+          });
+          if (result.isErr()) {
+            throw result.error;
+          }
+          // An unproven redline is a separate finding the rest of the suite
+          // owns; what is asserted here is that whatever it did produce
+          // round-trips at the table model.
+          if (result.value.verification.status === "unverified") {
+            return;
+          }
+          const compared = await FolioDocxReviewer.fromBuffer(result.value.buffer);
+          expect(projectTableGeometry(compared.storyTables({ view: "final" }))).toEqual(
+            projectTableGeometry((await FolioDocxReviewer.fromBuffer(target)).storyTables()),
+          );
+          expect(projectTableGeometry(compared.storyTables({ view: "original" }))).toEqual(
+            projectTableGeometry((await FolioDocxReviewer.fromBuffer(base)).storyTables()),
+          );
+        }),
+        propertyConfig(),
+      );
+    },
+    propertyTestTimeout(),
+  );
+});

--- a/packages/core/src/compare/verification.ts
+++ b/packages/core/src/compare/verification.ts
@@ -43,6 +43,12 @@ export const COMPARE_VERIFICATION_CAUSES = Object.freeze([
   "invisible-structure",
   "block-count",
   "container",
+  /**
+   * Every block is where it should be and a table's own properties are not:
+   * `w:tblPr`, the `w:tblGrid` widths, `w:trPr`, `w:tcPr`. No block carries
+   * them, so a projection of blocks alone cannot see them go.
+   */
+  "table-geometry",
   "style",
   "list-level",
   "inline-formatting",
@@ -220,6 +226,28 @@ type ClassifyOptions = {
   actual: readonly string[];
   /** What the invariant says it should leave. */
   expected: readonly string[];
+};
+
+/**
+ * The failure two table-geometry projections describe, or `null` when they
+ * agree. One line per table, so the detail names which table diverged and
+ * whether the count itself did — never a property value, which could carry a
+ * style name either document chose.
+ */
+export const classifyGeometryMismatch = ({
+  invariant,
+  story,
+  actual,
+  expected,
+}: ClassifyOptions): CompareVerificationFailure | null => {
+  if (sameProjection(actual, expected)) {
+    return null;
+  }
+  const detail =
+    actual.length === expected.length
+      ? `table ${String(actual.findIndex((entry, index) => entry !== expected[index]))} of ${String(actual.length)} carries different properties`
+      : `${String(actual.length)} tables against ${String(expected.length)}`;
+  return { invariant, cause: "table-geometry", story, detail };
 };
 
 /**

--- a/packages/core/src/document-operations.ts
+++ b/packages/core/src/document-operations.ts
@@ -1,5 +1,6 @@
 import { TaggedError } from "better-result";
 
+import type { FolioTableTemplates } from "./ai-edits/table-template";
 import {
   applyFolioAIEditOperations,
   type FolioAIEditApplyOutcome,
@@ -1350,6 +1351,14 @@ export type ApplyFolioDocumentOperationsOptions = {
   revisionStamp?: FolioRevisionStamp;
   /** Token size a replacement's redline is cut at. Word-level by default. */
   wordDiff?: FolioWordDiffOptions;
+  /**
+   * Tables and rows an `insertTable` / `insertTableRow` in the batch places
+   * verbatim, by operation id. Outside the serialized batch because a table
+   * node is not JSON: the contract still describes a table by its cell texts,
+   * and an in-process caller that already holds the table — a comparison
+   * copying the target document's — hands the whole thing over instead.
+   */
+  tableTemplates?: FolioTableTemplates;
 };
 
 type ApplyParsedDocumentOperationBatchOptions = {
@@ -1368,6 +1377,7 @@ export const applyFolioDocumentOperations = ({
   createUndoHandle,
   revisionStamp,
   wordDiff,
+  tableTemplates,
 }: ApplyFolioDocumentOperationsOptions): FolioDocumentOperationResult => {
   const parsedBatch = parseFolioDocumentOperationBatch(batch);
   const apply = ({
@@ -1385,6 +1395,7 @@ export const applyFolioDocumentOperations = ({
       ...(targetCreateCommentId !== undefined && { createCommentId: targetCreateCommentId }),
       ...(revisionStamp !== undefined && { revisionStamp }),
       ...(wordDiff !== undefined && { wordDiff }),
+      ...(tableTemplates !== undefined && { tableTemplates }),
     });
   };
 

--- a/packages/core/src/docx/serializer/tableSerializer.ts
+++ b/packages/core/src/docx/serializer/tableSerializer.ts
@@ -366,78 +366,70 @@ export function serializeTableFormatting(
 ): string {
   const parts: string[] = [];
 
+  // CT_TblPrBase is a SEQUENCE (ECMA-376 §17.4.60), so the children are
+  // written in the order it declares: tblStyle, tblpPr, tblOverlap,
+  // bidiVisual, tblW, jc, tblCellSpacing, tblInd, tblBorders, shd, tblLayout,
+  // tblCellMar, tblLook. A consumer validating the part refuses one written in
+  // any other order.
   if (formatting) {
-    // Table style (must be first)
     if (formatting.styleId) {
       parts.push(`<w:tblStyle w:val="${escapeXml(formatting.styleId)}"/>`);
     }
 
-    // Floating table properties
     const floatingXml = serializeFloatingTableProperties(formatting.floating);
     if (floatingXml) {
       parts.push(floatingXml);
     }
 
-    // Bidirectional
+    if (formatting.overlap) {
+      parts.push(`<w:tblOverlap w:val="${formatting.overlap}"/>`);
+    }
+
     if (formatting.bidi !== undefined) {
       parts.push(formatting.bidi ? "<w:bidiVisual/>" : '<w:bidiVisual w:val="0"/>');
     }
 
-    // Table width
     const widthXml = serializeMeasurement(formatting.width, "tblW");
     if (widthXml) {
       parts.push(widthXml);
     }
 
-    // Table justification
     if (formatting.justification) {
       parts.push(`<w:jc w:val="${formatting.justification}"/>`);
     }
 
-    // Cell spacing
     const cellSpacingXml = serializeMeasurement(formatting.cellSpacing, "tblCellSpacing");
     if (cellSpacingXml) {
       parts.push(cellSpacingXml);
     }
 
-    // Table indent
     const indentXml = serializeMeasurement(formatting.indent, "tblInd");
     if (indentXml) {
       parts.push(indentXml);
     }
 
-    // Table borders
     const bordersXml = serializeTableBorders(formatting.borders, "tblBorders");
     if (bordersXml) {
       parts.push(bordersXml);
     }
 
-    // Default cell margins
-    const marginsXml = serializeCellMargins(formatting.cellMargins, "tblCellMar");
-    if (marginsXml) {
-      parts.push(marginsXml);
-    }
-
-    // Table layout
-    if (formatting.layout) {
-      parts.push(`<w:tblLayout w:type="${formatting.layout}"/>`);
-    }
-
-    // Shading
     const shadingXml = serializeShading(formatting.shading);
     if (shadingXml) {
       parts.push(shadingXml);
     }
 
-    // Table look
+    if (formatting.layout) {
+      parts.push(`<w:tblLayout w:type="${formatting.layout}"/>`);
+    }
+
+    const marginsXml = serializeCellMargins(formatting.cellMargins, "tblCellMar");
+    if (marginsXml) {
+      parts.push(marginsXml);
+    }
+
     const lookXml = serializeTableLook(formatting.look);
     if (lookXml) {
       parts.push(lookXml);
-    }
-
-    // Overlap
-    if (formatting.overlap) {
-      parts.push(`<w:tblOverlap w:val="${formatting.overlap}"/>`);
     }
   }
 

--- a/packages/core/src/docx/tableParser.test.ts
+++ b/packages/core/src/docx/tableParser.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   serializeTableCellFormatting,
+  serializeTableFormatting,
   serializeTableRowFormatting,
 } from "./serializer/tableSerializer";
 import { parseBlockContent } from "./blockContentParser";
@@ -123,6 +124,45 @@ describe("table cell merge revisions", () => {
     expect(serializeTableCellFormatting(undefined, undefined, change)).toContain(
       '<w:cellMerge w:id="18" w:author="Reviewer"/>',
     );
+  });
+});
+
+describe("table properties", () => {
+  test("writes w:tblPr children in the order CT_TblPrBase declares", () => {
+    const xml = serializeTableFormatting({
+      styleId: "TableGrid",
+      overlap: "never",
+      bidi: false,
+      width: { value: 8000, type: "dxa" },
+      justification: "center",
+      indent: { value: 120, type: "dxa" },
+      borders: { top: { style: "single", size: 4, space: 0, color: { rgb: "000000" } } },
+      shading: { fill: { rgb: "D9D9D9" }, pattern: "clear" },
+      layout: "fixed",
+      cellMargins: { top: { value: 80, type: "dxa" } },
+      look: { firstRow: true },
+    });
+
+    // CT_TblPrBase is a sequence, so a consumer validating the part refuses
+    // any other order. Pinned because the elements are written from separate
+    // branches that read the same object.
+    const order = [...xml.matchAll(/<w:([A-Za-z]+)/gu)].map(([, name]) => name);
+    expect(order).toEqual([
+      "tblPr",
+      "tblStyle",
+      "tblOverlap",
+      "bidiVisual",
+      "tblW",
+      "jc",
+      "tblInd",
+      "tblBorders",
+      "top",
+      "shd",
+      "tblLayout",
+      "tblCellMar",
+      "top",
+      "tblLook",
+    ]);
   });
 });
 

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -3201,7 +3201,7 @@ function buildCellMarginsFromAttrs(m: {
 /**
  * Convert ProseMirror table attrs to TableFormatting
  */
-function tableAttrsToFormatting(attrs: TableAttrs): TableFormatting | undefined {
+export function tableAttrsToFormatting(attrs: TableAttrs): TableFormatting | undefined {
   // If we have the original formatting from the DOCX, use it as a base
   // for lossless round-trip. This preserves properties like cellSpacing,
   // indent, layout, bidi, overlap, shading that aren't tracked as PM attrs.
@@ -3424,7 +3424,7 @@ function createVerticalMergeContinuationCell(colspan: number): TableCell {
 /**
  * Convert ProseMirror table row attrs to TableRowFormatting
  */
-function tableRowAttrsToFormatting(attrs: TableRowAttrs): TableRowFormatting | undefined {
+export function tableRowAttrsToFormatting(attrs: TableRowAttrs): TableRowFormatting | undefined {
   // If we have the original formatting from the DOCX, use it as a base
   // for lossless round-trip. This preserves properties like cantSplit,
   // justification, hidden, conditionalFormat that aren't tracked as PM attrs.
@@ -3567,7 +3567,7 @@ type CellShading = NonNullable<TableCellFormatting["shading"]>;
 const cellShadingFromAttrs = (attrs: TableCellAttrs): CellShading =>
   attrs.backgroundColor ? { fill: { rgb: attrs.backgroundColor } } : { pattern: "nil" };
 
-function tableCellAttrsToFormatting(attrs: TableCellAttrs): TableCellFormatting | undefined {
+export function tableCellAttrsToFormatting(attrs: TableCellAttrs): TableCellFormatting | undefined {
   const backgroundChanged = attrs.backgroundColor !== attrs._resolvedBackgroundColor;
 
   // If we have the original formatting from the DOCX, use it as a base


### PR DESCRIPTION
A comparison derived every table it added from the cell texts of the
`insertTable` / `insertTableRow` operation it emitted. The result carried an
empty `w:tblPr`, a `w:tblGrid` whose `w:gridCol` elements had no width, no
`w:trPr`, no `w:tcPr` at all, and cell paragraphs stripped of their own
properties. Accepting the redline produced a table that was not the one it had
been compared against — different widths, no spans, no vertical merges, no
shading, borders, margins or alignment — and a table nested in a cell was
flattened into its parent.

## What changed

`insertTable` and `insertTableRow` keep their payloads: cell texts are the
right shape for a caller writing a table from nothing. A caller copying one it
already holds may now hand the operation the node to place, beside the batch
rather than inside it, because a document node is not JSON and the serialized
contract still describes a table by its cell texts. `compareDocx` resolves the
target's table for each such operation it derives and passes it through.

The copy keeps everything by default. What it drops is what only the package it
came from can resolve: relationship ids (a drawing, a hyperlink), note and
comment ids, bookmarks, paragraph identities, and that document's own tracked
changes. `w:tblPr` with its style, width, indent, justification, borders, cell
margins, layout and look; `w:tblGrid` with the target's column widths; each
row's `w:trPr`; each cell's `w:tcPr` with `w:tcW`, `w:gridSpan`, `w:vMerge`,
`w:shd`, `w:tcBorders`, `w:tcMar` and `w:vAlign`; cell paragraphs with their
properties and runs; and nested tables, recursively — all travel.

Alongside that:

- **A removed table marks its runs.** A deleted row already carried both
  `w:trPr/w:del` and `w:del` on every run in it; a deleted table only marked
  the rows, so a consumer that reads run-level revisions kept the text on
  accept. It now follows the same rule.
- **A whole inserted table marks its runs too**, for the mirror reason: with
  the row marker standing alone, rejecting the insertion left the text behind.
- **A paired table, row or cell whose properties changed** is rewritten to the
  target's and records the previous set as `w:tblPrChange` / `w:trPrChange` /
  `w:tcPrChange`. That change element stores the complete previous property
  set, so the record is built from what the node would serialize rather than
  from what its parser stored — a cell inherits borders and margins from the
  table and from a table style, and a record omitting them would reject to a
  third document. Where the live values cannot be rebuilt from the record, the
  difference is left alone rather than written as a revision that cannot be
  undone.
- **The round-trip self-check compares the table model**, not only the blocks.
  A second projection reads each table's, row's and cell's properties, under a
  new `table-geometry` verification cause, so a redline that reproduces every
  word and none of the geometry fails instead of passing.
- **`w:tblPr` children are written in the order `CT_TblPrBase` declares.**
  `w:tblLayout` was written after `w:tblCellMar` and `w:shd` after both, which
  a validating consumer refuses. Reachable now that a table folio writes from
  the model carries all three; pinned by a test over the emitted child order.

Table numbering also moves to one place: `folioStoryTables` is what numbers a
story's tables, and the block snapshot, the copy and the self-check all read
it, so no second walk can number the same document differently.

## Not covered

- `w:tblGridChange` is not in the editable model, so a paired table whose
  columns kept their text and changed their widths keeps the base's grid. A
  table the comparison ADDS carries the target's, because there is no previous
  grid to record.
- `colspan` / `rowspan` do not move on a paired cell: they shape the table's
  map, and changing one without restructuring the rows around it leaves the
  map inconsistent with its own grid. A span that changed is a row or column
  edit.
- A row inserted from a template is placed unmerged when the row it was copied
  from merged downwards, because the rows it reached into are not the receiving
  table's.

## Tests

`packages/core/src/compare/tableGeometry.test.ts`: a table added with spans,
vertical merges, shading, borders, explicit widths, a repeating header row and
a nested table; a table removed; a row inserted and removed mid-table with its
own properties; a cell, row and table property changed on its own. Each asserts
the serialized XML carries the elements AND that the parsed table model
round-trips — accept reproduces the target's, reject reproduces the base's —
read back out of the written package rather than from the in-memory document. A
fast-check property over generated tables with random spans, widths, shading,
header rows and heights holds the same round trip over the input class.
