### PR TITLE
fix: Declare every namespace prefix a rebuilt part uses

### DIFF
--- a/.changeset/brave-hounds-declare.md
+++ b/.changeset/brave-hounds-declare.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Declare every namespace prefix a rebuilt part uses. `word/document.xml`, headers, footers, note parts, `comments.xml`, `commentsExtended.xml` and the numbering, styles, settings, font-table and theme parts now derive their `xmlns:*` from the markup they emit instead of a hand-maintained list: each prefix is resolved through one namespace table, falling back to the bindings the source part's root declared, and a prefix that resolves to nothing fails the save with an `UnboundNamespacePrefixError` rather than being written unbound. `mc:Ignorable` comes from the same table, so it names only prefixes the part declares and every declared extension prefix it should. A document carrying content the parser preserves verbatim — a text box under `wne:txbxContent`, a `w16du:dateUtc` revision stamp — no longer saves to a part a consumer refuses to open.

--- a/packages/core/src/docx/__tests__/partNamespaceDeclarations.test.ts
+++ b/packages/core/src/docx/__tests__/partNamespaceDeclarations.test.ts
@@ -1,0 +1,185 @@
+/**
+ * A save never introduces a namespace defect into a package part.
+ *
+ * The serializers derive each rebuilt part's `xmlns:*` from the markup they
+ * assembled, so this gate checks the property that derivation exists for: every
+ * prefix in a saved part resolves to a namespace URI, and `mc:Ignorable` names
+ * only prefixes the part declares. Defects already present in a fixture's own
+ * part are subtracted, so a malformed source stays the source's problem while
+ * anything folio adds fails here.
+ *
+ * The whole corpus runs through `test.each`, so a fixture added later is
+ * covered with no edit here. Fixture provenance and licensing: see
+ * `__fixtures__/corpus/PROVENANCE.md`.
+ */
+
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+
+import { fromProseDoc } from "../../prosemirror/conversion/fromProseDoc";
+import { toProseDoc } from "../../prosemirror/conversion/toProseDoc";
+import type { Document } from "../../types/document";
+import { parseDocx } from "../parser";
+import { repackDocx } from "../rezip";
+import { serializeDocument } from "../serializer/documentSerializer";
+import { OOXML_NAMESPACES } from "../serializer/partNamespaces";
+import {
+  getNamespacePrefix,
+  parseXmlDocument,
+  type XmlElement,
+  type XmlNamespaceScope,
+} from "../xmlParser";
+
+const CORPUS_DIR = path.join(import.meta.dir, "__fixtures__", "corpus");
+const VISUAL_FIXTURES_DIR = path.resolve(import.meta.dir, "../../../../../tests/visual/fixtures");
+
+const CORPUS_FIXTURES: string[] = readdirSync(CORPUS_DIR)
+  .filter((name) => name.endsWith(".docx"))
+  .sort()
+  .map((name) => path.join(CORPUS_DIR, name));
+
+const VISUAL_FIXTURES = ["sample.docx", "docx-editor-demo.docx", "podily-bps.docx"].map((name) =>
+  path.join(VISUAL_FIXTURES_DIR, name),
+);
+
+const FIXTURES = [...CORPUS_FIXTURES, ...VISUAL_FIXTURES];
+
+const readFixture = (file: string): ArrayBuffer => {
+  const bytes = readFileSync(file);
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+};
+
+const resolvePrefix = (scope: XmlNamespaceScope | undefined, prefix: string): boolean => {
+  for (let current = scope; current; current = current.parent) {
+    if (current.bindings.has(prefix)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+/**
+ * Namespace defects in one part, as stable descriptions so a saved part's
+ * defects can be subtracted from its source's.
+ */
+const namespaceDefects = (xml: string): Set<string> => {
+  const defects = new Set<string>();
+  const root = parseXmlDocument(xml);
+  if (root === null) {
+    defects.add("unparseable");
+    return defects;
+  }
+
+  const visit = (element: XmlElement): void => {
+    const { namespaceScope } = element;
+    const elementPrefix = getNamespacePrefix(element.name ?? "");
+    if (elementPrefix !== null && !resolvePrefix(namespaceScope, elementPrefix)) {
+      defects.add(`unbound element prefix ${elementPrefix}`);
+    }
+    for (const attribute of Object.keys(element.attributes ?? {})) {
+      const attributePrefix = getNamespacePrefix(attribute);
+      if (
+        attributePrefix !== null &&
+        attributePrefix !== "xmlns" &&
+        attributePrefix !== "xml" &&
+        !resolvePrefix(namespaceScope, attributePrefix)
+      ) {
+        defects.add(`unbound attribute prefix ${attributePrefix}`);
+      }
+    }
+    for (const child of element.elements ?? []) {
+      if (child.type === "element") {
+        visit(child);
+      }
+    }
+  };
+  visit(root);
+
+  const ignorable = root.attributes?.["mc:Ignorable"];
+  if (typeof ignorable === "string") {
+    for (const prefix of ignorable.split(" ").filter(Boolean)) {
+      if (!resolvePrefix(root.namespaceScope, prefix)) {
+        defects.add(`mc:Ignorable names undeclared prefix ${prefix}`);
+      }
+    }
+  }
+  return defects;
+};
+
+type PartDefects = Map<string, Set<string>>;
+
+const packageDefects = async (buffer: ArrayBuffer): Promise<PartDefects> => {
+  const zip = await JSZip.loadAsync(buffer);
+  const defects: PartDefects = new Map();
+  for (const [name, file] of Object.entries(zip.files)) {
+    if (file.dir || !name.toLowerCase().endsWith(".xml")) {
+      continue;
+    }
+    defects.set(name, namespaceDefects(await file.async("text")));
+  }
+  return defects;
+};
+
+const roundTrip = async (original: Document): Promise<ArrayBuffer> =>
+  repackDocx(fromProseDoc(toProseDoc(original), original), { updateModifiedDate: false });
+
+describe("saved package namespace declarations", () => {
+  test.each(FIXTURES.map((file) => [path.basename(file), file] as const))(
+    "%s introduces no unbound prefix",
+    async (_name, file) => {
+      const original = readFixture(file);
+      const saved = await roundTrip(await parseDocx(original));
+
+      const before = await packageDefects(original);
+      const after = await packageDefects(saved);
+
+      const introduced = [...after].flatMap(([part, defects]) => {
+        const known = before.get(part) ?? new Set<string>();
+        return [...defects].filter((defect) => !known.has(defect)).map((d) => `${part}: ${d}`);
+      });
+      expect(introduced).toEqual([]);
+    },
+    30_000,
+  );
+
+  test("a text box replayed verbatim keeps its producer's prefix bound", () => {
+    // The parser preserves an unmodeled drawing as source XML. A text box
+    // written under ISO conformance reaches the serializer as `wne:txbxContent`
+    // whose only binding was on the source document's root.
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "run",
+                  content: [
+                    {
+                      type: "drawing",
+                      image: {
+                        type: "image",
+                        rId: "rId1",
+                        size: { width: 9525, height: 9525 },
+                        wrap: { type: "inline" },
+                      },
+                      rawXml:
+                        "<w:drawing><wp:inline><wp:txbx><wne:txbxContent><w:p/></wne:txbxContent></wp:txbx></wp:inline></w:drawing>",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const xml = serializeDocument(document);
+    expect(xml).toContain(`xmlns:wne="${OOXML_NAMESPACES.wne.uri}"`);
+    expect([...namespaceDefects(xml)]).toEqual([]);
+  });
+});

--- a/packages/core/src/docx/rezip.ts
+++ b/packages/core/src/docx/rezip.ts
@@ -74,6 +74,7 @@ import {
   serializeNewFootnotesPart,
 } from "./serializer/noteSerializer";
 import { serializeNumberingXml } from "./serializer/numberingSerializer";
+import { readRootNamespaceBindings } from "./serializer/partNamespaces";
 import { serializeFontTableXml } from "./serializer/fontTableSerializer";
 import { serializeSettingsXml } from "./serializer/settingsSerializer";
 import { serializeStyle, serializeStylesXml } from "./serializer/stylesSerializer";
@@ -223,10 +224,8 @@ async function serializeCommentsToZip(
 ): Promise<void> {
   const comments = doc.package.document.comments ?? [];
   const sourceCommentsFile = findZipEntryCaseInsensitive(zip, "word/comments.xml");
+  const sourceCommentsXml = sourceCommentsFile ? await sourceCommentsFile.async("text") : undefined;
   if (comments.length === 0) {
-    if (!sourceCommentsFile) {
-      return;
-    }
     // An empty source part is already a fixed point. Preserve it and its
     // packaging verbatim: adding a missing relationship or pruning an empty
     // extension part would turn a no-op save into a structural package edit.
@@ -234,8 +233,7 @@ async function serializeCommentsToZip(
     // A non-empty source part with an empty current model is different: the
     // user removed the last comment, so it must still be overwritten below to
     // prevent the old thread from reappearing.
-    const sourceCommentsXml = await sourceCommentsFile.async("text");
-    if (!hasCommentEntries(sourceCommentsXml)) {
+    if (sourceCommentsXml === undefined || !hasCommentEntries(sourceCommentsXml)) {
       return;
     }
   }
@@ -244,7 +242,10 @@ async function serializeCommentsToZip(
   // comments.xml and commentsExtended.xml reference the same key.
   ensureThreadedCommentParaIds(comments);
 
-  const commentsXml = serializeComments(comments);
+  const commentsXml = serializeComments(
+    comments,
+    sourceCommentsXml === undefined ? undefined : readRootNamespaceBindings(sourceCommentsXml),
+  );
   zip.file(sourceCommentsFile?.name ?? "word/comments.xml", commentsXml, {
     compression: "DEFLATE",
     compressionOptions: { level: compressionLevel },
@@ -919,7 +920,10 @@ const finishRepack = async ({
 
   applyReplyThreadMarkers(document);
 
-  const documentXml = serializeDocument(document);
+  const documentXml = serializeDocument(
+    document,
+    originalDocumentXml === undefined ? undefined : readRootNamespaceBindings(originalDocumentXml),
+  );
   if (originalDocumentXml) {
     assertDocumentPackageFidelity(originalDocumentXml, documentXml, document);
   }
@@ -930,7 +934,7 @@ const finishRepack = async ({
 
   await rebindWatermarkRelIds(document, outputZip, compressionLevel);
 
-  serializeHeadersFootersToZip(document, outputZip, compressionLevel);
+  await serializeHeadersFootersToZip(document, outputZip, compressionLevel);
 
   await serializeNotesToZip({
     doc: document,
@@ -1072,7 +1076,10 @@ export async function repackDocxFromRaw(
   // reply round-trips with matching commentRange markers + reference.
   applyReplyThreadMarkers(exportDocument);
 
-  const documentXml = serializeDocument(exportDocument);
+  const documentXml = serializeDocument(
+    exportDocument,
+    rawContent.documentXml ? readRootNamespaceBindings(rawContent.documentXml) : undefined,
+  );
   if (rawContent.documentXml) {
     assertDocumentPackageFidelity(rawContent.documentXml, documentXml, exportDocument);
   }
@@ -1087,7 +1094,7 @@ export async function repackDocxFromRaw(
   await rebindWatermarkRelIds(exportDocument, newZip, compressionLevel);
 
   // Serialize and update modified headers/footers
-  serializeHeadersFootersToZip(exportDocument, newZip, compressionLevel);
+  await serializeHeadersFootersToZip(exportDocument, newZip, compressionLevel);
 
   // Splice edited footnote/endnote bodies back into their parts (separators and
   // unedited notes stay byte-exact).
@@ -1999,7 +2006,16 @@ async function rebindWatermarkRelIds(
   }
 }
 
-export function collectHeaderFooterUpdates(doc: Document): Map<string, string> {
+/**
+ * Re-serialize every header/footer the model still owns, keyed by part path.
+ *
+ * `sourceZip` supplies each part as it stands before the save so the rebuilt
+ * root can keep any prefix binding only the source document declared.
+ */
+export async function collectHeaderFooterUpdates(
+  doc: Document,
+  sourceZip: JSZip,
+): Promise<Map<string, string>> {
   const updates = new Map<string, string>();
   const rels = doc.package.relationships;
   if (!rels) {
@@ -2022,8 +2038,12 @@ export function collectHeaderFooterUpdates(doc: Document): Map<string, string> {
     for (const [rId, headerFooter] of map.entries()) {
       const rel = rels.get(rId);
       if (rel && rel.type === type && rel.target) {
-        const filename = resolveRelativePath(documentRelsPath, rel.target);
-        updates.set(filename, serializeHeaderFooter(headerFooter));
+        const path = resolveRelativePath(documentRelsPath, rel.target);
+        const sourceFile = findZipEntryCaseInsensitive(sourceZip, path.toLowerCase());
+        const bindings = sourceFile
+          ? readRootNamespaceBindings(await sourceFile.async("text"))
+          : new Map<string, string>();
+        updates.set(path, serializeHeaderFooter(headerFooter, { path, bindings }));
       }
     }
   }
@@ -2034,9 +2054,13 @@ export function collectHeaderFooterUpdates(doc: Document): Map<string, string> {
 /**
  * Serialize modified headers and footers into the ZIP
  */
-function serializeHeadersFootersToZip(doc: Document, zip: JSZip, compressionLevel: number): void {
+async function serializeHeadersFootersToZip(
+  doc: Document,
+  zip: JSZip,
+  compressionLevel: number,
+): Promise<void> {
   const compressionOptions = { level: compressionLevel };
-  for (const [filename, xml] of collectHeaderFooterUpdates(doc)) {
+  for (const [filename, xml] of await collectHeaderFooterUpdates(doc, zip)) {
     zip.file(filename, xml, { compression: "DEFLATE", compressionOptions });
   }
 }

--- a/packages/core/src/docx/selectiveSave.ts
+++ b/packages/core/src/docx/selectiveSave.ts
@@ -50,6 +50,7 @@ import {
 import { serializeDocument } from "./serializer/documentSerializer";
 import { serializeEndnotes, serializeFootnotes } from "./serializer/noteSerializer";
 import { serializeNumberingXml } from "./serializer/numberingSerializer";
+import { readRootNamespaceBindings } from "./serializer/partNamespaces";
 
 /**
  * Check if document content has new images (data: URL without rId) or
@@ -457,7 +458,6 @@ export async function attemptSelectiveSave(
 
   const comments = doc.package.document.comments ?? [];
   const hasComments = comments.length > 0;
-  const headerFooterUpdates = collectHeaderFooterUpdates(doc);
 
   try {
     const JSZip = (await import("jszip")).default;
@@ -511,7 +511,7 @@ export async function attemptSelectiveSave(
       }
 
       if (bodyChangedIds.size > 0) {
-        const serializedDocXml = serializeDocument(doc);
+        const serializedDocXml = serializeDocument(doc, readRootNamespaceBindings(originalDocXml));
         const patchedDocXml = buildPatchedDocumentXml(
           originalDocXml,
           serializedDocXml,
@@ -528,12 +528,15 @@ export async function attemptSelectiveSave(
     // even if the editor now has zero comments — otherwise the stale
     // entries linger in the saved file (the rezip baseline copies the
     // previous part as-is) and round-trip back as phantom threads.
-    const hadCommentsFile = zip.file("word/comments.xml") !== null;
-    if (hasComments || hadCommentsFile) {
+    const sourceCommentsFile = zip.file("word/comments.xml");
+    if (hasComments || sourceCommentsFile) {
       // Threaded/resolved comments need a stable last-paragraph paraId so
       // comments.xml and commentsExtended.xml reference the same key.
       ensureThreadedCommentParaIds(comments);
-      updates.set("word/comments.xml", serializeComments(comments));
+      const sourceBindings = sourceCommentsFile
+        ? readRootNamespaceBindings(await sourceCommentsFile.async("text"))
+        : undefined;
+      updates.set("word/comments.xml", serializeComments(comments, sourceBindings));
     }
     if (hasComments) {
       // Ensure [Content_Types].xml has an Override for comments.xml
@@ -583,7 +586,7 @@ export async function attemptSelectiveSave(
     await patchNumberingPart(zip, doc, updates);
 
     // Serialize modified headers/footers
-    for (const [path, xml] of headerFooterUpdates) {
+    for (const [path, xml] of await collectHeaderFooterUpdates(doc, zip)) {
       updates.set(path, xml);
     }
 

--- a/packages/core/src/docx/serializer/commentSerializer.ts
+++ b/packages/core/src/docx/serializer/commentSerializer.ts
@@ -7,6 +7,7 @@
 import { deterministicHexId } from "../../utils/hexId";
 import type { Comment, Paragraph } from "../../types/content";
 import type { TextFormatting } from "../../types/formatting";
+import { serializePartElement, type OoxmlNamespacePrefix } from "./partNamespaces";
 import { serializeParagraph } from "./paragraphSerializer";
 import { serializeTextFormatting } from "./runSerializer";
 import { escapeXml } from "./xmlUtils";
@@ -70,33 +71,35 @@ function serializeComment(comment: Comment): string {
   return xml;
 }
 
-const COMMENT_EXTENSION_NAMESPACES = {
-  w14: "http://schemas.microsoft.com/office/word/2010/wordml",
-  wp14: "http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing",
-} as const;
+// Prefixes word/comments.xml declares whether or not the comment bodies use
+// them, so a comment carrying a drawing or a raw-replayed extension lands on a
+// root that already declares its prefix.
+const COMMENTS_BASELINE_PREFIXES = [
+  "wpc",
+  "mc",
+  "o",
+  "r",
+  "m",
+  "v",
+  "wp",
+  "w10",
+  "w",
+  // Every ignorable prefix needs a binding even when no comment uses its elements.
+  "w14",
+  "wp14",
+  "wpg",
+  "wpi",
+  "wne",
+  "wps",
+] as const satisfies readonly OoxmlNamespacePrefix[];
 
-// Every ignorable prefix needs a binding even when no comment uses its elements.
-const COMMENT_EXTENSION_DECLARATIONS = Object.entries(COMMENT_EXTENSION_NAMESPACES)
-  .map(([prefix, namespace]) => `xmlns:${prefix}="${namespace}"`)
-  .join(" ");
+const COMMENTS_EXTENDED_BASELINE_PREFIXES = [
+  "mc",
+  "w",
+  "w15",
+] as const satisfies readonly OoxmlNamespacePrefix[];
 
-const COMMENTS_HEADER =
-  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n' +
-  '<w:comments xmlns:wpc="http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas" ' +
-  'xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" ' +
-  'xmlns:o="urn:schemas-microsoft-com:office:office" ' +
-  'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" ' +
-  'xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math" ' +
-  'xmlns:v="urn:schemas-microsoft-com:vml" ' +
-  'xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" ' +
-  'xmlns:w10="urn:schemas-microsoft-com:office:word" ' +
-  'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" ' +
-  `${COMMENT_EXTENSION_DECLARATIONS} ` +
-  'xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup" ' +
-  'xmlns:wpi="http://schemas.microsoft.com/office/word/2010/wordprocessingInk" ' +
-  'xmlns:wne="http://schemas.microsoft.com/office/word/2006/wordml" ' +
-  'xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape" ' +
-  `mc:Ignorable="${Object.keys(COMMENT_EXTENSION_NAMESPACES).join(" ")}">`;
+const XML_DECLARATION = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n';
 
 /**
  * Serialize comments array to comments.xml content. Returns a valid empty
@@ -105,7 +108,10 @@ const COMMENTS_HEADER =
  * comment — leaving the previous file in place would otherwise re-emit
  * the orphaned comment threads on every save.
  */
-export function serializeComments(comments: Comment[]): string {
+export function serializeComments(
+  comments: Comment[],
+  sourceBindings?: ReadonlyMap<string, string>,
+): string {
   // Separate top-level comments and replies in a single pass
   const topLevel: Comment[] = [];
   const replies: Comment[] = [];
@@ -115,18 +121,21 @@ export function serializeComments(comments: Comment[]): string {
     (parentId === null || parentId === undefined ? topLevel : replies).push(c);
   }
 
-  let xml = COMMENTS_HEADER;
-
   // Serialize top-level comments first, then replies
-  for (const comment of topLevel) {
-    xml += serializeComment(comment);
-  }
-  for (const reply of replies) {
-    xml += serializeComment(reply);
-  }
+  const body =
+    topLevel.map((comment) => serializeComment(comment)).join("") +
+    replies.map((reply) => serializeComment(reply)).join("");
 
-  xml += "</w:comments>";
-  return xml;
+  return (
+    XML_DECLARATION +
+    serializePartElement({
+      partPath: "word/comments.xml",
+      rootName: "w:comments",
+      baselinePrefixes: COMMENTS_BASELINE_PREFIXES,
+      sourceBindings,
+      body,
+    })
+  );
 }
 
 /** The `w14:paraId` Word threads a comment by: its LAST paragraph's paraId. */
@@ -271,13 +280,6 @@ function buildCommentExtendedEntries(comments: readonly Comment[]): CommentExten
   return entries.length > 0 ? entries : null;
 }
 
-const COMMENTS_EXTENDED_HEADER =
-  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n' +
-  '<w15:commentsEx xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" ' +
-  'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" ' +
-  'xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml" ' +
-  'mc:Ignorable="w15">';
-
 /**
  * Serialize `commentsExtended.xml` (`w15:commentsEx`) for reply threading and
  * resolved state, or `null` when no comment needs an entry (see
@@ -290,14 +292,24 @@ export function serializeCommentsExtended(comments: readonly Comment[]): string 
     return null;
   }
 
-  let xml = COMMENTS_EXTENDED_HEADER;
-  for (const entry of entries) {
-    const parentAttr =
-      entry.paraIdParent !== undefined
-        ? ` w15:paraIdParent="${escapeXml(entry.paraIdParent)}"`
-        : "";
-    xml += `<w15:commentEx w15:paraId="${escapeXml(entry.paraId)}"${parentAttr} w15:done="${entry.done ? "1" : "0"}"/>`;
-  }
-  xml += "</w15:commentsEx>";
-  return xml;
+  const body = entries
+    .map((entry) => {
+      const parentAttr =
+        entry.paraIdParent !== undefined
+          ? ` w15:paraIdParent="${escapeXml(entry.paraIdParent)}"`
+          : "";
+      return `<w15:commentEx w15:paraId="${escapeXml(entry.paraId)}"${parentAttr} w15:done="${entry.done ? "1" : "0"}"/>`;
+    })
+    .join("");
+
+  return (
+    XML_DECLARATION +
+    serializePartElement({
+      partPath: "word/commentsExtended.xml",
+      rootName: "w15:commentsEx",
+      baselinePrefixes: COMMENTS_EXTENDED_BASELINE_PREFIXES,
+      sourceBindings: undefined,
+      body,
+    })
+  );
 }

--- a/packages/core/src/docx/serializer/documentSerializer.ts
+++ b/packages/core/src/docx/serializer/documentSerializer.ts
@@ -13,99 +13,43 @@
 
 import type { Document, DocumentBody, BlockContent } from "../../types/document";
 import { serializeBlockSdt } from "./blockSdtSerializer";
+import { serializePartElement, type OoxmlNamespacePrefix } from "./partNamespaces";
 import { serializeParagraph } from "./paragraphSerializer";
 import { resetAutoIdCounter } from "./runSerializer";
 import { serializeSectionProperties } from "./sectionPropertiesSerializer";
 import { serializeTable } from "./tableSerializer";
 
-// ============================================================================
-// XML NAMESPACES
-// ============================================================================
-
 /**
- * Standard OOXML namespaces for document.xml
+ * Prefixes document.xml declares whether or not the body uses them.
+ *
+ * A canonical `<w:sdtPr>` legitimately carries `<w16sdtdh:dataHash>` /
+ * `<w16cex:*>` / `<w16cid:*>` children the parser stores opaquely, and the
+ * drawing prefixes host raw-replayed shapes, so the part keeps the shape Word
+ * writes even when this particular save emits none of them.
  */
-const NAMESPACES = {
-  a: "http://schemas.openxmlformats.org/drawingml/2006/main",
-  wpc: "http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas",
-  cx: "http://schemas.microsoft.com/office/drawing/2014/chartex",
-  cx1: "http://schemas.microsoft.com/office/drawing/2015/9/8/chartex",
-  cx2: "http://schemas.microsoft.com/office/drawing/2015/10/21/chartex",
-  cx3: "http://schemas.microsoft.com/office/drawing/2016/5/9/chartex",
-  cx4: "http://schemas.microsoft.com/office/drawing/2016/5/10/chartex",
-  cx5: "http://schemas.microsoft.com/office/drawing/2016/5/11/chartex",
-  cx6: "http://schemas.microsoft.com/office/drawing/2016/5/12/chartex",
-  cx7: "http://schemas.microsoft.com/office/drawing/2016/5/13/chartex",
-  cx8: "http://schemas.microsoft.com/office/drawing/2016/5/14/chartex",
-  mc: "http://schemas.openxmlformats.org/markup-compatibility/2006",
-  aink: "http://schemas.microsoft.com/office/drawing/2016/ink",
-  am3d: "http://schemas.microsoft.com/office/drawing/2017/model3d",
-  o: "urn:schemas-microsoft-com:office:office",
-  oel: "http://schemas.microsoft.com/office/2019/extlst",
-  pic: "http://schemas.openxmlformats.org/drawingml/2006/picture",
-  r: "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
-  m: "http://schemas.openxmlformats.org/officeDocument/2006/math",
-  v: "urn:schemas-microsoft-com:vml",
-  wp14: "http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing",
-  wp: "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing",
-  w10: "urn:schemas-microsoft-com:office:word",
-  w: "http://schemas.openxmlformats.org/wordprocessingml/2006/main",
-  w14: "http://schemas.microsoft.com/office/word/2010/wordml",
-  w15: "http://schemas.microsoft.com/office/word/2012/wordml",
-  w16cex: "http://schemas.microsoft.com/office/word/2018/wordml/cex",
-  w16cid: "http://schemas.microsoft.com/office/word/2016/wordml/cid",
-  w16: "http://schemas.microsoft.com/office/word/2018/wordml",
-  w16sdtdh: "http://schemas.microsoft.com/office/word/2020/wordml/sdtdatahash",
-  w16se: "http://schemas.microsoft.com/office/word/2015/wordml/symex",
-  wpg: "http://schemas.microsoft.com/office/word/2010/wordprocessingGroup",
-  wpi: "http://schemas.microsoft.com/office/word/2010/wordprocessingInk",
-  wne: "http://schemas.microsoft.com/office/word/2006/wordml",
-  wps: "http://schemas.microsoft.com/office/word/2010/wordprocessingShape",
-};
-
-/**
- * Build namespace declaration string for document element
- */
-function buildNamespaceDeclarations(): string {
-  // Declare every namespace the parser preserves verbatim through
-  // `rawPropertiesXml` / `rawEndPropertiesXml` (and any other raw
-  // replay path). A canonical `<w:sdtPr>` legitimately contains
-  // `<w16sdtdh:dataHash>` / `<w16cex:*>` / `<w16cid:*>` children that
-  // the parser stores opaquely; without these declarations on the
-  // document root, the replayed XML would carry undefined prefixes and
-  // Word refuses to open the file.
-  const declared = {
-    a: NAMESPACES.a,
-    wpc: NAMESPACES.wpc,
-    mc: NAMESPACES.mc,
-    o: NAMESPACES.o,
-    pic: NAMESPACES.pic,
-    r: NAMESPACES.r,
-    m: NAMESPACES.m,
-    v: NAMESPACES.v,
-    wp14: NAMESPACES.wp14,
-    wp: NAMESPACES.wp,
-    w10: NAMESPACES.w10,
-    w: NAMESPACES.w,
-    w14: NAMESPACES.w14,
-    w15: NAMESPACES.w15,
-    w16: NAMESPACES.w16,
-    w16cex: NAMESPACES.w16cex,
-    w16cid: NAMESPACES.w16cid,
-    w16sdtdh: NAMESPACES.w16sdtdh,
-    w16se: NAMESPACES.w16se,
-    wpg: NAMESPACES.wpg,
-    wps: NAMESPACES.wps,
-  };
-
-  return Object.entries(declared)
-    .map(([prefix, uri]) => `xmlns:${prefix}="${uri}"`)
-    .join(" ");
-}
-
-// ============================================================================
-// XML ESCAPING
-// ============================================================================
+const DOCUMENT_BASELINE_PREFIXES = [
+  "a",
+  "wpc",
+  "mc",
+  "o",
+  "pic",
+  "r",
+  "m",
+  "v",
+  "wp14",
+  "wp",
+  "w10",
+  "w",
+  "w14",
+  "w15",
+  "w16",
+  "w16cex",
+  "w16cid",
+  "w16sdtdh",
+  "w16se",
+  "wpg",
+  "wps",
+] as const satisfies readonly OoxmlNamespacePrefix[];
 
 // ============================================================================
 // CONTENT SERIALIZATION
@@ -159,30 +103,29 @@ export function serializeDocumentBody(body: DocumentBody): string {
  * Serialize a complete Document to valid document.xml
  *
  * @param doc - The document to serialize
+ * @param sourceBindings - Root `xmlns:*` of the part being replaced, so a
+ *   prefix only the source document bound keeps its URI
  * @returns Complete XML string for document.xml
  */
-export function serializeDocument(doc: Document): string {
+export function serializeDocument(
+  doc: Document,
+  sourceBindings?: ReadonlyMap<string, string>,
+): string {
   // Reset auto-incrementing image/shape ID counter for this serialization pass
   resetAutoIdCounter();
 
-  const parts: string[] = [];
+  const body = `<w:body>${serializeDocumentBody(doc.package.document)}</w:body>`;
 
-  // XML declaration
-  parts.push('<?xml version="1.0" encoding="UTF-8" standalone="yes"?>');
-
-  // Document element with namespaces
-  const nsDecl = buildNamespaceDeclarations();
-  parts.push(`<w:document ${nsDecl} mc:Ignorable="w14 w15 wp14">`);
-
-  // Document body
-  parts.push("<w:body>");
-  parts.push(serializeDocumentBody(doc.package.document));
-  parts.push("</w:body>");
-
-  // Close document element
-  parts.push("</w:document>");
-
-  return parts.join("");
+  return (
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+    serializePartElement({
+      partPath: "word/document.xml",
+      rootName: "w:document",
+      baselinePrefixes: DOCUMENT_BASELINE_PREFIXES,
+      sourceBindings,
+      body,
+    })
+  );
 }
 
 /**

--- a/packages/core/src/docx/serializer/fontTableSerializer.ts
+++ b/packages/core/src/docx/serializer/fontTableSerializer.ts
@@ -1,12 +1,16 @@
 import type { FontInfo, FontTable } from "../../types/document";
+import { serializePartElement } from "./partNamespaces";
 import { escapeXml } from "./xmlUtils";
 
-const W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
-
-export const serializeFontTableXml = (fontTable: FontTable): string => {
-  const fonts = fontTable.fonts.map(serializeFont).join("");
-  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n<w:fonts xmlns:w="${W_NS}">${fonts}</w:fonts>`;
-};
+export const serializeFontTableXml = (fontTable: FontTable): string =>
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n' +
+  serializePartElement({
+    partPath: "word/fontTable.xml",
+    rootName: "w:fonts",
+    baselinePrefixes: ["w"],
+    sourceBindings: undefined,
+    body: fontTable.fonts.map(serializeFont).join(""),
+  });
 
 const serializeFont = (font: FontInfo): string => {
   const parts: string[] = [];

--- a/packages/core/src/docx/serializer/headerFooterSerializer.ts
+++ b/packages/core/src/docx/serializer/headerFooterSerializer.ts
@@ -13,48 +13,41 @@
 import type { BlockContent, HeaderFooter, Watermark } from "../../types/document";
 import { getHeaderFooterVerbatimXml, canReplayHeaderFooterVerbatim } from "../headerFooterVerbatim";
 import { serializeBlockSdt } from "./blockSdtSerializer";
+import { serializePartElement, type OoxmlNamespacePrefix, type SourcePart } from "./partNamespaces";
 import { serializeParagraph } from "./paragraphSerializer";
 import { serializeTable } from "./tableSerializer";
 import { escapeXml } from "./xmlUtils";
 
-// Namespaces declared on the header/footer root. Mirrors the document
-// serializer's declared set so any raw replay path (`rawPropertiesXml`,
+// Prefixes a header/footer declares whether or not the body uses them. Mirrors
+// the document serializer's baseline so any raw replay path (`rawPropertiesXml`,
 // unmodeled OOXML extensions inside a captured SDT) lands on a root that
-// declares every standard prefix it might use.
-const NAMESPACES: Record<string, string> = {
-  wpc: "http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas",
-  mc: "http://schemas.openxmlformats.org/markup-compatibility/2006",
-  o: "urn:schemas-microsoft-com:office:office",
-  r: "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
-  m: "http://schemas.openxmlformats.org/officeDocument/2006/math",
-  v: "urn:schemas-microsoft-com:vml",
-  // DrawingML core + picture. Required for raw-replay of DrawingML
-  // watermarks captured by `parseWatermark`: `rawWatermarkXml` carries
-  // `<a:graphic>` / `<a:txBody>` / `<pic:pic>` descendants, but the
-  // hosting paragraph alone doesn't preserve the original header's
-  // ancestor namespace declarations.
-  a: "http://schemas.openxmlformats.org/drawingml/2006/main",
-  pic: "http://schemas.openxmlformats.org/drawingml/2006/picture",
-  wp14: "http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing",
-  wp: "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing",
-  w10: "urn:schemas-microsoft-com:office:word",
-  w: "http://schemas.openxmlformats.org/wordprocessingml/2006/main",
-  w14: "http://schemas.microsoft.com/office/word/2010/wordml",
-  w15: "http://schemas.microsoft.com/office/word/2012/wordml",
-  w16: "http://schemas.microsoft.com/office/word/2018/wordml",
-  w16cex: "http://schemas.microsoft.com/office/word/2018/wordml/cex",
-  w16cid: "http://schemas.microsoft.com/office/word/2016/wordml/cid",
-  w16sdtdh: "http://schemas.microsoft.com/office/word/2020/wordml/sdtdatahash",
-  w16se: "http://schemas.microsoft.com/office/word/2015/wordml/symex",
-  wpg: "http://schemas.microsoft.com/office/word/2010/wordprocessingGroup",
-  wps: "http://schemas.microsoft.com/office/word/2010/wordprocessingShape",
-};
-
-function buildNamespaceDeclarations(): string {
-  return Object.entries(NAMESPACES)
-    .map(([prefix, uri]) => `xmlns:${prefix}="${uri}"`)
-    .join(" ");
-}
+// declares every standard prefix it might use. `a` and `pic` cover DrawingML
+// watermarks: `rawWatermarkXml` carries `<a:graphic>` / `<a:txBody>` /
+// `<pic:pic>` descendants, but the hosting paragraph does not preserve the
+// original header's ancestor declarations.
+const HEADER_FOOTER_BASELINE_PREFIXES = [
+  "wpc",
+  "mc",
+  "o",
+  "r",
+  "m",
+  "v",
+  "a",
+  "pic",
+  "wp14",
+  "wp",
+  "w10",
+  "w",
+  "w14",
+  "w15",
+  "w16",
+  "w16cex",
+  "w16cid",
+  "w16sdtdh",
+  "w16se",
+  "wpg",
+  "wps",
+] as const satisfies readonly OoxmlNamespacePrefix[];
 
 /**
  * Serialize a block content item (paragraph, table, or block-level SDT) for
@@ -74,16 +67,17 @@ function serializeBlock(block: BlockContent): string {
  * Serialize a HeaderFooter object to valid OOXML XML
  *
  * @param hf - HeaderFooter object to serialize
+ * @param source - The part being replaced, so a prefix only the source
+ *   document bound keeps its URI
  * @returns Complete XML string for header*.xml or footer*.xml
  */
-export function serializeHeaderFooter(hf: HeaderFooter): string {
+export function serializeHeaderFooter(hf: HeaderFooter, source?: SourcePart): string {
   const verbatim = getHeaderFooterVerbatimXml(hf);
   if (verbatim && canReplayHeaderFooterVerbatim(hf)) {
     return verbatim;
   }
 
   const rootTag = hf.type === "header" ? "w:hdr" : "w:ftr";
-  const nsDecl = buildNamespaceDeclarations();
 
   // Watermark replay. The parser captured the hosting paragraph's
   // verbatim XML (`rawWatermarkXml`) and detached it from `content`,
@@ -114,7 +108,16 @@ export function serializeHeaderFooter(hf: HeaderFooter): string {
     contentXml = "<w:p><w:pPr/></w:p>";
   }
 
-  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n<${rootTag} ${nsDecl}>${contentXml}</${rootTag}>`;
+  return (
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n' +
+    serializePartElement({
+      partPath: source?.path ?? `word/${hf.type}.xml`,
+      rootName: rootTag,
+      baselinePrefixes: HEADER_FOOTER_BASELINE_PREFIXES,
+      sourceBindings: source?.bindings,
+      body: contentXml,
+    })
+  );
 }
 
 function serializeWatermarkParagraph(hf: HeaderFooter): string {

--- a/packages/core/src/docx/serializer/noteSerializer.ts
+++ b/packages/core/src/docx/serializer/noteSerializer.ts
@@ -22,41 +22,47 @@
 
 import type { BlockContent, Endnote, Footnote } from "../../types/document";
 import { serializeBlockSdt } from "./blockSdtSerializer";
+import { serializePartElement, type OoxmlNamespacePrefix } from "./partNamespaces";
 import { serializeParagraph } from "./paragraphSerializer";
 import { serializeTable } from "./tableSerializer";
 
-// Namespaces declared on the notes root. Mirrors the header/footer serializer's
-// declared set so note bodies carrying DrawingML, math, or raw-replayed SDT
-// extensions land on a root that declares every prefix they might use.
-const NAMESPACES: Record<string, string> = {
-  wpc: "http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas",
-  mc: "http://schemas.openxmlformats.org/markup-compatibility/2006",
-  o: "urn:schemas-microsoft-com:office:office",
-  r: "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
-  m: "http://schemas.openxmlformats.org/officeDocument/2006/math",
-  v: "urn:schemas-microsoft-com:vml",
-  a: "http://schemas.openxmlformats.org/drawingml/2006/main",
-  pic: "http://schemas.openxmlformats.org/drawingml/2006/picture",
-  wp14: "http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing",
-  wp: "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing",
-  w10: "urn:schemas-microsoft-com:office:word",
-  w: "http://schemas.openxmlformats.org/wordprocessingml/2006/main",
-  w14: "http://schemas.microsoft.com/office/word/2010/wordml",
-  w15: "http://schemas.microsoft.com/office/word/2012/wordml",
-  w16: "http://schemas.microsoft.com/office/word/2018/wordml",
-  w16cex: "http://schemas.microsoft.com/office/word/2018/wordml/cex",
-  w16cid: "http://schemas.microsoft.com/office/word/2016/wordml/cid",
-  w16sdtdh: "http://schemas.microsoft.com/office/word/2020/wordml/sdtdatahash",
-  w16se: "http://schemas.microsoft.com/office/word/2015/wordml/symex",
-  wpg: "http://schemas.microsoft.com/office/word/2010/wordprocessingGroup",
-  wps: "http://schemas.microsoft.com/office/word/2010/wordprocessingShape",
-};
+// Prefixes a notes part declares whether or not the bodies use them. Mirrors
+// the header/footer baseline so note bodies carrying DrawingML, math, or
+// raw-replayed SDT extensions land on a root that declares every prefix they
+// might use.
+const NOTE_BASELINE_PREFIXES = [
+  "wpc",
+  "mc",
+  "o",
+  "r",
+  "m",
+  "v",
+  "a",
+  "pic",
+  "wp14",
+  "wp",
+  "w10",
+  "w",
+  "w14",
+  "w15",
+  "w16",
+  "w16cex",
+  "w16cid",
+  "w16sdtdh",
+  "w16se",
+  "wpg",
+  "wps",
+] as const satisfies readonly OoxmlNamespacePrefix[];
 
-function buildNamespaceDeclarations(): string {
-  return Object.entries(NAMESPACES)
-    .map(([prefix, uri]) => `xmlns:${prefix}="${uri}"`)
-    .join(" ");
-}
+const serializeNotePart = (elementName: "footnote" | "endnote", body: string): string =>
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n' +
+  serializePartElement({
+    partPath: `word/${elementName}s.xml`,
+    rootName: `w:${elementName}s`,
+    baselinePrefixes: NOTE_BASELINE_PREFIXES,
+    sourceBindings: undefined,
+    body,
+  });
 
 /**
  * Serialize a block content item (paragraph, table, or block-level SDT) for a
@@ -127,16 +133,12 @@ function serializeNewNotePart(
   elementName: "footnote" | "endnote",
   notes: readonly (Footnote | Endnote)[],
 ): string {
-  const nsDecl = buildNamespaceDeclarations();
   const serializedNotes = notes
     .map((note) => insertNoteReferenceMark(serializeNote(elementName, note), elementName))
     .join("");
-  return (
-    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n` +
-    `<w:${elementName}s ${nsDecl} mc:Ignorable="w14 w15 wp14">` +
-    serializeRequiredNoteSeparators(elementName) +
-    serializedNotes +
-    `</w:${elementName}s>`
+  return serializeNotePart(
+    elementName,
+    serializeRequiredNoteSeparators(elementName) + serializedNotes,
   );
 }
 
@@ -147,9 +149,10 @@ function serializeNewNotePart(
  * @returns Complete footnotes.xml string.
  */
 export function serializeFootnotes(footnotes: readonly Footnote[]): string {
-  const nsDecl = buildNamespaceDeclarations();
-  const notes = footnotes.map((fn) => serializeNote("footnote", fn)).join("");
-  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n<w:footnotes ${nsDecl} mc:Ignorable="w14 w15 wp14">${notes}</w:footnotes>`;
+  return serializeNotePart(
+    "footnote",
+    footnotes.map((fn) => serializeNote("footnote", fn)).join(""),
+  );
 }
 
 /**
@@ -159,9 +162,7 @@ export function serializeFootnotes(footnotes: readonly Footnote[]): string {
  * @returns Complete endnotes.xml string.
  */
 export function serializeEndnotes(endnotes: readonly Endnote[]): string {
-  const nsDecl = buildNamespaceDeclarations();
-  const notes = endnotes.map((en) => serializeNote("endnote", en)).join("");
-  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n<w:endnotes ${nsDecl} mc:Ignorable="w14 w15 wp14">${notes}</w:endnotes>`;
+  return serializeNotePart("endnote", endnotes.map((en) => serializeNote("endnote", en)).join(""));
 }
 
 /** Serialize a brand-new footnote part, including Word's required separators

--- a/packages/core/src/docx/serializer/numberingSerializer.ts
+++ b/packages/core/src/docx/serializer/numberingSerializer.ts
@@ -29,10 +29,9 @@ import type {
   NumberingInstance,
   ParagraphFormatting,
 } from "../../types/document";
+import { serializePartElement } from "./partNamespaces";
 import { serializeTextFormatting } from "./runSerializer";
 import { escapeXml, intAttr } from "./xmlUtils";
-
-const W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
 
 /**
  * Serialize a level's paragraph properties — the modeled subset is indentation
@@ -178,5 +177,14 @@ function serializeNum(instance: NumberingInstance): string {
 export function serializeNumberingXml(numbering: NumberingDefinitions): string {
   const abstractNums = numbering.abstractNums.map(serializeAbstractNum).join("");
   const nums = numbering.nums.map(serializeNum).join("");
-  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n<w:numbering xmlns:w="${W_NS}">${abstractNums}${nums}</w:numbering>`;
+  return (
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n' +
+    serializePartElement({
+      partPath: "word/numbering.xml",
+      rootName: "w:numbering",
+      baselinePrefixes: ["w"],
+      sourceBindings: undefined,
+      body: `${abstractNums}${nums}`,
+    })
+  );
 }

--- a/packages/core/src/docx/serializer/partNamespaces.test.ts
+++ b/packages/core/src/docx/serializer/partNamespaces.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  OOXML_NAMESPACES,
+  UnboundNamespacePrefixError,
+  readRootNamespaceBindings,
+  serializePartElement,
+} from "./partNamespaces";
+
+const declaredPrefixes = (xml: string): string[] =>
+  [...xml.matchAll(/xmlns:(?<prefix>[\w.-]+)=/gu)].map((match) => match.groups?.prefix ?? "");
+
+const ignorablePrefixes = (xml: string): string[] => {
+  const attribute = /mc:Ignorable="(?<value>[^"]*)"/u.exec(xml);
+  return attribute ? (attribute.groups?.value ?? "").split(" ").filter(Boolean) : [];
+};
+
+const serialize = (body: string, sourceBindings?: ReadonlyMap<string, string>): string =>
+  serializePartElement({
+    partPath: "word/document.xml",
+    rootName: "w:document",
+    baselinePrefixes: ["mc", "w", "w14"],
+    sourceBindings,
+    body,
+  });
+
+describe("serializePartElement", () => {
+  test("declares the baseline even when the body uses none of it", () => {
+    expect(declaredPrefixes(serialize("<w:body/>"))).toEqual(["mc", "w", "w14"]);
+  });
+
+  test("declares a prefix the body uses beyond the baseline", () => {
+    const xml = serialize("<w:body><wp:txbx><wne:txbxContent/></wp:txbx></w:body>");
+    expect(declaredPrefixes(xml)).toContain("wne");
+    expect(xml).toContain(`xmlns:wne="${OOXML_NAMESPACES.wne.uri}"`);
+  });
+
+  test("declares a prefix carried only by an attribute name", () => {
+    expect(
+      declaredPrefixes(serialize('<w:body><w:p w16du:dateUtc="2024-01-01T00:00:00Z"/></w:body>')),
+    ).toContain("w16du");
+  });
+
+  test("keeps the URI the source part bound for a prefix the table does not know", () => {
+    const xml = serialize(
+      "<w:body><acme:marker/></w:body>",
+      new Map([["acme", "urn:acme:markers"]]),
+    );
+    expect(xml).toContain('xmlns:acme="urn:acme:markers"');
+  });
+
+  test("prefers the table over a source binding that disagrees", () => {
+    const xml = serialize("<w:body/>", new Map([["w", "urn:wrong"]]));
+    expect(xml).toContain(`xmlns:w="${OOXML_NAMESPACES.w.uri}"`);
+    expect(xml).not.toContain("urn:wrong");
+  });
+
+  test("leaves a prefix the body binds for its own subtree to that binding", () => {
+    const body = '<w:body><a14:x xmlns:a14="urn:inline"/></w:body>';
+    expect(declaredPrefixes(serialize(body))).toEqual(["mc", "w", "w14", "a14"]);
+  });
+
+  test("fails on a prefix nothing binds rather than writing it unbound", () => {
+    expect(() => serialize("<w:body><acme:marker/></w:body>")).toThrow(UnboundNamespacePrefixError);
+  });
+
+  test("reports every unbound prefix in the part", () => {
+    try {
+      serialize("<w:body><acme:a/><zeta:b/></w:body>");
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toBeInstanceOf(UnboundNamespacePrefixError);
+      expect((error as UnboundNamespacePrefixError).prefixes).toEqual(["acme", "zeta"]);
+      expect((error as UnboundNamespacePrefixError).partPath).toBe("word/document.xml");
+    }
+  });
+
+  test("a colon inside an attribute value is not a namespace prefix", () => {
+    const xml = serialize('<w:body><w:p w:rsidR="see http://x/y note:this"/></w:body>');
+    expect(declaredPrefixes(xml)).toEqual(["mc", "w", "w14"]);
+  });
+
+  test("comments, CDATA and processing instructions carry no prefixes", () => {
+    const body = "<w:body><!-- acme:not-a-tag --><![CDATA[<zeta:nope/>]]><?pi acme:x?></w:body>";
+    expect(declaredPrefixes(serialize(body))).toEqual(["mc", "w", "w14"]);
+  });
+
+  test("mc:Ignorable lists exactly the declared prefixes marked ignorable", () => {
+    const xml = serialize('<w:body><w:p w16du:dateUtc="2024-01-01T00:00:00Z"/></w:body>');
+    const declared = new Set(declaredPrefixes(xml));
+    const listed = ignorablePrefixes(xml);
+    expect(listed).toEqual(["w14", "w16du"]);
+    for (const prefix of listed) {
+      expect(declared.has(prefix)).toBe(true);
+    }
+    for (const prefix of declared) {
+      const entry = Object.entries(OOXML_NAMESPACES).find(([name]) => name === prefix)?.[1];
+      expect(entry?.ignorable === true).toBe(listed.includes(prefix));
+    }
+  });
+
+  test("omits mc:Ignorable when no declared prefix is ignorable", () => {
+    const xml = serializePartElement({
+      partPath: "word/styles.xml",
+      rootName: "w:styles",
+      baselinePrefixes: ["w"],
+      sourceBindings: undefined,
+      body: "<w:style/>",
+    });
+    expect(xml).not.toContain("mc:Ignorable");
+    expect(xml).not.toContain("xmlns:mc");
+  });
+
+  test("keeps root attributes that are not namespace declarations", () => {
+    const xml = serializePartElement({
+      partPath: "word/theme/theme1.xml",
+      rootName: "a:theme",
+      rootAttributes: 'name="Folio"',
+      baselinePrefixes: ["a"],
+      sourceBindings: undefined,
+      body: "<a:themeElements/>",
+    });
+    expect(xml.startsWith('<a:theme name="Folio" xmlns:a=')).toBe(true);
+  });
+});
+
+describe("readRootNamespaceBindings", () => {
+  test("reads the root element's declarations past the prolog", () => {
+    const bindings = readRootNamespaceBindings(
+      '<?xml version="1.0"?>\n<!-- a note -->\n' +
+        '<w:document xmlns:w="urn:w" xmlns:acme="urn:acme"><w:body><x:y xmlns:x="urn:inner"/></w:body></w:document>',
+    );
+    expect([...bindings.entries()].sort()).toEqual([
+      ["acme", "urn:acme"],
+      ["w", "urn:w"],
+    ]);
+  });
+
+  test("is empty for markup with no root declarations", () => {
+    expect(readRootNamespaceBindings("<w:hdr><w:p/></w:hdr>").size).toBe(0);
+  });
+});

--- a/packages/core/src/docx/serializer/partNamespaces.ts
+++ b/packages/core/src/docx/serializer/partNamespaces.ts
@@ -1,0 +1,388 @@
+/**
+ * Namespace declarations for parts folio rebuilds from the model.
+ *
+ * A rebuilt part carries content the parser preserved verbatim: raw property
+ * XML, text-box bodies, drawing extensions, unmodeled attributes. That content
+ * can use any prefix its producer bound on the source part's root, so a
+ * hand-maintained declaration list on the serializer silently drops bindings
+ * and emits an unbound prefix, which makes the part malformed and the package
+ * unopenable. The declarations are therefore derived: every prefix the
+ * assembled part actually uses is resolved through {@link OOXML_NAMESPACES},
+ * falling back to what the source part bound, and a prefix that resolves to
+ * nothing fails the save instead of being written unbound.
+ */
+
+import { OOXML_NS, type OoxmlPrefix } from "@stll/docx-utils";
+import { TaggedError } from "better-result";
+
+import { escapeXml } from "./xmlUtils";
+
+/**
+ * A namespace a rebuilt WordprocessingML part may declare.
+ *
+ * `ignorable` marks an extension that decorates baseline elements in place
+ * (`w14:paraId`, `w16du:dateUtc`, `wp14:sizeRelH`): a consumer that predates it
+ * has to be told through `mc:Ignorable` to skip it, or it rejects the part.
+ * Extensions reachable only inside an `mc:AlternateContent` choice or an
+ * `a:graphicData` payload (`wps`, `wpg`, `wne`, `cx*`) are already gated by
+ * that wrapper, so they stay out of the attribute, as mainstream producers
+ * leave them.
+ */
+export type OoxmlNamespace = {
+  readonly uri: string;
+  readonly ignorable: boolean;
+};
+
+/** Packaging prefixes; they never appear inside a WordprocessingML part. */
+type PackagingPrefix = "ct" | "pr";
+
+/**
+ * A prefix folio can bind on a rebuilt part without consulting the source.
+ *
+ * Every prefix the parser resolves is a member, so a prefix the parser
+ * understands can always be written back, and {@link OOXML_NAMESPACES} is total
+ * over the union: a member with no entry, or an entry with no member, does not
+ * compile.
+ */
+export type OoxmlNamespacePrefix =
+  | Exclude<OoxmlPrefix, PackagingPrefix>
+  | "cx"
+  | "cx1"
+  | "cx2"
+  | "cx3"
+  | "cx4"
+  | "cx5"
+  | "cx6"
+  | "cx7"
+  | "cx8"
+  | "aink"
+  | "am3d"
+  | "oel"
+  | "w10"
+  | "w16"
+  | "w16cex"
+  | "w16cid"
+  | "w16du"
+  | "w16sdtdh"
+  | "w16se"
+  | "wpi"
+  | "wne";
+
+/**
+ * Every namespace a rebuilt part can declare, in the order producers write them.
+ *
+ * URIs shared with the parser are taken from its table rather than retyped, so
+ * the two cannot drift.
+ */
+export const OOXML_NAMESPACES: Readonly<Record<OoxmlNamespacePrefix, OoxmlNamespace>> = {
+  wpc: { uri: OOXML_NS.wpc, ignorable: false },
+  cx: { uri: "http://schemas.microsoft.com/office/drawing/2014/chartex", ignorable: false },
+  cx1: { uri: "http://schemas.microsoft.com/office/drawing/2015/9/8/chartex", ignorable: false },
+  cx2: { uri: "http://schemas.microsoft.com/office/drawing/2015/10/21/chartex", ignorable: false },
+  cx3: { uri: "http://schemas.microsoft.com/office/drawing/2016/5/9/chartex", ignorable: false },
+  cx4: { uri: "http://schemas.microsoft.com/office/drawing/2016/5/10/chartex", ignorable: false },
+  cx5: { uri: "http://schemas.microsoft.com/office/drawing/2016/5/11/chartex", ignorable: false },
+  cx6: { uri: "http://schemas.microsoft.com/office/drawing/2016/5/12/chartex", ignorable: false },
+  cx7: { uri: "http://schemas.microsoft.com/office/drawing/2016/5/13/chartex", ignorable: false },
+  cx8: { uri: "http://schemas.microsoft.com/office/drawing/2016/5/14/chartex", ignorable: false },
+  mc: { uri: OOXML_NS.mc, ignorable: false },
+  aink: { uri: "http://schemas.microsoft.com/office/drawing/2016/ink", ignorable: false },
+  am3d: { uri: "http://schemas.microsoft.com/office/drawing/2017/model3d", ignorable: false },
+  o: { uri: OOXML_NS.o, ignorable: false },
+  oel: { uri: "http://schemas.microsoft.com/office/2019/extlst", ignorable: false },
+  r: { uri: OOXML_NS.r, ignorable: false },
+  m: { uri: OOXML_NS.m, ignorable: false },
+  v: { uri: OOXML_NS.v, ignorable: false },
+  wp14: { uri: OOXML_NS.wp14, ignorable: true },
+  wp: { uri: OOXML_NS.wp, ignorable: false },
+  w10: { uri: "urn:schemas-microsoft-com:office:word", ignorable: false },
+  w: { uri: OOXML_NS.w, ignorable: false },
+  w14: { uri: OOXML_NS.w14, ignorable: true },
+  w15: { uri: OOXML_NS.w15, ignorable: true },
+  w16cex: { uri: "http://schemas.microsoft.com/office/word/2018/wordml/cex", ignorable: true },
+  w16cid: { uri: "http://schemas.microsoft.com/office/word/2016/wordml/cid", ignorable: true },
+  w16: { uri: "http://schemas.microsoft.com/office/word/2018/wordml", ignorable: true },
+  w16du: { uri: "http://schemas.microsoft.com/office/word/2023/wordml/word16du", ignorable: true },
+  w16sdtdh: {
+    uri: "http://schemas.microsoft.com/office/word/2020/wordml/sdtdatahash",
+    ignorable: true,
+  },
+  w16se: { uri: "http://schemas.microsoft.com/office/word/2015/wordml/symex", ignorable: true },
+  wpg: { uri: OOXML_NS.wpg, ignorable: false },
+  wpi: { uri: "http://schemas.microsoft.com/office/word/2010/wordprocessingInk", ignorable: false },
+  wne: { uri: "http://schemas.microsoft.com/office/word/2006/wordml", ignorable: false },
+  wps: { uri: OOXML_NS.wps, ignorable: false },
+  a: { uri: OOXML_NS.a, ignorable: false },
+  pic: { uri: OOXML_NS.pic, ignorable: false },
+};
+
+/** {@link OOXML_NAMESPACES} keyed for lookup by a prefix read out of markup. */
+const NAMESPACE_TABLE: ReadonlyMap<string, OoxmlNamespace> = new Map(
+  Object.entries(OOXML_NAMESPACES),
+);
+
+/** A rebuilt part uses a prefix that resolves to no namespace URI. */
+export class UnboundNamespacePrefixError extends TaggedError("UnboundNamespacePrefixError")<{
+  message: string;
+  partPath: string;
+  prefixes: readonly string[];
+}> {}
+
+const XMLNS_ATTRIBUTE_PREFIX = "xmlns:";
+/** Bound by the XML specification itself; never declared. */
+const RESERVED_PREFIX = "xml";
+
+const isWhitespace = (character: string): boolean =>
+  character === " " || character === "\t" || character === "\n" || character === "\r";
+
+const isNameBoundary = (character: string): boolean =>
+  isWhitespace(character) || character === ">" || character === "/" || character === "=";
+
+const namePrefix = (qualifiedName: string): string | undefined => {
+  const colon = qualifiedName.indexOf(":");
+  if (colon <= 0) {
+    return undefined;
+  }
+  const prefix = qualifiedName.slice(0, colon);
+  return prefix === RESERVED_PREFIX ? undefined : prefix;
+};
+
+type ScannedNames = {
+  /** Prefixes carried by element and attribute names. */
+  used: ReadonlySet<string>;
+  /** `xmlns:*` bindings found in the scanned markup, latest occurrence winning. */
+  declared: ReadonlyMap<string, string>;
+};
+
+/**
+ * Collect prefixes from element and attribute names in one quote-aware pass.
+ *
+ * Attribute values are skipped rather than matched, so a URI or a text value
+ * containing a colon cannot be mistaken for a namespace prefix.
+ */
+const scanXmlNames = (xml: string, rootTagOnly: boolean): ScannedNames => {
+  const used = new Set<string>();
+  const declared = new Map<string, string>();
+  const length = xml.length;
+  let index = 0;
+
+  while (index < length) {
+    const tagStart = xml.indexOf("<", index);
+    if (tagStart === -1) {
+      break;
+    }
+    index = tagStart + 1;
+
+    if (xml.startsWith("?", index)) {
+      const end = xml.indexOf("?>", index);
+      if (end === -1) {
+        break;
+      }
+      index = end + 2;
+      continue;
+    }
+    if (xml.startsWith("!--", index)) {
+      const end = xml.indexOf("-->", index);
+      if (end === -1) {
+        break;
+      }
+      index = end + 3;
+      continue;
+    }
+    if (xml.startsWith("![CDATA[", index)) {
+      const end = xml.indexOf("]]>", index);
+      if (end === -1) {
+        break;
+      }
+      index = end + 3;
+      continue;
+    }
+    if (xml.startsWith("!", index)) {
+      const end = xml.indexOf(">", index);
+      if (end === -1) {
+        break;
+      }
+      index = end + 1;
+      continue;
+    }
+    if (xml.startsWith("/", index)) {
+      index += 1;
+    }
+
+    const nameStart = index;
+    while (index < length && !isNameBoundary(xml[index] ?? ">")) {
+      index += 1;
+    }
+    const elementPrefix = namePrefix(xml.slice(nameStart, index));
+    if (elementPrefix) {
+      used.add(elementPrefix);
+    }
+
+    while (index < length) {
+      const character = xml[index] ?? ">";
+      if (isWhitespace(character) || character === "/") {
+        index += 1;
+        continue;
+      }
+      if (character === ">") {
+        index += 1;
+        break;
+      }
+
+      const attributeStart = index;
+      while (index < length && !isNameBoundary(xml[index] ?? ">")) {
+        index += 1;
+      }
+      const attributeName = xml.slice(attributeStart, index);
+
+      while (index < length && isWhitespace(xml[index] ?? ">")) {
+        index += 1;
+      }
+      let value = "";
+      if (xml[index] === "=") {
+        index += 1;
+        while (index < length && isWhitespace(xml[index] ?? ">")) {
+          index += 1;
+        }
+        const quote = xml[index];
+        if (quote === '"' || quote === "'") {
+          const valueEnd = xml.indexOf(quote, index + 1);
+          if (valueEnd === -1) {
+            index = length;
+            break;
+          }
+          value = xml.slice(index + 1, valueEnd);
+          index = valueEnd + 1;
+        }
+      }
+
+      if (attributeName.startsWith(XMLNS_ATTRIBUTE_PREFIX)) {
+        declared.set(attributeName.slice(XMLNS_ATTRIBUTE_PREFIX.length), value);
+        continue;
+      }
+      const attributePrefix = namePrefix(attributeName);
+      if (attributePrefix) {
+        used.add(attributePrefix);
+      }
+    }
+
+    if (rootTagOnly) {
+      break;
+    }
+  }
+
+  return { used, declared };
+};
+
+/**
+ * The `xmlns:*` bindings a source part declared on its root element.
+ *
+ * Reused when the part is rebuilt so a producer-specific prefix that
+ * {@link OOXML_NAMESPACES} does not know keeps the URI the document gave it.
+ */
+export const readRootNamespaceBindings = (partXml: string): ReadonlyMap<string, string> =>
+  scanXmlNames(partXml, true).declared;
+
+/** The part a rebuild replaces: where it lives, and what its root element bound. */
+export type SourcePart = {
+  path: string;
+  bindings: ReadonlyMap<string, string>;
+};
+
+export type PartElementOptions = {
+  /** Package-relative path of the part, reported when a prefix is unbound. */
+  partPath: string;
+  /** Qualified name of the root element, for example `w:document`. */
+  rootName: string;
+  /** Root-element attributes other than the namespace declarations. */
+  rootAttributes?: string;
+  /**
+   * Prefixes declared whether or not the body uses them, so the part keeps a
+   * stable shape across saves and unmodeled extensions have somewhere to land.
+   */
+  baselinePrefixes: readonly OoxmlNamespacePrefix[];
+  /** Root bindings of the part being replaced, when the save has the source. */
+  sourceBindings: ReadonlyMap<string, string> | undefined;
+  /** Assembled part content, everything between the root tags. */
+  body: string;
+};
+
+/**
+ * Wrap an assembled part body in a root element that declares every prefix the
+ * part uses and lists the ignorable ones in `mc:Ignorable`.
+ */
+export const serializePartElement = ({
+  partPath,
+  rootName,
+  rootAttributes,
+  baselinePrefixes,
+  sourceBindings,
+  body,
+}: PartElementOptions): string => {
+  const openingTag = `<${rootName}${rootAttributes ? ` ${rootAttributes}` : ""}`;
+  const fromRoot = scanXmlNames(`${openingTag}/>`, true);
+  const { used, declared } = scanXmlNames(body, false);
+  const required = new Set<string>([...fromRoot.used, ...used]);
+
+  const bindings = new Map<string, string>();
+  for (const prefix of baselinePrefixes) {
+    bindings.set(prefix, OOXML_NAMESPACES[prefix].uri);
+  }
+
+  const unbound: string[] = [];
+  for (const prefix of required) {
+    if (bindings.has(prefix)) {
+      continue;
+    }
+    const uri = NAMESPACE_TABLE.get(prefix)?.uri ?? sourceBindings?.get(prefix);
+    if (uri !== undefined) {
+      bindings.set(prefix, uri);
+      continue;
+    }
+    // An inner element may bind the prefix for its own subtree; only a prefix
+    // nothing binds anywhere would be written unbound.
+    if (!declared.has(prefix)) {
+      unbound.push(prefix);
+    }
+  }
+
+  if (unbound.length > 0) {
+    const prefixes = unbound.sort();
+    throw new UnboundNamespacePrefixError({
+      message: `${partPath} uses namespace prefixes bound to no URI: ${prefixes.join(", ")}`,
+      partPath,
+      prefixes,
+    });
+  }
+
+  const hasIgnorable = [...bindings.keys()].some(
+    (prefix) => NAMESPACE_TABLE.get(prefix)?.ignorable === true,
+  );
+  if (hasIgnorable) {
+    // The attribute itself needs the markup-compatibility binding.
+    bindings.set("mc", OOXML_NAMESPACES.mc.uri);
+  }
+
+  // Baseline order first, then the table's order for what the body added, then
+  // source-only prefixes: a part whose body needs nothing extra keeps the exact
+  // declaration list it had before, so an unrelated edit does not rewrite it.
+  const baseline = new Set<string>(baselinePrefixes);
+  const extra = new Set([...bindings.keys()].filter((prefix) => !baseline.has(prefix)));
+  const orderedPrefixes = [
+    ...baselinePrefixes,
+    ...[...NAMESPACE_TABLE.keys()].filter((prefix) => extra.has(prefix)),
+    ...[...extra].filter((prefix) => !NAMESPACE_TABLE.has(prefix)).sort(),
+  ];
+  const attributes = orderedPrefixes.map(
+    // SAFETY: every ordered prefix came from `bindings`.
+    (prefix) => `xmlns:${prefix}="${escapeXml(bindings.get(prefix)!)}"`,
+  );
+  const ignorable = orderedPrefixes.filter(
+    (prefix) => NAMESPACE_TABLE.get(prefix)?.ignorable === true,
+  );
+  if (ignorable.length > 0) {
+    attributes.push(`mc:Ignorable="${ignorable.join(" ")}"`);
+  }
+
+  return `${openingTag} ${attributes.join(" ")}>${body}</${rootName}>`;
+};

--- a/packages/core/src/docx/serializer/settingsSerializer.ts
+++ b/packages/core/src/docx/serializer/settingsSerializer.ts
@@ -1,7 +1,6 @@
 import type { DocumentSettings } from "../../types/document";
+import { serializePartElement } from "./partNamespaces";
 import { escapeXml, intAttr } from "./xmlUtils";
-
-const W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
 
 export const serializeSettingsXml = (settings: DocumentSettings): string => {
   const parts = [`<w:defaultTabStop w:val="${intAttr(settings.defaultTabStop)}"/>`];
@@ -23,5 +22,14 @@ export const serializeSettingsXml = (settings: DocumentSettings): string => {
       parts.push(`<w:themeFontLang ${attrs.join(" ")}/>`);
     }
   }
-  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n<w:settings xmlns:w="${W_NS}">${parts.join("")}</w:settings>`;
+  return (
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n' +
+    serializePartElement({
+      partPath: "word/settings.xml",
+      rootName: "w:settings",
+      baselinePrefixes: ["w"],
+      sourceBindings: undefined,
+      body: parts.join(""),
+    })
+  );
 };

--- a/packages/core/src/docx/serializer/stylesSerializer.ts
+++ b/packages/core/src/docx/serializer/stylesSerializer.ts
@@ -1,4 +1,5 @@
 import type { Style, StyleDefinitions } from "../../types/document";
+import { serializePartElement } from "./partNamespaces";
 import { serializeParagraphFormatting } from "./paragraphSerializer";
 import { serializeTextFormatting } from "./runSerializer";
 import {
@@ -8,13 +9,20 @@ import {
 } from "./tableSerializer";
 import { escapeXml } from "./xmlUtils";
 
-const W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
-
 export const serializeStylesXml = (definitions: StyleDefinitions): string => {
   const docDefaults = serializeDocumentDefaults(definitions);
   const latentStyles = serializeLatentStyles(definitions);
   const styles = definitions.styles.map(serializeStyle).join("");
-  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n<w:styles xmlns:w="${W_NS}">${docDefaults}${latentStyles}${styles}</w:styles>`;
+  return (
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n' +
+    serializePartElement({
+      partPath: "word/styles.xml",
+      rootName: "w:styles",
+      baselinePrefixes: ["w"],
+      sourceBindings: undefined,
+      body: `${docDefaults}${latentStyles}${styles}`,
+    })
+  );
 };
 
 const serializeDocumentDefaults = (definitions: StyleDefinitions): string => {

--- a/packages/core/src/docx/serializer/themeSerializer.ts
+++ b/packages/core/src/docx/serializer/themeSerializer.ts
@@ -1,11 +1,21 @@
 import type { Theme, ThemeColorScheme, ThemeFont } from "../../types/document";
+import { serializePartElement } from "./partNamespaces";
 import { escapeXml } from "./xmlUtils";
-
-const A_NS = "http://schemas.openxmlformats.org/drawingml/2006/main";
 
 export const serializeThemeXml = (theme: Theme): string => {
   const name = escapeXml(theme.name ?? "Folio Theme");
-  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n<a:theme xmlns:a="${A_NS}" name="${name}"><a:themeElements>${serializeColorScheme(theme.colorScheme)}${serializeFontScheme(theme)}${serializeFormatScheme(theme)}</a:themeElements></a:theme>`;
+  const elements = `${serializeColorScheme(theme.colorScheme)}${serializeFontScheme(theme)}${serializeFormatScheme(theme)}`;
+  return (
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n' +
+    serializePartElement({
+      partPath: "word/theme/theme1.xml",
+      rootName: "a:theme",
+      rootAttributes: `name="${name}"`,
+      baselinePrefixes: ["a"],
+      sourceBindings: undefined,
+      body: `<a:themeElements>${elements}</a:themeElements>`,
+    })
+  );
 };
 
 const serializeColorScheme = (colors: ThemeColorScheme | undefined): string => {


### PR DESCRIPTION
## What changed

Every serializer that emits a part root kept its own hand-maintained namespace list and a fixed `mc:Ignorable`. Content the parser preserves verbatim — raw property XML, a text box body, a drawing extension, an unmodeled attribute — can use any prefix its producer bound on the source part's root. A prefix missing from the list was written unbound, which makes the part malformed and the package one a consumer refuses to open.

`serializePartElement` (new, `docx/serializer/partNamespaces.ts`) now owns the root element:

- it scans the assembled part in one quote-aware pass for the prefixes its element and attribute names use (attribute *values* are skipped, so a URI or a colon in text is never mistaken for a prefix);
- it resolves each through `OOXML_NAMESPACES`, one table built on the parser's own URIs (`OOXML_NS`) so the two cannot drift, and total over every prefix the parser resolves;
- for a prefix that table does not know it falls back to the `xmlns:*` the source part declared on its root, read at save time from the package being replaced;
- a prefix that resolves to nothing and is bound nowhere inside the part throws `UnboundNamespacePrefixError` instead of reaching the package;
- `mc:Ignorable` is filtered from the same table, so it names only prefixes the part declares, and every declared extension prefix that a 2006-era consumer must be told to skip is named.

Every part folio rebuilds goes through it: `document.xml`, headers and footers, note parts, `comments.xml`, `commentsExtended.xml`, and the numbering, styles, settings, font-table and theme parts. The three duplicated `buildNamespaceDeclarations()` copies and the five one-off `W_NS`/`A_NS` constants are gone.

Each part keeps its previous baseline declarations in their previous order and gains only what the body needs, so a part whose body needs nothing extra is byte-identical to before; `mc:Ignorable` is the one intended change, since the old fixed strings named a subset of what the roots declared.

## Why

Two defects this reaches, both from the same class:

- a document whose root bound `wne` and whose body carries a text box came back with `wne:txbxContent` unbound in the rebuilt `document.xml`;
- `podily-bps.docx`, a fixture already in this repo, came back with an unbound `w16du:` attribute prefix.

A hand-updated list of prefixes cannot be kept correct by discipline, so the list is derived from the markup and the failure is loud.

## Tests

- `docx/serializer/partNamespaces.test.ts` — the scanner (attribute values, comments, CDATA, processing instructions), source-binding fallback and table precedence, an inner `xmlns` binding accepted, the unbound-prefix error, and `mc:Ignorable` derivation.
- `docx/__tests__/partNamespaceDeclarations.test.ts` — the whole fixture corpus plus three visual fixtures, each parsed, saved, and reopened: every part is walked with the XML parser and must gain no unbound element or attribute prefix and no `mc:Ignorable` entry it does not declare, with defects already present in the fixture subtracted. Plus a text box replayed verbatim under a producer's prefix. Both fail on `main`.
- `bun test src` in `packages/core` is green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DOCX saving so namespace prefixes remain correctly bound across rebuilt document parts.
  * Prevented generated files from containing invalid namespace references that could make them fail to open in compatible applications.
  * Preserved namespace bindings for verbatim content, including text boxes and revision timestamps.
  * Added clearer errors when a required namespace prefix cannot be resolved.

* **Tests**
  * Added round-trip coverage to detect namespace defects across DOCX parts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->