### PR TITLE
fix(core): honor fixed-row page boundaries

### DIFF
--- a/.changeset/neat-rows-rest.md
+++ b/.changeset/neat-rows-rest.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Honor cached page boundaries on exact-height multi-cell table rows.

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -50,6 +50,7 @@ import type {
   ParagraphMeasure,
   ParagraphFragment,
   TableBlock,
+  TableCell,
   TableMeasure,
   TableFragment,
   ImageBlock,
@@ -937,13 +938,14 @@ export function getHeaderRowsHeight(measure: TableMeasure, headerRowCount: numbe
 }
 
 const tableRowStartsWithRenderedPageBreak = (block: TableBlock, rowIndex: number): boolean => {
-  const visibleCells = block.rows[rowIndex]?.cells.filter((cell) =>
+  const row = block.rows[rowIndex];
+  const visibleCells = row?.cells.filter((cell) =>
     cell.blocks.some((cellBlock) => cellBlock.kind !== "paragraph" || !isEmptyParagraph(cellBlock)),
   );
   if (!visibleCells || visibleCells.length === 0) {
     return false;
   }
-  return visibleCells.every((cell) => {
+  const startsWithRenderedPageBreak = (cell: TableCell): boolean => {
     const firstVisibleBlock = cell.blocks.find(
       (cellBlock) => cellBlock.kind !== "paragraph" || !isEmptyParagraph(cellBlock),
     );
@@ -951,7 +953,15 @@ const tableRowStartsWithRenderedPageBreak = (block: TableBlock, rowIndex: number
       firstVisibleBlock?.kind === "paragraph" &&
       firstVisibleBlock.attrs?.renderedPageBreakBefore === true
     );
-  });
+  };
+
+  // A fixed row's leading marker describes the row boundary once, in its
+  // first visible cell. Flexible rows need agreement across visible cells
+  // because unmarked siblings may carry content from the preceding page.
+  if (row?.heightRule === "exact") {
+    return startsWithRenderedPageBreak(visibleCells[0]!); // SAFETY: guarded by length check.
+  }
+  return visibleCells.every(startsWithRenderedPageBreak);
 };
 
 const getVerticallyMergedRows = (block: TableBlock): Set<number> => {

--- a/packages/core/src/layout-engine/tableRowBreak.test.ts
+++ b/packages/core/src/layout-engine/tableRowBreak.test.ts
@@ -1710,6 +1710,54 @@ describe("oversized table row splits across pages (#570)", () => {
     });
   });
 
+  test("promotes the first cell's cached boundary for an exact-height row", () => {
+    const spacer: FlowBlock = {
+      kind: "paragraph",
+      id: "spacer",
+      runs: [{ kind: "text", text: "spacer" }],
+    };
+    const spacerMeasure = paraMeasureWithLineHeight(1, 70);
+    const { block, measure } = tallTable(5);
+    markFirstTableParagraphWithRenderedBreak(block);
+    block.rows[0]!.height = 5 * LINE;
+    block.rows[0]!.heightRule = "exact";
+    block.rows[0]!.cells.push({
+      id: "c1",
+      padding: { top: 0, right: 0, bottom: 0, left: 0 },
+      blocks: [
+        {
+          kind: "paragraph",
+          id: "p1",
+          runs: [{ kind: "text", text: "starts with its row" }],
+        },
+      ],
+    });
+    block.columnWidths = [110, 110];
+    measure.rows[0]!.cells.push({
+      blocks: [paraMeasure(5)],
+      width: 110,
+      height: 5 * LINE,
+    });
+    measure.rows[0]!.cells[0]!.width = 110;
+    measure.columnWidths = [110, 110];
+
+    const layout = layoutDocument([spacer, block], [spacerMeasure, measure], OPTIONS);
+    const fragments = layout.pages
+      .flatMap((page) => page.fragments)
+      .filter((fragment): fragment is TableFragment => fragment.kind === "table");
+
+    expect(layout.pages[0]?.fragments.every((fragment) => fragment.kind !== "table")).toBe(true);
+    expect(fragments).toHaveLength(1);
+    expect(fragments[0]).toMatchObject({
+      y: OPTIONS.margins.top,
+      height: 5 * LINE,
+      fromRow: 0,
+      toRow: 1,
+    });
+    expect(fragments[0]?.topClip).toBeUndefined();
+    expect(fragments[0]?.bottomClip).toBeUndefined();
+  });
+
   test("still splits an oversized cached-boundary row on the fresh page", () => {
     const spacer: FlowBlock = {
       kind: "paragraph",


### PR DESCRIPTION
## Summary

- treat a leading cached page boundary in the first visible cell as row-level for exact-height rows
- retain all-visible-cell agreement for flexible rows
- cover fixed and flexible multi-cell pagination behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Exact-height table rows now honour cached page boundaries when spanning pages.
  - Rows with a cached page break are placed wholly on a fresh page, preventing incorrect table fragments and clipping.
  - Flexible-height rows continue to use existing page-boundary handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->