### PR TITLE
fix(core): a saved package carries a schema-valid AppVersion

### DIFF
--- a/.changeset/quiet-pugs-repeat.md
+++ b/.changeset/quiet-pugs-repeat.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+State an application version of the form the schema fixes on every save. The extended-properties `AppVersion` in `docProps/app.xml` is `XX.YYYY`, and a value with two dots is refused by consumers outright; folio copied the part through verbatim when saving a document it had not created, so a package could carry such a value in and back out. Both save exits — the full repack and the selective save — now rewrite a value the form rejects to one derived from it alone (`1.0.0` becomes `1.0000`), leave the rest of the part byte-identical, and add extended properties to no package that lacked them.

--- a/packages/core/src/compare/__fixtures__/body-sequence.ts
+++ b/packages/core/src/compare/__fixtures__/body-sequence.ts
@@ -16,6 +16,10 @@ const WORDPROCESSING = "application/vnd.openxmlformats-officedocument.wordproces
 const MARKUP_COMPATIBILITY = "http://schemas.openxmlformats.org/markup-compatibility/2006";
 const PACKAGE_RELATIONSHIPS = "http://schemas.openxmlformats.org/package/2006";
 const CORE_PROPERTIES_TYPE = "application/vnd.openxmlformats-package.core-properties+xml";
+const EXTENDED_PROPERTIES =
+  "http://schemas.openxmlformats.org/officeDocument/2006/extended-properties";
+const EXTENDED_PROPERTIES_TYPE =
+  "application/vnd.openxmlformats-officedocument.extended-properties+xml";
 const WORDML_2010 = "http://schemas.microsoft.com/office/word/2010/wordml";
 
 /** Pinned so two builds of the fixture produce identical bytes. */
@@ -440,12 +444,14 @@ export const buildBodySequenceDocx = async (
         ? `<Override PartName="/word/header1.xml" ContentType="${WORDPROCESSING}.header+xml"/>`
         : "") +
       `<Override PartName="/docProps/core.xml" ContentType="${CORE_PROPERTIES_TYPE}"/>` +
+      `<Override PartName="/docProps/app.xml" ContentType="${EXTENDED_PROPERTIES_TYPE}"/>` +
       `</Types>`,
     "_rels/.rels":
       `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
       `<Relationships xmlns="${RELATIONSHIPS}">` +
       `<Relationship Id="rId1" Type="${OFFICE_RELATIONSHIPS}/officeDocument" Target="word/document.xml"/>` +
       `<Relationship Id="rId2" Type="${PACKAGE_RELATIONSHIPS}/metadata/core-properties" Target="docProps/core.xml"/>` +
+      `<Relationship Id="rId3" Type="${OFFICE_RELATIONSHIPS}/extended-properties" Target="docProps/app.xml"/>` +
       `</Relationships>`,
     // A real package dates itself. Without this part nothing would prove that
     // the comparison stamps `dcterms:modified` from its own timestamp rather
@@ -458,6 +464,14 @@ export const buildBodySequenceDocx = async (
       `<dcterms:created xsi:type="dcterms:W3CDTF">2000-01-01T00:00:00Z</dcterms:created>` +
       `<dcterms:modified xsi:type="dcterms:W3CDTF">2000-01-01T00:00:00Z</dcterms:modified>` +
       `</cp:coreProperties>`,
+    // A package also states which application wrote it, in a version whose
+    // form the schema fixes. This one states a version the form rejects, so
+    // that a comparison carrying it through would be visible.
+    "docProps/app.xml":
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+      `<Properties xmlns="${EXTENDED_PROPERTIES}">` +
+      `<AppVersion>1.0.0</AppVersion>` +
+      `</Properties>`,
     "word/_rels/document.xml.rels":
       `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
       `<Relationships xmlns="${RELATIONSHIPS}">` +

--- a/packages/core/src/compare/package-shape.test.ts
+++ b/packages/core/src/compare/package-shape.test.ts
@@ -27,11 +27,11 @@ type ComparedDocumentOptions = {
   onUnverified?: "emit";
 };
 
