### PR TITLE
fix(core): preserve watermark host clearance

### DIFF
--- a/.changeset/calm-watermark-clearance.md
+++ b/.changeset/calm-watermark-clearance.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve watermark hosting paragraphs when they contribute header clearance.

--- a/packages/core/src/docx/headerFooterParser-watermark.test.ts
+++ b/packages/core/src/docx/headerFooterParser-watermark.test.ts
@@ -455,6 +455,31 @@ describe("parseHeader watermark detection", () => {
     expect(header.watermarkBlockIndex).toBe(1);
   });
 
+  test("retains the empty watermark host paragraph for header flow", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:hdr ${NS}>
+  <w:p>
+    <w:pPr><w:pStyle w:val="Header"/></w:pPr>
+    <w:r>
+      <w:pict>
+        <v:shape id="PowerPlusWaterMarkObject1" type="#_x0000_t136">
+          <v:textpath string="DRAFT"/>
+        </v:shape>
+      </w:pict>
+    </w:r>
+  </w:p>
+</w:hdr>`;
+    const header = parseHeader(xml);
+    const host = header.content.at(0);
+
+    expect(host?.type).toBe("paragraph");
+    if (host?.type !== "paragraph") {
+      return;
+    }
+    expect(host.formatting?.styleId).toBe("Header");
+    expect(host.content).toEqual([]);
+  });
+
   test("treats `w:t` consistently even when WordprocessingML is bound to a foreign prefix", () => {
     // Producers occasionally bind WordprocessingML as a non-`w` prefix
     // (the spec allows any prefix). The mixed-paragraph guard now

--- a/packages/core/src/docx/headerFooterParser.ts
+++ b/packages/core/src/docx/headerFooterParser.ts
@@ -119,10 +119,10 @@ export function parseHeader(
     return result;
   }
 
-  // Watermark detection runs first so the hosting paragraph can be
-  // excluded from regular body parsing — otherwise the parser would
-  // emit an empty paragraph placeholder where the watermark sat (the
-  // run-level VML / DrawingML is not surfaced by `runParser`).
+  // Watermark detection runs independently from regular block parsing. The
+  // run-level VML / DrawingML is owned by `watermarkParser`, while its hosting
+  // paragraph still participates in header flow. Keep that empty, formatted
+  // paragraph so its line box can clear a body margin that overlaps the header.
   const watermarkResult = parseWatermark(rootElement);
   if (watermarkResult) {
     result.watermark = watermarkResult.watermark;
@@ -132,32 +132,23 @@ export function parseHeader(
     // anchored to a stable, package-absolute path by parseHeadersAndFooters,
     // which knows this header part's own path.
   }
-  const contentRoot = watermarkResult
-    ? withoutChild(rootElement, watermarkResult.hostingParagraph)
-    : rootElement;
-
-  result.content = parseBlockContent(contentRoot, styles, theme, numbering, rels, media, {
+  result.content = parseBlockContent(rootElement, styles, theme, numbering, rels, media, {
     inHeaderFooter: true,
     rootXmlns: collectXmlnsDeclarations(rootElement),
   });
+  if (watermarkResult) {
+    const host = result.content.at(watermarkResult.blockIndex);
+    if (host?.type === "paragraph") {
+      // The modeled watermark paints the detached VML / DrawingML. Retain only
+      // the host paragraph's formatting here so header flow keeps its line box
+      // without painting the same artwork a second time.
+      result.content[watermarkResult.blockIndex] = { ...host, content: [] };
+    }
+  }
 
   assignHeaderFooterVerbatimXml(result, headerXml);
 
   return result;
-}
-
-/**
- * Return a shallow copy of `parent` whose `elements` array omits the
- * single child reference `child`. Used to skip the watermark paragraph
- * when feeding the header into `parseBlockContent` — without this the
- * body parser would emit an empty placeholder paragraph where the
- * watermark sits in the source.
- */
-function withoutChild(parent: XmlElement, child: XmlElement): XmlElement {
-  return {
-    ...parent,
-    elements: (parent.elements ?? []).filter((el) => el !== child),
-  };
 }
 
 /**

--- a/packages/core/src/docx/serializer/headerFooterSerializer-watermark.test.ts
+++ b/packages/core/src/docx/serializer/headerFooterSerializer-watermark.test.ts
@@ -13,6 +13,7 @@ import { describe, expect, test } from "bun:test";
 
 import type { HeaderFooter } from "../../types/document";
 import { parseHeader } from "../headerFooterParser";
+import { clearHeaderFooterVerbatimXml } from "../headerFooterVerbatim";
 import { serializeHeaderFooter } from "./headerFooterSerializer";
 
 const NS =
@@ -214,8 +215,8 @@ describe("serializeHeaderFooter — watermark replay", () => {
   });
 
   test("does not duplicate the watermark paragraph in the regular content stream", () => {
-    // Regression for the parser-side filtering: the watermark paragraph
-    // is detached from `content` so it isn't emitted twice.
+    // The parser retains the host for layout. Exercise structural serialization
+    // to prove raw replay replaces that placeholder instead of duplicating it.
     const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <w:hdr ${NS}>
   <w:p>
@@ -229,9 +230,75 @@ describe("serializeHeaderFooter — watermark replay", () => {
   </w:p>
 </w:hdr>`;
     const header = parseHeader(sourceXml);
+    expect(header.content).toHaveLength(1);
+    clearHeaderFooterVerbatimXml(header);
     const out = serializeHeaderFooter(header);
     // Watermark shape appears exactly once.
     expect(out.match(/<v:shape/gu)?.length).toBe(1);
     expect(out.match(/string="CONFIDENTIAL"/gu)?.length).toBe(1);
+  });
+
+  test("preserves edited host formatting during structural watermark serialization", () => {
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:hdr ${NS}>
+  <w:p>
+    <w:pPr><w:pStyle w:val="Header"/></w:pPr>
+    <w:r>
+      <w:pict>
+        <v:shape id="PowerPlusWaterMarkObject1" type="#_x0000_t136">
+          <v:textpath string="DRAFT"/>
+        </v:shape>
+      </w:pict>
+    </w:r>
+  </w:p>
+</w:hdr>`;
+    const header = parseHeader(sourceXml);
+    const host = header.content.at(0);
+    expect(host?.type).toBe("paragraph");
+    if (host?.type !== "paragraph") {
+      return;
+    }
+    host.formatting = { ...host.formatting, styleId: "ChangedHeader" };
+    clearHeaderFooterVerbatimXml(header);
+
+    const out = serializeHeaderFooter(header);
+
+    expect(out).toContain('<w:pStyle w:val="ChangedHeader"/>');
+    expect(out.match(/<v:shape/gu)?.length).toBe(1);
+    expect(out.match(/<w:p(?=[\s>])/gu)?.length).toBe(1);
+  });
+
+  test("keeps watermark position after a block content control", () => {
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:hdr ${NS}>
+  <w:sdt>
+    <w:sdtPr><w:tag w:val="prefix"/></w:sdtPr>
+    <w:sdtContent><w:p><w:r><w:t>preceding</w:t></w:r></w:p></w:sdtContent>
+  </w:sdt>
+  <w:p>
+    <w:r>
+      <w:pict>
+        <v:shape id="PowerPlusWaterMarkObject1" type="#_x0000_t136">
+          <v:textpath string="DRAFT"/>
+        </v:shape>
+      </w:pict>
+    </w:r>
+  </w:p>
+  <w:p><w:r><w:t>following</w:t></w:r></w:p>
+</w:hdr>`;
+    const header = parseHeader(sourceXml);
+    expect(header.content.map(({ type }) => type)).toEqual(["blockSdt", "paragraph", "paragraph"]);
+    expect(header.watermarkBlockIndex).toBe(1);
+    clearHeaderFooterVerbatimXml(header);
+
+    const out = serializeHeaderFooter(header);
+    const precedingPosition = out.indexOf("preceding");
+    const watermarkPosition = out.indexOf('string="DRAFT"');
+    const followingPosition = out.indexOf("following");
+
+    expect(precedingPosition).toBeGreaterThan(-1);
+    expect(watermarkPosition).toBeGreaterThan(precedingPosition);
+    expect(followingPosition).toBeGreaterThan(watermarkPosition);
+    expect(out.match(/<v:shape/gu)?.length).toBe(1);
   });
 });

