### PR TITLE
fix(core): render percentage shading

### DIFF
--- a/.changeset/render-percentage-shading.md
+++ b/.changeset/render-percentage-shading.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Render percentage shading patterns as blended foreground and background colors.

--- a/packages/core/src/prosemirror/conversion/effectiveTableCellFormatting.test.ts
+++ b/packages/core/src/prosemirror/conversion/effectiveTableCellFormatting.test.ts
@@ -47,6 +47,18 @@ describe("resolveEffectiveTableCellFormatting", () => {
     expect(result.background).toEqual({ type: "none", source: "direct" });
   });
 
+  test("resolves automatic percentage shading into a display background", () => {
+    const result = resolveFormatting({
+      directFormatting: { shading: { pattern: "pct12" } },
+    });
+
+    expect(result.background).toEqual({
+      type: "color",
+      source: "direct",
+      rgb: "DFDFDF",
+    });
+  });
+
   test("records whether width came from the authored cell or table grid", () => {
     const direct = resolveFormatting({
       directFormatting: { width: { value: 1440, type: "dxa" } },

--- a/packages/core/src/utils/__tests__/formatToStyle-shading.test.ts
+++ b/packages/core/src/utils/__tests__/formatToStyle-shading.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, test } from "bun:test";
 import type { ShadingProperties } from "../../types/colors";
 import { resolveShadingFill } from "../formatToStyle";
 
-describe("resolveShadingFill — clear pattern shows the fill", () => {
+describe("resolveShadingFill", () => {
   test("clear + concrete fill renders the fill as a solid background", () => {
     expect(resolveShadingFill({ pattern: "clear", fill: { rgb: "D9D9D9" } })).toBe("#D9D9D9");
   });
@@ -34,6 +34,20 @@ describe("resolveShadingFill — clear pattern shows the fill", () => {
 
   test("solid pattern still uses the pattern colour when there is no fill", () => {
     expect(resolveShadingFill({ pattern: "solid", color: { rgb: "FF0000" } })).toBe("#FF0000");
+  });
+
+  test("renders percentage shading with automatic colors", () => {
+    expect(resolveShadingFill({ pattern: "pct12" })).toBe("#DFDFDF");
+  });
+
+  test("blends explicit percentage pattern and background colors", () => {
+    expect(
+      resolveShadingFill({
+        pattern: "pct25",
+        color: { rgb: "FF0000" },
+        fill: { rgb: "FFFFFF" },
+      }),
+    ).toBe("#FFBFBF");
   });
 
   test("undefined shading is transparent", () => {

--- a/packages/core/src/utils/formatToStyle.ts
+++ b/packages/core/src/utils/formatToStyle.ts
@@ -475,6 +475,53 @@ export function borderToStyle(
   return style;
 }
 
+const HALF_STEP_SHADING_PATTERNS = new Set(["pct12", "pct37", "pct62", "pct87"]);
+const AUTO_PATTERN_COLOR = "000000";
+const AUTO_PATTERN_BACKGROUND = "FFFFFF";
+
+function percentageShadingRatio(pattern: ShadingProperties["pattern"]): number | undefined {
+  if (!pattern?.startsWith("pct")) {
+    return undefined;
+  }
+  const percentage = Number.parseInt(pattern.slice(3), 10);
+  if (!Number.isFinite(percentage)) {
+    return undefined;
+  }
+  return (percentage + (HALF_STEP_SHADING_PATTERNS.has(pattern) ? 0.5 : 0)) / 100;
+}
+
+type ResolvePatternHexOptions = {
+  color: ColorValue | undefined;
+  fallback: string;
+  theme: Theme | null | undefined;
+};
+
+function resolvePatternHex({ color, fallback, theme }: ResolvePatternHexOptions): string {
+  const resolved = resolveShadingColor(color, theme);
+  const match = /^#(?<hex>[0-9A-F]{6})$/iu.exec(resolved);
+  return match?.groups?.["hex"]?.toUpperCase() ?? fallback;
+}
+
+type BlendShadingColorsOptions = {
+  foreground: string;
+  background: string;
+  ratio: number;
+};
+
+function blendShadingColors({ foreground, background, ratio }: BlendShadingColorsOptions): string {
+  const channels: string[] = [];
+  for (let offset = 0; offset < 6; offset += 2) {
+    const foregroundChannel = Number.parseInt(foreground.slice(offset, offset + 2), 16);
+    const backgroundChannel = Number.parseInt(background.slice(offset, offset + 2), 16);
+    channels.push(
+      Math.round(foregroundChannel * ratio + backgroundChannel * (1 - ratio))
+        .toString(16)
+        .padStart(2, "0"),
+    );
+  }
+  return `#${channels.join("").toUpperCase()}`;
+}
+
 /**
  * Convert ShadingProperties to background color
  *
@@ -500,6 +547,23 @@ export function resolveShadingFill(
     return "";
   }
 
+  const percentageRatio = percentageShadingRatio(shading.pattern);
+  if (percentageRatio !== undefined) {
+    return blendShadingColors({
+      foreground: resolvePatternHex({
+        color: shading.color,
+        fallback: AUTO_PATTERN_COLOR,
+        theme,
+      }),
+      background: resolvePatternHex({
+        color: shading.fill,
+        fallback: AUTO_PATTERN_BACKGROUND,
+        theme,
+      }),
+      ratio: percentageRatio,
+    });
+  }
+
   // Check fill (background color)
   if (shading.fill) {
     // 'auto' fill means transparent
@@ -515,12 +579,6 @@ export function resolveShadingFill(
 
   // Pattern with solid typically uses the color field
   if (shading.pattern === "solid" && shading.color) {
-    return resolveShadingColor(shading.color, theme);
-  }
-
-  // For percentage patterns, blend color and fill
-  // This is a simplified handling - complex patterns would need more work
-  if (shading.pattern && shading.pattern.startsWith("pct") && shading.color) {
     return resolveShadingColor(shading.color, theme);
   }
 


### PR DESCRIPTION
## Summary

- blend percentage-pattern foreground and background colors for display
- apply automatic black-on-white defaults when pattern colors are omitted
- preserve existing clear, solid, and nil shading behavior