-const comparedDocumentXml = async (
+const comparedPackage = async (
   base: readonly BodyItem[],
   target: readonly BodyItem[],
   { onUnverified }: ComparedDocumentOptions = {},
-): Promise<string> => {
+): Promise<JSZip> => {
   const result = await compareDocx(
     await buildBodySequenceDocx(base),
     await buildBodySequenceDocx(target),
@@ -40,7 +40,15 @@ const comparedDocumentXml = async (
   if (result.isErr()) {
     throw result.error;
   }
-  const zip = await JSZip.loadAsync(result.value.buffer);
+  return await JSZip.loadAsync(result.value.buffer);
+};
+
+const comparedDocumentXml = async (
+  base: readonly BodyItem[],
+  target: readonly BodyItem[],
+  options: ComparedDocumentOptions = {},
+): Promise<string> => {
+  const zip = await comparedPackage(base, target, options);
   return (await zip.file("word/document.xml")?.async("text")) ?? "";
 };
 
@@ -330,5 +338,23 @@ describe("paragraph ids", () => {
       [{ kind: "paragraph", text: "alpha BETA", paraId: OUT_OF_RANGE[1] }],
     ];
     expect(await comparedDocumentXml(...pair)).toBe(await comparedDocumentXml(...pair));
+  });
+});
+
+describe("extended properties", () => {
+  /** The extended-properties `AppVersion` is `XX.YYYY`. */
+  const SCHEMA_FORM = /^\d{1,2}\.\d{4}$/u;
+
+  test("states an application version of the form the schema fixes", async () => {
+    // Both inputs state a version the form rejects, and the comparison copies
+    // the part through, so an untouched package would hand a consumer a
+    // version it refuses to open the document over.
+    const zip = await comparedPackage(
+      [{ kind: "paragraph", text: "alpha beta" }],
+      [{ kind: "paragraph", text: "alpha BETA" }],
+    );
+
+    const xml = (await zip.file("docProps/app.xml")?.async("text")) ?? "";
+    expect(/<AppVersion>([^<]*)<\/AppVersion>/u.exec(xml)?.[1] ?? "").toMatch(SCHEMA_FORM);
   });
 });