--- a/packages/core/src/docx/serializer/headerFooterSerializer.ts
+++ b/packages/core/src/docx/serializer/headerFooterSerializer.ts
@@ -12,6 +12,9 @@
 
 import type { BlockContent, HeaderFooter, Watermark } from "../../types/document";
 import { getHeaderFooterVerbatimXml, canReplayHeaderFooterVerbatim } from "../headerFooterVerbatim";
+import { isEmptyParagraph } from "../paragraphParser";
+import { captureVerbatimXml } from "../verbatimCapture";
+import { getLocalName, parseXmlDocument } from "../xmlParser";
 import { serializeBlockSdt } from "./blockSdtSerializer";
 import { serializePartElement, type OoxmlNamespacePrefix, type SourcePart } from "./partNamespaces";
 import { serializeParagraph } from "./paragraphSerializer";
@@ -79,13 +82,12 @@ export function serializeHeaderFooter(hf: HeaderFooter, source?: SourcePart): st
 
   const rootTag = hf.type === "header" ? "w:hdr" : "w:ftr";
 
-  // Watermark replay. The parser captured the hosting paragraph's
-  // verbatim XML (`rawWatermarkXml`) and detached it from `content`,
-  // so emit it back at its original block position (tracked in
-  // `watermarkBlockIndex`). If a caller mutated `hf.watermark` without
-  // updating the raw XML (e.g. the setDocumentWatermark path), the
-  // model-driven synthesizer takes over and emits a freshly-built VML
-  // watermark paragraph at the top of the header.
+  // Watermark replay. The parser retains the empty hosting paragraph in
+  // `content` so its formatting participates in header layout. Merge the
+  // captured watermark run into that modeled paragraph so structural saves
+  // preserve later formatting edits without emitting a second host line. If
+  // the host acquired visible content, preserve it and insert the captured
+  // paragraph beside it. Model-driven watermarks keep insertion semantics.
   const watermarkXml = serializeWatermarkParagraph(hf);
   const watermarkInsertIndex =
     hf.watermarkBlockIndex !== undefined
