### PR TITLE
test(core): state the true change budget for relocations and table row edits

### DIFF
--- a/.changeset/property-relocation-budget.md
+++ b/.changeset/property-relocation-budget.md
@@ -1,0 +1,6 @@
+---
+---
+
+Test-only: the compare property's change budget now states the true bound for a
+relocation the alignment describes from the neighbour's side. No shipped
+behavior changes.

--- a/packages/core/src/compare/compare.property.test.ts
+++ b/packages/core/src/compare/compare.property.test.ts
@@ -464,12 +464,13 @@ const roundTripScriptArb = (blocks: readonly FolioAIBlock[]): fc.Arbitrary<EditS
 const kindsOf = (changes: readonly CompareChange[]): string[] => changes.map(({ kind }) => kind);
 
 /**
- * The formatting a block carries, one entry per character, so two text-equal
- * blocks compare on what a reader sees rather than on how their runs happen to
- * be split. A block the snapshot gives no runs for is unstyled throughout.
+ * A block's text with the formatting it carries, one entry per character, so
+ * two blocks compare on what a reader sees rather than on how their runs happen
+ * to be split. A block the snapshot gives no runs for is unstyled throughout.
  */
-const characterFormatting = (block: FolioAIBlock): string =>
-  JSON.stringify(
+const blockSignature = (block: FolioAIBlock): string =>
+  JSON.stringify([
+    block.text,
     (block.previewRuns ?? [{ text: block.text }]).flatMap((run) => {
       const formatting = [
         run.bold,
@@ -482,32 +483,43 @@ const characterFormatting = (block: FolioAIBlock): string =>
       ];
       return Array.from(run.text, () => formatting);
     }),
-  );
+  ]);
+
+/** Every block a story holds, as signatures in an order-independent form. */
+const signaturesOf = (blocks: readonly FolioAIBlock[]): string =>
+  blocks.map(blockSignature).toSorted().join("\n");
 
 /**
- * Whether the relocation of `moved` arrived carrying different formatting.
+ * Whether a relocation re-inserted its paragraph carrying different formatting.
  *
  * `moveParagraph` is a deletion plus an insertion of the block's TEXT: the
  * operation vocabulary carries a paragraph's style and list level to the new
- * position but not its direct character formatting, so a styled block arrives
- * plain. Read off the target instead of predicted from the base, because only
- * the arrival separates the formatting the block got from its style (which the
- * re-insertion keeps) from the formatting set on its runs (which it does not).
+ * position but not the formatting set on its runs, so a directly styled block
+ * arrives plain. Only the arrival separates the two, since the style's share
+ * survives the trip, so the step is applied and the result read back.
+ *
+ * Applied ON ITS OWN, and compared as an order-independent whole: a relocation
+ * that carried its formatting leaves the very same paragraphs in a different
+ * order, so any difference at all is formatting the re-insertion dropped. That
+ * needs no guess about which arrival belongs to the step, which matching by
+ * text alone cannot tell when a document repeats a paragraph.
  */