--- a/packages/core/src/docx/appVersionNormalization.test.ts
+++ b/packages/core/src/docx/appVersionNormalization.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+import JSZip from "jszip";
+
+import { propertyConfig } from "../../../../test/property-testing";
+
+import {
+  appVersionInSchemaForm,
+  normalizeAppVersionInExtendedProperties,
+} from "./appVersionNormalization";
+import { parseDocx } from "./parser";
+import { createEmptyDocx, repackDocx, updateMultipleFiles } from "./rezip";
+
+const SCHEMA_FORM = /^\d{1,2}\.\d{4}$/u;
+
+const EXTENDED_PROPERTIES_PATH = "docProps/app.xml";
+
+const extendedProperties = (appVersionElement: string): string =>
+  `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n` +
+  `<Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties">` +
+  `<Pages>1</Pages><Words>2</Words><Characters>11</Characters>` +
+  appVersionElement +
+  `<Lines>1</Lines><Paragraphs>1</Paragraphs>` +
+  `</Properties>`;
+
+describe("appVersionInSchemaForm", () => {
+  test.each([
+    ["1.0.0", "1.0000"],
+    ["16.0000", "16.0000"],
+    ["1.0", "1.0000"],
+    ["abc", "1.0000"],
+    ["", "1.0000"],
+    ["12.1.3.4", "12.0000"],
+    ["1234.5", "1.0000"],
+  ])("%p becomes %p", (value, expected) => {
+    expect(appVersionInSchemaForm(value)).toBe(expected);
+  });
+});
+
+describe("normalizeAppVersionInExtendedProperties", () => {
+  test("rewrites a three-part version and leaves the rest of the part alone", () => {
+    const xml = extendedProperties("<AppVersion>1.0.0</AppVersion>");
+
+    expect(normalizeAppVersionInExtendedProperties(xml)).toBe(
+      extendedProperties("<AppVersion>1.0000</AppVersion>"),
+    );
+  });
+
+  test("returns a part whose version already fits unchanged", () => {
+    const xml = extendedProperties("<AppVersion>16.0000</AppVersion>");
+
+    expect(normalizeAppVersionInExtendedProperties(xml)).toBe(xml);
+  });
+
+  test("returns a part that states no version unchanged", () => {
+    const xml = extendedProperties("");
+
+    expect(normalizeAppVersionInExtendedProperties(xml)).toBe(xml);
+  });
+
+  test("writes a value of the schema form for any version a part can state", () => {
+    fc.assert(
+      fc.property(fc.string(), (value) => {
+        const normalized = normalizeAppVersionInExtendedProperties(
+          extendedProperties(`<AppVersion>${value.replaceAll(/[<&]/gu, "")}</AppVersion>`),
+        );
+        const written = /<AppVersion>([^<]*)<\/AppVersion>/u.exec(normalized)?.[1] ?? "";
+
+        expect(written).toMatch(SCHEMA_FORM);
+        expect(normalizeAppVersionInExtendedProperties(normalized)).toBe(normalized);
+      }),
+      propertyConfig({ numRuns: 500 }),
+    );
+  });
+});
+
+const appVersionOf = async (buffer: ArrayBuffer): Promise<string> => {
+  const zip = await JSZip.loadAsync(buffer);
+  const xml = (await zip.file(EXTENDED_PROPERTIES_PATH)?.async("text")) ?? "";
+  return /<AppVersion>([^<]*)<\/AppVersion>/u.exec(xml)?.[1] ?? "";
+};
+
+const extendedPropertiesOf = async (buffer: ArrayBuffer): Promise<string> => {
+  const zip = await JSZip.loadAsync(buffer);
+  return (await zip.file(EXTENDED_PROPERTIES_PATH)?.async("text")) ?? "";
+};
+
+/** A package that states a version the schema form rejects. */
+const packageStatingAppVersion = async (value: string): Promise<ArrayBuffer> => {
+  const zip = await JSZip.loadAsync(await createEmptyDocx());
+  zip.file(EXTENDED_PROPERTIES_PATH, extendedProperties(`<AppVersion>${value}</AppVersion>`));
+  return await zip.generateAsync({ type: "arraybuffer" });
+};
+
+describe("a saved package states a version of the schema form", () => {
+  test("the full repack rewrites it and changes nothing else in the part", async () => {
+    const source = await packageStatingAppVersion("1.0.0");
+
+    const saved = await repackDocx(await parseDocx(source));
+
+    expect(await appVersionOf(saved)).toBe("1.0000");
+    expect(await extendedPropertiesOf(saved)).toBe(
+      (await extendedPropertiesOf(source)).replace("1.0.0", "1.0000"),
+    );
+  });
+
+  test("the selective save rewrites it and changes nothing else in the part", async () => {
+    const source = await packageStatingAppVersion("1.0.0");
+
+    const saved = await updateMultipleFiles(source, new Map());
+
+    expect(await appVersionOf(saved)).toBe("1.0000");
+    expect(await extendedPropertiesOf(saved)).toBe(
+      (await extendedPropertiesOf(source)).replace("1.0.0", "1.0000"),
+    );
+  });
+
+  test("a package that already fits keeps the version it stated", async () => {
+    const source = await packageStatingAppVersion("16.0000");
+
+    expect(await appVersionOf(await repackDocx(await parseDocx(source)))).toBe("16.0000");
+    expect(await appVersionOf(await updateMultipleFiles(source, new Map()))).toBe("16.0000");
+  });
+
+  test("a package that carries no extended properties gains none", async () => {
+    const zip = await JSZip.loadAsync(await createEmptyDocx());
+    zip.remove(EXTENDED_PROPERTIES_PATH);
+    const source = await zip.generateAsync({ type: "arraybuffer" });
+
+    const saved = await updateMultipleFiles(source, new Map());
+
+    expect((await JSZip.loadAsync(saved)).file(EXTENDED_PROPERTIES_PATH)).toBeNull();
+  });
+});