@@ -95,9 +97,21 @@ export function serializeHeaderFooter(hf: HeaderFooter, source?: SourcePart): st
   const blocksXml = hf.content.map((block) => serializeBlock(block));
   let contentXml: string;
   if (watermarkXml) {
+    const watermarkHost = hf.content.at(watermarkInsertIndex);
+    const rawWatermarkXml = hf.rawWatermarkXml;
+    const mergesIntoRetainedHost =
+      rawWatermarkXml !== undefined &&
+      watermarkHost?.type === "paragraph" &&
+      isEmptyParagraph(watermarkHost);
+    if (mergesIntoRetainedHost) {
+      blocksXml[watermarkInsertIndex] = serializeRawWatermarkIntoHost({
+        hostXml: blocksXml[watermarkInsertIndex] ?? serializeParagraph(watermarkHost),
+        rawWatermarkXml,
+      });
+    }
     contentXml =
       blocksXml.slice(0, watermarkInsertIndex).join("") +
-      watermarkXml +
+      (mergesIntoRetainedHost ? "" : watermarkXml) +
       blocksXml.slice(watermarkInsertIndex).join("");
   } else {
     contentXml = blocksXml.join("");
@@ -118,6 +132,38 @@ export function serializeHeaderFooter(hf: HeaderFooter, source?: SourcePart): st
       body: contentXml,
     })
   );
