### PR TITLE
feat(core): the id a recorded block answers to now

### DIFF
--- a/.changeset/recorded-block-ids-resolve.md
+++ b/.changeset/recorded-block-ids-resolve.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Export `currentFolioBlockId`: the id a block recorded under an earlier version answers to now. A paragraph id above the 31-bit bound is brought into range on parse, so a block id recorded from such a paragraph before that stopped resolving; the mapping is a pure function of the id, so a host resolves a recorded id without the document.

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -524,6 +524,9 @@ export const createStellaStyleDocumentPreset: () => DocumentPreset;
 export const createStellaStyleSet: () => DocumentStyleSet;
 
 // @public
+export const currentFolioBlockId: (id: string) => string;
+
+// @public
 export const DEFAULT_AI_SUGGESTION_PRESETS: AISuggestionPreset[];
 
 // @public

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -524,6 +524,9 @@ export const createStellaStyleDocumentPreset: () => DocumentPreset;
 export const createStellaStyleSet: () => DocumentStyleSet;
 
 // @public
+export const currentFolioBlockId: (id: string) => string;
+
+// @public
 export const DEFAULT_AI_SUGGESTION_PRESETS: AISuggestionPreset[];
 
 // @public

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -73,6 +73,7 @@ export {
   type InspectDocxCompatibilityOptions,
 } from "./docx/compatibility";
 export {
+  currentFolioBlockId,
   deriveBlockId,
   getFolioParaIdFromBlockId,
   isFolioBlockId,

--- a/packages/core/src/types/block-id.test.ts
+++ b/packages/core/src/types/block-id.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  currentFolioBlockId,
   deriveBlankBlockId,
   deriveBlockId,
   getFolioParaIdFromBlockId,
@@ -8,6 +9,7 @@ import {
   isFolioBlockId,
   isSequentialFolioBlockId,
 } from "./block-id";
+import { paraIdInRange } from "../docx/paraIdRangeNormalization";
 
 describe("deriveBlockId", () => {
   test("returns the source paraId when present and unused", () => {
@@ -132,6 +134,23 @@ describe("isFolioBlockId", () => {
     expect(isFolioBlockId(undefined)).toBe(false);
     expect(isFolioBlockId(null)).toBe(false);
     expect(isFolioBlockId(42)).toBe(false);
+  });
+});
+
+describe("currentFolioBlockId", () => {
+  test("an id the parser brings into range resolves to the id it gives now", () => {
+    expect(currentFolioBlockId("FFFF0001")).toBe(paraIdInRange("FFFF0001"));
+    expect(currentFolioBlockId("FFFF0001")).not.toBe("FFFF0001");
+  });
+
+  test("an id already in range is returned as it is", () => {
+    expect(currentFolioBlockId("7FFF0001")).toBe("7FFF0001");
+  });
+
+  test("sequential, blank and non-hex ids pass through", () => {
+    expect(currentFolioBlockId("seq-0004")).toBe("seq-0004");
+    expect(currentFolioBlockId("blank-0002")).toBe("blank-0002");
+    expect(currentFolioBlockId("not-a-para-id")).toBe("not-a-para-id");
   });
 });
 

--- a/packages/core/src/types/block-id.ts
+++ b/packages/core/src/types/block-id.ts
@@ -27,6 +27,9 @@
  * every stored citation after the first blank line in a document.
  */
 
+import { paraIdInRange } from "../docx/paraIdRangeNormalization";
+import { isValidHexId } from "../utils/hexId";
+
 const SEQUENTIAL_BLOCK_ID_PREFIX = "seq-";
 const BLANK_BLOCK_ID_PREFIX = "blank-";
 const SEQUENTIAL_BLOCK_ID_PADDING = 4;
@@ -130,6 +133,21 @@ export const isBlankFolioBlockId = (id: string): boolean => BLANK_BLOCK_ID_PATTE
  */
 export const getFolioParaIdFromBlockId = (id: string): string | null =>
   isSequentialFolioBlockId(id) || isBlankFolioBlockId(id) ? null : id;
+
+/**
+ * The id a block recorded earlier answers to in the document as parsed now.
+ *
+ * A paragraph id above the 31-bit bound the schema sets is brought into range
+ * on parse, so an id recorded from such a paragraph before that no longer
+ * names it. The mapping is a pure function of the id alone, so the recorded id
+ * resolves to the current one with no document in hand. Sequential and blank
+ * ids carry no paragraph id, and an id the parser would not have mapped is
+ * returned as it is.
+ */
+export const currentFolioBlockId = (id: string): string => {
+  const paraId = getFolioParaIdFromBlockId(id);
+  return paraId !== null && isValidHexId(paraId) ? paraIdInRange(paraId) : id;
+};
 
 /**
  * The 1-based document position encoded in a sequential fallback id


### PR DESCRIPTION
A paragraph id above the 31-bit bound the schema sets is brought into range on parse, so a block id a host recorded from such a paragraph before that no longer names it, and a persisted operation anchored on it resolves nowhere. The mapping is a pure function of the id alone, so the recorded id resolves to the current one with no document in hand.

`currentFolioBlockId` applies it to a paraId-backed id the parser would have mapped and returns every other id as it is: sequential and blank ids carry no paragraph id, and a value that is not an eight-digit hex id was never mapped on parse.

Exported from the main entry; API report and changeset included.