--- a/packages/core/src/docx/appVersionNormalization.ts
+++ b/packages/core/src/docx/appVersionNormalization.ts
@@ -1,0 +1,90 @@
+/**
+ * Keep the application version a package states about itself in the form the
+ * schema gives it.
+ *
+ * `AppVersion` in the extended-properties part is `XX.YYYY`: a one- or
+ * two-digit integer, a dot, and four digits. Producers exist that write a
+ * three-part version there instead, and folio copies `docProps/app.xml`
+ * through verbatim when it saves a document it did not create — so a package
+ * can carry a value with two dots in, and a save that copies it out hands a
+ * consumer a package it refuses to open at all.
+ *
+ * {@link appVersionInSchemaForm} is the one mapping, and it is a pure function
+ * of the value alone: it keeps the leading integer where the value opens with
+ * one the form allows, and writes the build digits the form requires. Nothing
+ * else in the part is touched, and a package that carries no extended
+ * properties keeps carrying none — synthesizing metadata a document never
+ * stated is a different decision.
+ */
+
+import { TaggedError } from "better-result";
+
+/** `XX.YYYY`: the only form the extended-properties `AppVersion` may take. */
+const SCHEMA_FORM = /^\d{1,2}\.\d{4}$/u;
+
+/** The leading integer, when the value opens with one the form allows. */
+const LEADING_MAJOR = /^\d{1,2}(?!\d)/u;
+
+/** Major version for a value that does not open with one. */
+const DEFAULT_MAJOR = "1";
+
+/**
+ * The build digits a rewritten value gets. A value the form rejects states no
+ * build this pass could carry over, so every rewrite lands on the same one.
+ */
+const CANONICAL_BUILD = "0000";
+
+/**
+ * A value reached the package that the schema form does not accept.
+ *
+ * The normalization hands every value it writes to one choke point, which
+ * throws this rather than letting the package go out carrying a version a
+ * consumer refuses.
+ */
+export class AppVersionSchemaError extends TaggedError("AppVersionSchemaError")<{
+  message: string;
+  appVersion: string;
+}> {}
+
+/**
+ * `value` when it already fits, and a value derived from it when it does not.
+ *
+ * The derivation reads the value and nothing else — not the package, not the
+ * clock, not folio's own version — so two saves of one document state the same
+ * application version.
+ */
+export const appVersionInSchemaForm = (value: string): string => {
+  if (SCHEMA_FORM.test(value)) {
+    return value;
+  }
+  const major = LEADING_MAJOR.exec(value.trim())?.[0] ?? DEFAULT_MAJOR;
+  const normalized = `${major}.${CANONICAL_BUILD}`;
+  if (!SCHEMA_FORM.test(normalized)) {
+    throw new AppVersionSchemaError({
+      message: `Derived application version ${normalized} is not of the form XX.YYYY`,
+      appVersion: value,
+    });
+  }
+  return normalized;
+};
+
+/**
+ * The element and its content, with the prefix and attributes it was written
+ * with preserved: the replacement rewrites the value between the tags and
+ * leaves the rest of the part byte-identical.
+ */
+const APP_VERSION_ELEMENT =
+  /(<(?:[^\s<>/:]+:)?AppVersion(?:\s[^<>]*)?>)([^<]*)(<\/(?:[^\s<>/:]+:)?AppVersion>)/u;
+
+/**
+ * Rewrite the application version an extended-properties part states.
+ *
+ * Returns the part unchanged when the value already fits and when the part
+ * states no version at all, so a save of a document that never carried a
+ * malformed one is byte-identical.
+ */
+export const normalizeAppVersionInExtendedProperties = (xml: string): string =>
+  xml.replace(APP_VERSION_ELEMENT, (whole, open: string, value: string, close: string) => {
+    const replacement = appVersionInSchemaForm(value);
+    return replacement === value ? whole : `${open}${replacement}${close}`;
+  });

--- a/packages/core/src/docx/rezip.ts
+++ b/packages/core/src/docx/rezip.ts
@@ -97,6 +97,7 @@ import {
   WORDPROCESSINGML_NAMESPACE_URIS,
   type XmlElement,
 } from "./xmlParser";
+import { normalizeAppVersionInExtendedProperties } from "./appVersionNormalization";
 import { normalizeParaIdRangeInXmlParts } from "./paraIdRangeNormalization";
 import { normalizeRevisionIdsInXmlParts } from "./revisionIdNormalization";
 import { assertXmlResourceLimits } from "./xmlResourceLimits";
@@ -804,6 +805,37 @@ const normalizePackageIdsInZip = async (zip: JSZip, compressionLevel: number): P
   }
 };
 