-const relocationDroppedFormatting = (
-  moved: FolioAIBlock,
-  targetBlocks: readonly FolioAIBlock[],
-): boolean => {
-  const before = characterFormatting(moved);
-  return targetBlocks.some(
-    (block) => block.text === moved.text && characterFormatting(block) !== before,
-  );
+const relocationDroppedFormatting = async (
+  base: ArrayBuffer,
+  baseBlocks: readonly FolioAIBlock[],
+  step: Extract<EditScriptStep, { type: "moveParagraph" }>,
+): Promise<boolean> => {
+  const relocated = await applyEditScript(base, [step]);
+  if (relocated.isErr()) {
+    throw relocated.error;
+  }
+  return signaturesOf(await blocksOf(relocated.value.buffer)) !== signaturesOf(baseBlocks);
 };
 
 type TouchedBlockBudgetOptions = {
+  base: ArrayBuffer;
   applied: readonly EditScriptStep[];
   baseBlocks: readonly FolioAIBlock[];
-  targetBlocks: readonly FolioAIBlock[];
 };
 
 /**
@@ -529,43 +541,57 @@ type TouchedBlockBudgetOptions = {
  * so an engine that reports a plain relocation more granularly than that is
  * still caught.
  *
- * A table whose row COUNT changed is budgeted at its whole size. Rows pair on
- * exact text first and positionally after that, so once the counts differ the
+ * A table whose row COUNT changed is budgeted at every cell it holds in the
+ * base, plus one for each row the script added or removed. Rows pair on exact
+ * text first and positionally after that, so once the counts differ the
  * surviving rows can line up one row off and every cell in the table reports as
- * changed. The result still accepts back to the target — that is a separate
- * property — but it is more granular than the script was. Bounding it at one
- * table keeps the real guarantee: the comparison never invents work beyond the
- * content the script disturbed.
+ * changed; the rows left with nothing to pair against are reported whole, one
+ * change each, on top of that. The result still accepts back to the target —
+ * that is a separate property — but it is more granular than the script was.
+ * Bounding it at the table plus its row edits keeps the real guarantee: the
+ * comparison never invents work beyond the content the script disturbed.
+ *
+ * That budget covers the steps that stay inside the table, which is every step
+ * anchored in one of its cells EXCEPT an insertion: no operation places a
+ * paragraph in a cell, so an insertion anchored in one writes its paragraph
+ * beside the table instead. It is a body change wherever it was anchored, so it
+ * is budgeted like any other paragraph step.
  */
-const touchedBlockBudget = ({
+const touchedBlockBudget = async ({
+  base,
   applied,
   baseBlocks,
-  targetBlocks,
-}: TouchedBlockBudgetOptions): number => {
-  const rowCountChanged = new Set(
-    applied.flatMap((step) => {
-      if (step.type !== "insertTableRow" && step.type !== "deleteTableRow") {
-        return [];
-      }
-      const tableIndex = baseBlocks[step.blockIndex]?.table?.tableIndex;
-      return tableIndex === undefined ? [] : [tableIndex];
-    }),
-  );
+}: TouchedBlockBudgetOptions): Promise<number> => {
+  const rowEditsByTable = new Map<number, number>();
+  for (const step of applied) {
+    if (step.type !== "insertTableRow" && step.type !== "deleteTableRow") {
+      continue;
+    }
+    const tableIndex = baseBlocks[step.blockIndex]?.table?.tableIndex;
+    if (tableIndex !== undefined) {
+      rowEditsByTable.set(tableIndex, (rowEditsByTable.get(tableIndex) ?? 0) + 1);
+    }
+  }
   let budget = 0;
-  for (const tableIndex of rowCountChanged) {
-    budget += baseBlocks.filter((block) => block.table?.tableIndex === tableIndex).length;
+  for (const [tableIndex, rowEdits] of rowEditsByTable) {
+    budget +=
+      baseBlocks.filter((block) => block.table?.tableIndex === tableIndex).length + rowEdits;
   }
   for (const step of applied) {
-    const block = baseBlocks[step.blockIndex];
-    const tableIndex = block?.table?.tableIndex;
-    if (tableIndex !== undefined && rowCountChanged.has(tableIndex)) {
+    const tableIndex = baseBlocks[step.blockIndex]?.table?.tableIndex;
+    const staysInsideChangedTable =
+      tableIndex !== undefined &&
+      rowEditsByTable.has(tableIndex) &&
+      step.type !== "insertParagraphAfter";
+    if (staysInsideChangedTable) {
       continue;
     }
     if (step.type !== "moveParagraph") {
       budget += 1;
       continue;
     }
-    budget += block && relocationDroppedFormatting(block, targetBlocks) ? 3 : 2;
+    // oxlint-disable-next-line no-await-in-loop -- each relocation is replayed on its own
+    budget += (await relocationDroppedFormatting(base, baseBlocks, step)) ? 3 : 2;
   }
   return budget;
 };
@@ -690,11 +716,7 @@ describe("compareDocx", () => {
             }
             const { changes } = await compareOrThrow(base, scripted.value.buffer);
             expect(changes.length).toBeLessThanOrEqual(
-              touchedBlockBudget({
-                applied: scripted.value.applied,
-                baseBlocks,
-                targetBlocks: await blocksOf(scripted.value.buffer),
-              }),
+              await touchedBlockBudget({ base, applied: scripted.value.applied, baseBlocks }),
             );
           }),
           propertyConfig({ numRuns: 12 }),
@@ -742,10 +764,51 @@ describe("compareDocx", () => {
     // the direct formatting its plain re-insertion could not carry.
     const base = readFixture("upstream-styled-content.docx");
     const baseBlocks = await blocksOf(base);
+    const move = { type: "moveParagraph", blockIndex: 1, beforeBlockIndex: 4 } as const;
+    const script: EditScript = [{ type: "deleteParagraph", blockIndex: 2 }, move];
+
+    // The scenario reads the fixture by index, so pin the shape it relies on:
+    // the relocated paragraph carries direct formatting, and it swaps past
+    // exactly one surviving neighbour.
+    expect(baseBlocks.map(({ text }) => text)).toEqual([
+      "Normal text. Bold text. Italic text. Underlined text.",
+      "Bold and italic text. Strikethrough text.",
+      "Large text (18pt). Small text (8pt).",
+      "Centered paragraph.",
+      "Right-aligned paragraph.",
+    ]);
+    expect(await relocationDroppedFormatting(base, baseBlocks, move)).toBe(true);
+
+    const scripted = await applyEditScript(base, script);
+    if (scripted.isErr()) {
+      throw scripted.error;
+    }
+    expect(scripted.value.unresolved).toEqual([]);
+
+    const { changes } = await compareOrThrow(base, scripted.value.buffer);
+    expect(kindsOf(changes).toSorted()).toEqual(["delete", "delete", "format", "insert"]);
+    expect(changes.length).toBe(
+      await touchedBlockBudget({ base, applied: scripted.value.applied, baseBlocks }),
+    );
+  });
+
+  test("a paragraph inserted on a cell anchor lands beside the table it grew", async () => {
+    // The second counterexample the change-count property found. An insertion
+    // anchored in a cell writes its paragraph beside the table, so a script that
+    // also changes that table's row count produces body changes the table's own
+    // budget does not cover.
+    const base = readFixture("upstream-with-tables.docx");
+    const baseBlocks = await blocksOf(base);
     const script: EditScript = [
-      { type: "deleteParagraph", blockIndex: 2 },
-      { type: "moveParagraph", blockIndex: 1, beforeBlockIndex: 4 },
+      { type: "insertParagraphAfter", blockIndex: 3, text: "Anchored in the third cell." },
+      { type: "insertParagraphAfter", blockIndex: 4, text: "Anchored in the fourth cell." },
+      { type: "insertTableRow", blockIndex: 1, cellTexts: ["one", "two", "three"] },
+      { type: "insertTableRow", blockIndex: 2, cellTexts: ["four", "five", "six"] },
     ];
+
+    // The scenario reads the fixture by index, so pin the shape it relies on:
+    // blocks 1 to 4 are cells of one table with three columns.
+    expect(baseBlocks.slice(1, 5).map(({ table }) => table?.tableIndex)).toEqual([0, 0, 0, 0]);
 
     const scripted = await applyEditScript(base, script);
     if (scripted.isErr()) {
@@ -754,16 +817,48 @@ describe("compareDocx", () => {
     expect(scripted.value.unresolved).toEqual([]);
 
     const targetBlocks = await blocksOf(scripted.value.buffer);
-    const moved = baseBlocks[1];
-    if (!moved) {
-      throw new Error("The styled fixture no longer holds the block this scenario relocates.");
-    }
-    expect(relocationDroppedFormatting(moved, targetBlocks)).toBe(true);
+    expect(targetBlocks.filter(({ table }) => table === undefined).map(({ text }) => text)).toEqual(
+      [
+        "Document with tables:",
+        "Anchored in the third cell.",
+        "Anchored in the fourth cell.",
+        "End of document.",
+      ],
+    );
 
     const { changes } = await compareOrThrow(base, scripted.value.buffer);
-    expect(kindsOf(changes).toSorted()).toEqual(["delete", "delete", "format", "insert"]);
-    expect(changes.length).toBe(
-      touchedBlockBudget({ applied: scripted.value.applied, baseBlocks, targetBlocks }),
+    expect(kindsOf(changes).filter((kind) => kind === "insert")).toHaveLength(2);
+    expect(changes.length).toBeLessThanOrEqual(
+      await touchedBlockBudget({ base, applied: scripted.value.applied, baseBlocks }),
+    );
+  });
+
+  test("added rows are reported on top of the cells that report as changed", async () => {
+    // The third counterexample the change-count property found. Rows added past
+    // the count the base table holds have nothing to pair against, so each is
+    // reported whole, over and above the cells that report as changed. A table's
+    // own size does not bound that.
+    const base = readFixture("upstream-with-tables.docx");
+    const baseBlocks = await blocksOf(base);
+    const cells = baseBlocks.filter(({ table }) => table?.tableIndex === 0);
+    const script: EditScript = [
+      { type: "insertTableRow", blockIndex: 1, cellTexts: ["one", "two", "three"] },
+      { type: "insertTableRow", blockIndex: 3, cellTexts: ["four", "five", "six"] },
+      { type: "insertTableRow", blockIndex: 7, cellTexts: ["seven", "eight", "nine"] },
+      { type: "insertTableRow", blockIndex: 9, cellTexts: ["ten", "eleven", "twelve"] },
+    ];
+
+    const scripted = await applyEditScript(base, script);
+    if (scripted.isErr()) {
+      throw scripted.error;
+    }
+    expect(scripted.value.unresolved).toEqual([]);
+
+    const { changes } = await compareOrThrow(base, scripted.value.buffer);
+    expect(kindsOf(changes).filter((kind) => kind === "table-row-insert")).toHaveLength(4);
+    expect(changes.length).toBeGreaterThan(cells.length);
+    expect(changes.length).toBeLessThanOrEqual(
+      await touchedBlockBudget({ base, applied: scripted.value.applied, baseBlocks }),
     );
   });
 

--- a/packages/core/src/compare/compare.property.test.ts
+++ b/packages/core/src/compare/compare.property.test.ts
@@ -464,11 +464,70 @@ const roundTripScriptArb = (blocks: readonly FolioAIBlock[]): fc.Arbitrary<EditS
 const kindsOf = (changes: readonly CompareChange[]): string[] => changes.map(({ kind }) => kind);
 
 /**
+ * The formatting a block carries, one entry per character, so two text-equal
+ * blocks compare on what a reader sees rather than on how their runs happen to
+ * be split. A block the snapshot gives no runs for is unstyled throughout.
+ */
+const characterFormatting = (block: FolioAIBlock): string =>
+  JSON.stringify(
+    (block.previewRuns ?? [{ text: block.text }]).flatMap((run) => {
+      const formatting = [
+        run.bold,
+        run.italic,
+        run.underline,
+        run.strike,
+        run.fontFamily,
+        run.fontSizePt,
+        run.color,
+      ];
+      return Array.from(run.text, () => formatting);
+    }),
+  );
+
+/**
+ * Whether the relocation of `moved` arrived carrying different formatting.
+ *
+ * `moveParagraph` is a deletion plus an insertion of the block's TEXT: the
+ * operation vocabulary carries a paragraph's style and list level to the new
+ * position but not its direct character formatting, so a styled block arrives
+ * plain. Read off the target instead of predicted from the base, because only
+ * the arrival separates the formatting the block got from its style (which the
+ * re-insertion keeps) from the formatting set on its runs (which it does not).
+ */
+const relocationDroppedFormatting = (
+  moved: FolioAIBlock,
+  targetBlocks: readonly FolioAIBlock[],
+): boolean => {
+  const before = characterFormatting(moved);
+  return targetBlocks.some(
+    (block) => block.text === moved.text && characterFormatting(block) !== before,
+  );
+};
+
+type TouchedBlockBudgetOptions = {
+  applied: readonly EditScriptStep[];
+  baseBlocks: readonly FolioAIBlock[];
+  targetBlocks: readonly FolioAIBlock[];
+};
+
+/**
  * Changes one script may legitimately produce.
  *
  * A paragraph step touches one block. A relocation touches two, and is
  * reported as two when the move pass declines to pair it (its text is below
  * the word floor, or it landed where the alignment can still walk forward).
+ *
+ * A relocation that also dropped the block's formatting is budgeted at three,
+ * because it made two differences and the alignment picks which one it names.
+ * Swapping a block past a SINGLE neighbour reads equally well from either side
+ * ("this one moved down" and "that one moved up" match the same number of
+ * blocks), and the alignment breaks that tie by position, not by which side the
+ * script meant. When it relocates the neighbour, the moved block pairs where it
+ * always was and reports the formatting its plain re-insertion lost, on top of
+ * the neighbour's two ends. Both readings accept back to the target; this one
+ * costs one change more. A move that kept its formatting stays budgeted at two,
+ * so an engine that reports a plain relocation more granularly than that is
+ * still caught.
  *
  * A table whose row COUNT changed is budgeted at its whole size. Rows pair on
  * exact text first and positionally after that, so once the counts differ the
@@ -478,29 +537,35 @@ const kindsOf = (changes: readonly CompareChange[]): string[] => changes.map(({ 
  * table keeps the real guarantee: the comparison never invents work beyond the
  * content the script disturbed.
  */
-const touchedBlockBudget = (
-  applied: readonly EditScriptStep[],
-  blocks: readonly FolioAIBlock[],
-): number => {
+const touchedBlockBudget = ({
+  applied,
+  baseBlocks,
+  targetBlocks,
+}: TouchedBlockBudgetOptions): number => {
   const rowCountChanged = new Set(
     applied.flatMap((step) => {
       if (step.type !== "insertTableRow" && step.type !== "deleteTableRow") {
         return [];
       }
-      const tableIndex = blocks[step.blockIndex]?.table?.tableIndex;
+      const tableIndex = baseBlocks[step.blockIndex]?.table?.tableIndex;
       return tableIndex === undefined ? [] : [tableIndex];
     }),
   );
   let budget = 0;
   for (const tableIndex of rowCountChanged) {
-    budget += blocks.filter((block) => block.table?.tableIndex === tableIndex).length;
+    budget += baseBlocks.filter((block) => block.table?.tableIndex === tableIndex).length;
   }
   for (const step of applied) {
-    const tableIndex = blocks[step.blockIndex]?.table?.tableIndex;
+    const block = baseBlocks[step.blockIndex];
+    const tableIndex = block?.table?.tableIndex;
     if (tableIndex !== undefined && rowCountChanged.has(tableIndex)) {
       continue;
     }
-    budget += step.type === "moveParagraph" ? 2 : 1;
+    if (step.type !== "moveParagraph") {
+      budget += 1;
+      continue;
+    }
+    budget += block && relocationDroppedFormatting(block, targetBlocks) ? 3 : 2;
   }
   return budget;
 };
@@ -625,7 +690,11 @@ describe("compareDocx", () => {
             }
             const { changes } = await compareOrThrow(base, scripted.value.buffer);
             expect(changes.length).toBeLessThanOrEqual(
-              touchedBlockBudget(scripted.value.applied, baseBlocks),
+              touchedBlockBudget({
+                applied: scripted.value.applied,
+                baseBlocks,
+                targetBlocks: await blocksOf(scripted.value.buffer),
+              }),
             );
           }),
           propertyConfig({ numRuns: 12 }),
@@ -663,6 +732,40 @@ describe("compareDocx", () => {
       );
     }
   }
+
+  test("a relocation past one neighbour may be reported from the neighbour's side", async () => {
+    // The counterexample the change-count property found. Pinned so the shape
+    // is covered on every run rather than on the draw that happens to reach it:
+    // the styled paragraph swaps past exactly one neighbour, so both readings
+    // of the swap match the same number of blocks, and the alignment names the
+    // neighbour. The moved paragraph then pairs where it always was and reports
+    // the direct formatting its plain re-insertion could not carry.
+    const base = readFixture("upstream-styled-content.docx");
+    const baseBlocks = await blocksOf(base);
+    const script: EditScript = [
+      { type: "deleteParagraph", blockIndex: 2 },
+      { type: "moveParagraph", blockIndex: 1, beforeBlockIndex: 4 },
+    ];
+
+    const scripted = await applyEditScript(base, script);
+    if (scripted.isErr()) {
+      throw scripted.error;
+    }
+    expect(scripted.value.unresolved).toEqual([]);
+
+    const targetBlocks = await blocksOf(scripted.value.buffer);
+    const moved = baseBlocks[1];
+    if (!moved) {
+      throw new Error("The styled fixture no longer holds the block this scenario relocates.");
+    }
+    expect(relocationDroppedFormatting(moved, targetBlocks)).toBe(true);
+
+    const { changes } = await compareOrThrow(base, scripted.value.buffer);
+    expect(kindsOf(changes).toSorted()).toEqual(["delete", "delete", "format", "insert"]);
+    expect(changes.length).toBe(
+      touchedBlockBudget({ applied: scripted.value.applied, baseBlocks, targetBlocks }),
+    );
+  });
 
   for (const { name, buffer: base, blocks: baseBlocks } of BASE_CASES) {
     test(


### PR DESCRIPTION
The compare property `the change count never exceeds the blocks the script touched` is seed-dependent. It fails at run 1664 of a 12,000-run sweep on the `upstream-styled-content.docx` base, with 4 changes against a budget of 3:

```
{ seed: -405248958, path: "1663:1:5" }
[
  { "type": "deleteParagraph", "blockIndex": 2 },
  { "type": "moveParagraph", "blockIndex": 1, "beforeBlockIndex": 4 }
]
```

Chasing it down turned up three shapes the budget got wrong. Every change the engine reported in each of them names a block the script disturbed, so the arithmetic was what was wrong, not the comparison.

## 1. A relocation the alignment describes from the other side

Base and target for the script above:

| | base | target |
| --- | --- | --- |
| 0 | Normal text. Bold text. … | Normal text. Bold text. … |
| 1 | **Bold and italic text.** ~~Strikethrough text.~~ | Centered paragraph. |
| 2 | Large text (18pt). Small text (8pt). | Bold and italic text. Strikethrough text. |
| 3 | Centered paragraph. | Right-aligned paragraph. |
| 4 | Right-aligned paragraph. | |

Four changes come back: `insert` and `delete` of "Centered paragraph.", a `format` change on "Bold and italic text. Strikethrough text.", and the scripted `delete` of "Large text (18pt). Small text (8pt).".

`moveParagraph` is a deletion plus an insertion of the block's TEXT. The operation vocabulary carries a paragraph's style and list level to the new position but not the formatting set on its runs, so a directly styled block arrives plain. The step therefore makes two differences, not one: the position and the formatting.

The position change is symmetric. The moved paragraph swaps past exactly one neighbour, so "this one moved down" and "that one moved up" match the same number of blocks; the alignment breaks that tie by position, not by which side the script meant, and it names the neighbour. The moved paragraph then pairs where it always stood, and the formatting its plain re-insertion lost reports on top of the neighbour's two ends.

A relocation whose re-insertion dropped formatting is now budgeted at three. Whether it dropped anything is decided by applying the step ON ITS OWN and comparing the result with the base as an order-independent whole: a relocation that carried its formatting leaves the very same paragraphs in a different order, so any difference at all is formatting the re-insertion could not carry. Nothing is matched by text, so repeated paragraphs cannot answer for the wrong arrival. A relocation that kept its formatting stays budgeted at two, so a plain move reported more granularly than delete plus insert is still caught.

## 2. An insertion anchored in a table cell

No operation places a paragraph in a cell, so an insertion anchored in one writes its paragraph beside the table. The budget treated every step anchored in a row-count-changed table as covered by that table's own budget, so those body insertions cost nothing:

```
[
  { "type": "insertParagraphAfter", "blockIndex": 3, "text": "…" },
  { "type": "insertParagraphAfter", "blockIndex": 4, "text": "…" },
  { "type": "insertTableRow", "blockIndex": 1, "cellTexts": ["…", "…", "…"] },
  { "type": "insertTableRow", "blockIndex": 2, "cellTexts": ["…", "…", "…"] }
]
```

10 changes against a budget of 9: six cell replaces and two row insertions inside the table, plus the two body paragraphs. Only the steps that stay inside the table are covered by the table's budget now.

## 3. Rows added past the base table's size

```
[
  { "type": "insertTableRow", "blockIndex": 1, "cellTexts": ["…", "…", "…"] },
  { "type": "insertTableRow", "blockIndex": 3, "cellTexts": ["…", "…", "…"] },
  { "type": "insertTableRow", "blockIndex": 7, "cellTexts": ["…", "…", "…"] },
  { "type": "insertTableRow", "blockIndex": 9, "cellTexts": ["…", "…", "…"] }
]
```

Four rows added to a three-row, nine-cell table: 10 changes (six cell replaces plus four row insertions) against a budget of 9. Rows pair on exact text first and positionally after that, so the rows left over have nothing to pair against and are each reported whole, over and above the cells that report as changed. A table whose row count changed is now budgeted at its cells plus one for each row the script added or removed.

## Regression scenarios

All three counterexamples are pinned as their own scenarios beside the property, so each shape is covered on every run instead of on the draw that reaches it. The relocation one asserts the exact change kinds and that the count equals the budget, so that case stays tight rather than merely under a ceiling.

## Validation

- 96,000 runs of the property across the four base documents (`PROPERTY_TEST_NUM_RUNS_FACTOR=2000`), plus 150,000 runs against the tables base and 100,000 against the complex-styles base through a seed-looping harness. Before the change each of the three shapes fails within that budget.
- `bun test src/compare/compare.property.test.ts` passes.

Test-only; no shipped behavior changes, so the changeset is empty.

## `redline.test.ts` does not share this

The operation-limit cases in `packages/core/src/redline.test.ts` are not property tests: the file uses no fast-check, and the two limit cases build a fixed 10,000 and 10,001 paragraphs. Locally they run in 7.7 s and 0.6 s against a 60 s per-test budget, and eight consecutive runs of the file passed. Nothing seed-dependent to reproduce there; if that file flakes it is the wall-clock budget under load, not an input.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated comparison property tests to account for formatting changes when blocks are relocated.
  - Added coverage for relocation reporting from a neighbouring block’s perspective.
  - Corrected expected change budgets for relocations where formatting is not retained and for table row edits.
  - Added coverage for cell-anchored insertions beside tables and row additions alongside changed cells.

- **Documentation**
  - Documented the corrected change budget for the comparison property test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->