+}
+
+type SerializeRawWatermarkIntoHostOptions = {
+  hostXml: string;
+  rawWatermarkXml: string;
+};
+
+function serializeRawWatermarkIntoHost({
+  hostXml,
+  rawWatermarkXml,
+}: SerializeRawWatermarkIntoHostOptions): string {
+  const rawHost = parseXmlDocument(rawWatermarkXml);
+  if (!rawHost || getLocalName(rawHost.name ?? "") !== "p") {
+    return rawWatermarkXml;
+  }
+
+  const watermarkContent = (rawHost.elements ?? [])
+    .filter((child) => child.type === "element" && getLocalName(child.name ?? "") !== "pPr")
+    .map((child) => captureVerbatimXml(child))
+    .join("");
+  if (!watermarkContent) {
+    return rawWatermarkXml;
+  }
+
+  const namespaceAttributes = Object.entries(rawHost.attributes ?? {})
+    .filter(
+      ([name, value]) => value !== undefined && (name === "xmlns" || name.startsWith("xmlns:")),
+    )
+    .map(([name, value]) => ` ${name}="${escapeXml(String(value))}"`)
+    .join("");
+  const namespacedHost = hostXml.replace(/^<w:p(?=[\s>])/u, `<w:p${namespaceAttributes}`);
+  return namespacedHost.replace("</w:p>", `${watermarkContent}</w:p>`);
 }
 
 function serializeWatermarkParagraph(hf: HeaderFooter): string {

--- a/packages/core/src/docx/watermarkParser.ts
+++ b/packages/core/src/docx/watermarkParser.ts
@@ -47,10 +47,8 @@ export type ParsedWatermark = {
   hostingParagraph: XmlElement;
   /**
    * Index where the watermark paragraph sat among block-level siblings
-   * (`w:p` / `w:tbl`) in the source header. After the host paragraph is
-   * filtered out of `content`, the serializer inserts the watermark
-   * back at this index so a header that originally placed the
-   * watermark after visible text rounds-trips with the same flow.
+   * (`w:p` / `w:tbl` / `w:sdt`) in the source header. The serializer uses
+   * this index to replace the retained host paragraph with watermark XML.
    */
   blockIndex: number;
 };
@@ -125,11 +123,9 @@ export function parseWatermark(header: XmlElement): ParsedWatermark | undefined 
 }
 
 /**
- * Index of `target` among block-level children of `header` (only
- * `w:p` and `w:tbl` count as blocks). Since the hosting paragraph
- * is filtered out of `content` after parse, this is the index the
- * serializer needs to splice the watermark XML back into so the
- * header rounds-trips with the same flow as the source.
+ * Index of `target` among block-level children of `header`. Keep this list
+ * aligned with `parseBlockContent`, which emits paragraphs, tables, and
+ * block-level content controls as one content item each.
  */
 function blockIndexOf(header: XmlElement, target: XmlElement): number {
   let blockIdx = 0;
@@ -141,7 +137,7 @@ function blockIndexOf(header: XmlElement, target: XmlElement): number {
       continue;
     }
     const local = getLocalName(child.name ?? "");
-    if (local === "p" || local === "tbl") {
+    if (local === "p" || local === "tbl" || local === "sdt") {
       blockIdx++;
     }
   }

--- a/packages/core/src/layout-bridge/convert/headerFooterLayout.test.ts
+++ b/packages/core/src/layout-bridge/convert/headerFooterLayout.test.ts
@@ -852,6 +852,17 @@ describe("header/footer layout conversion", () => {
     expect(bounds).toEqual({ top: 0, bottom: 0 });
   });
 
+  test("keeps a styled watermark host line in body margin clearance", () => {
+    const bounds = calculateHeaderFooterMarginPushBounds(
+      [emptyParagraph({ id: "watermark-host", attrs: { styleId: "Header" } })],
+      [{ kind: "paragraph", lines: [], totalHeight: 12 }],
+      12,
+      metrics,
+    );
+
+    expect(bounds).toEqual({ top: 0, bottom: 12 });
+  });
+
   test("keeps a tab-only story out of body margin clearance", () => {
     const bounds = calculateHeaderFooterMarginPushBounds(
       [paragraph({ id: "tab-only-story", runs: [{ kind: "tab" }] })],
@@ -1004,5 +1015,30 @@ describe("convertHeaderFooterPmDocToContent", () => {
     if (trailing?.kind === "paragraph") {
       expect(trailing.totalHeight).toBe(0);
     }
+  });
+
+  test("preserves styled empty header clearance on direct and PM-doc paths", () => {
+    const hf: HeaderFooter = {
+      type: "header",
+      hdrFtrType: "default",
+      content: [
+        {
+          type: "paragraph",
+          content: [],
+          formatting: { styleId: "Header" },
+        },
+      ],
+    };
+
+    const fromContent = convertHeaderFooterToContent(hf, 456, pmMetrics, {
+      measureBlocks,
+    });
+    const pmDoc = headerFooterToProseDoc(hf.content);
+    const fromPmDoc = convertHeaderFooterPmDocToContent(pmDoc, 456, pmMetrics, {
+      measureBlocks,
+    });
+
+    expect(fromContent?.marginPushBottom).toBe(12);
+    expect(fromPmDoc?.marginPushBottom).toBe(12);
   });
 });

--- a/packages/core/src/layout-bridge/convert/headerFooterLayout.ts
+++ b/packages/core/src/layout-bridge/convert/headerFooterLayout.ts
@@ -558,7 +558,12 @@ export function calculateHeaderFooterMarginPushBounds(
 ): { top: number; bottom: number } {
   const isPaintlessStory =
     blocks.length > 0 &&
-    blocks.every((block) => isPaintlessParagraph(block) && !hasAuthoredVisualContent(block));
+    blocks.every(
+      (block) =>
+        isPaintlessParagraph(block) &&
+        !hasAuthoredVisualContent(block) &&
+        !(block.kind === "paragraph" && preservesInheritedSpacing(block)),
+    );
   if (isPaintlessStory) {
     return { top: 0, bottom: 0 };
   }

--- a/packages/core/src/watermark/index.test.ts
+++ b/packages/core/src/watermark/index.test.ts
@@ -99,6 +99,31 @@ describe("setDocumentWatermark", () => {
     expect(header?.rawWatermarkXml).toBeUndefined();
   });
 
+  test.each([
+    { label: "replaced", watermark: { kind: "text", text: "NEW" } satisfies Watermark },
+    { label: "cleared", watermark: undefined },
+  ])("removes a retained watermark host when the watermark is $label", ({ watermark }) => {
+    const retainedHost: HeaderFooter = {
+      ...emptyHeader(),
+      content: [
+        {
+          type: "paragraph",
+          content: [],
+          formatting: { styleId: "Header" },
+        },
+      ],
+      watermark: { kind: "text", text: "OLD" },
+      watermarkBlockIndex: 0,
+      rawWatermarkXml: "<w:p><w:r><w:pict>OLD VML</w:pict></w:r></w:p>",
+    };
+    const doc = makeDoc({ rId1: retainedHost });
+
+    const next = setDocumentWatermark(doc, watermark);
+
+    expect(next.package.headers?.get("rId1")?.content).toEqual([]);
+    expect(retainedHost.content).toHaveLength(1);
+  });
+
   test("passing undefined removes the watermark from every header", () => {
     const doc = makeDoc({
       rId1: { ...emptyHeader(), watermark: { kind: "text", text: "x" } },

--- a/packages/core/src/watermark/index.ts
+++ b/packages/core/src/watermark/index.ts
@@ -15,6 +15,7 @@ import type {
   SectionProperties,
   Watermark,
 } from "../types/document";
+import { isEmptyParagraph } from "../docx/paragraphParser";
 
 export type { Watermark, TextWatermark, PictureWatermark } from "../types/document";
 
@@ -72,6 +73,19 @@ export function setDocumentWatermark(doc: Document, watermark: Watermark | undef
   if (headers) {
     for (const [rId, header] of headers) {
       const next: HeaderFooter = { ...header };
+      const retainedHostIndex = next.watermarkBlockIndex;
+      const retainedHost =
+        next.rawWatermarkXml !== undefined && retainedHostIndex !== undefined
+          ? next.content.at(retainedHostIndex)
+          : undefined;
+      if (
+        retainedHostIndex !== undefined &&
+        retainedHost?.type === "paragraph" &&
+        isEmptyParagraph(retainedHost)
+      ) {
+        next.content = [...next.content];
+        next.content.splice(retainedHostIndex, 1);
+      }
       if (watermark === undefined) {
         delete next.watermark;
         // No watermark left to position — drop the parsed block index too


### PR DESCRIPTION
## Summary

- retain watermark host formatting so body margins account for its line box
- merge captured watermark content into structurally serialized hosts without losing edits
- preserve block-control ordering and remove obsolete hosts when watermarks change