+const EXTENDED_PROPERTIES_PATH = "docProps/app.xml";
+
+/**
+ * Bring the application version the package states about itself into the form
+ * the schema gives it. A package that holds no extended properties keeps
+ * holding none.
+ */
+const normalizeAppVersionInZip = async (zip: JSZip, compressionLevel: number): Promise<void> => {
+  const extendedProperties = zip.file(EXTENDED_PROPERTIES_PATH);
+  if (!extendedProperties) {
+    return;
+  }
+  const xml = await extendedProperties.async("text");
+  const normalized = normalizeAppVersionInExtendedProperties(xml);
+  if (normalized !== xml) {
+    zip.file(EXTENDED_PROPERTIES_PATH, normalized, {
+      compression: "DEFLATE",
+      compressionOptions: { level: compressionLevel },
+    });
+  }
+};
+
+/**
+ * Every pass a save owes the package as a whole, in one function so that the
+ * full repack and the selective save cannot drift into running different ones.
+ */
+const normalizePackageOnSave = async (zip: JSZip, compressionLevel: number): Promise<void> => {
+  await normalizePackageIdsInZip(zip, compressionLevel);
+  await normalizeAppVersionInZip(zip, compressionLevel);
+};
+
 /**
  * The single exit for a repacked package. Reconciliation runs here rather than
  * at each caller so no save path can emit a package whose relationships or
@@ -811,7 +843,7 @@ const normalizePackageIdsInZip = async (zip: JSZip, compressionLevel: number): P
  */
 const generateDocxZip = async (zip: JSZip, compressionLevel: number): Promise<ArrayBuffer> => {
   await reconcilePackageReferences(zip, compressionLevel);
-  await normalizePackageIdsInZip(zip, compressionLevel);
+  await normalizePackageOnSave(zip, compressionLevel);
   return zip.generateAsync({
     type: "arraybuffer",
     compression: "DEFLATE",
@@ -1414,11 +1446,11 @@ export async function updateMultipleFiles(
  * Apply file updates to an already-loaded JSZip instance and generate the output.
  * Use this when the zip is already loaded to avoid a redundant decompression pass.
  *
- * This is the selective save's exit, so it owes the package the same id passes
+ * This is the selective save's exit, so it owes the package the same passes
  * {@link generateDocxZip} runs: a save that rewrites only the changed
  * paragraphs still has to see the parts it left alone, both to know which
- * revision ids are free and because an out-of-range paragraph id can sit in a
- * part it never touched.
+ * revision ids are free and because an out-of-range paragraph id, or a
+ * malformed application version, can sit in a part it never touched.
  */
 export async function applyUpdatesToZip(
   zip: JSZip,
@@ -1434,7 +1466,7 @@ export async function applyUpdatesToZip(
     });
   }
 
-  await normalizePackageIdsInZip(zip, compressionLevel);
+  await normalizePackageOnSave(zip, compressionLevel);
 
   return await zip.generateAsync({
     type: "arraybuffer",


### PR DESCRIPTION
The extended-properties `AppVersion` in `docProps/app.xml` is `XX.YYYY`: a one- or two-digit integer, a dot, four digits. A value with two dots is not of that form and is refused by consumers outright — the document does not open at all.

Saving a document folio did not create copied `docProps/app.xml` through verbatim, so a package that arrived stating such a value handed it straight back out.

## What changed

`appVersionNormalization.ts` holds the one mapping. It is a pure function of the value alone — not of the package, the clock, or folio's own version — so two saves of one document state the same version: a value the form accepts is returned unchanged, and a value it rejects becomes the leading integer the value opens with (when it opens with one the form allows) plus the build digits the form requires. `1.0.0` becomes `1.0000`, `1.0` becomes `1.0000`, a value with no leading integer becomes `1.0000`. Every value the pass writes goes through one choke point that throws a typed `AppVersionSchemaError` rather than letting a package go out carrying a version a consumer refuses.

Both save exits run it — the full repack and the selective save — and they now share one `normalizePackageOnSave` function so neither can acquire a pass the other lacks. Nothing else in the part is touched: the element keeps the prefix and attributes it was written with, and the rest of the part is byte-identical. A package that states no extended properties gains none.

## Tests

- `appVersionNormalization.test.ts`: the mapping over `1.0.0`, `16.0000`, `1.0`, a non-numeric value, an empty value, a four-part value and an over-long major; a part whose version already fits and a part that states none, both returned unchanged; a fast-check property that any version a part can state is written back in the schema form and that a second pass changes nothing; and a round trip through both save exits asserting the written value fits and the rest of the part is byte-identical.
- `compare/package-shape.test.ts`: a compared package states a version of the schema form. The body-sequence fixture now carries a `docProps/app.xml` stating a value the form rejects, so a comparison that copied it through would be visible.
- The fresh-package path still writes `1.0000` (`createDocxStyleSet.test.ts`, unchanged).
