### PR TITLE
fix(core): exclude fully hidden paragraphs from layout

### DIFF
--- a/.changeset/quiet-hidden-paragraphs.md
+++ b/.changeset/quiet-hidden-paragraphs.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Exclude fully hidden paragraphs from visual layout while preserving their editable source runs.

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -975,6 +975,43 @@ describe("toFlowBlocks paragraph formatting", () => {
     expect(paragraph?.attrs?.listMarkerHidden).toBe(true);
   });
 
+  test("suppresses a paragraph whose mark and text runs are hidden", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", { defaultTextFormatting: { hidden: true } }, [
+        schema.text("Internal drafting note", [schema.marks.hidden.create()]),
+      ]),
+    ]);
+
+    const paragraph = toFlowBlocks(doc).at(0);
+
+    expect(paragraph?.kind).toBe("paragraph");
+    if (paragraph?.kind !== "paragraph") {
+      return;
+    }
+    expect(paragraph.runs).toMatchObject([
+      { kind: "text", text: "Internal drafting note", hidden: true },
+    ]);
+    expect(paragraph.attrs?.suppressEmptyParagraphHeight).toBe(true);
+  });
+
+  test("keeps a line when either its paragraph mark or a text run remains visible", () => {
+    const hidden = schema.marks.hidden.create();
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text("Hidden text", [hidden])]),
+      schema.node("paragraph", { defaultTextFormatting: { hidden: true } }, [
+        schema.text("Hidden", [hidden]),
+        schema.text(" visible"),
+      ]),
+    ]);
+
+    const paragraphs = toFlowBlocks(doc).filter((block) => block.kind === "paragraph");
+
+    expect(paragraphs.map((paragraph) => paragraph.attrs?.suppressEmptyParagraphHeight)).toEqual([
+      undefined,
+      undefined,
+    ]);
+  });
+
   test("suppresses a paintless imported page-break carrier", () => {
     const doc = schema.node("doc", null, [
       schema.node("paragraph", { _pageBreakCarrier: true, spaceBefore: 360 }),

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -1861,6 +1861,10 @@ function hasOnlyVisuallyEmptyTextRuns(runs: Run[]): boolean {
   );
 }
 
+function hasOnlyHiddenTextRuns(runs: Run[]): boolean {
+  return runs.length > 0 && runs.every((run) => run.kind === "text" && run.hidden === true);
+}
+
 function convertParagraph(
   node: PMNode,
   startPos: number,
@@ -1914,11 +1918,13 @@ function convertParagraph(
       }
     }
   }
-  if (runs.length === 0 && defaultTextFormatting?.hidden === true) {
+  const isFullyHiddenParagraph =
+    defaultTextFormatting?.hidden === true && (runs.length === 0 || hasOnlyHiddenTextRuns(runs));
+  if (isFullyHiddenParagraph && attrs.listMarker !== undefined) {
+    attrs.listMarkerHidden = true;
+  }
+  if (isFullyHiddenParagraph) {
     attrs.suppressEmptyParagraphHeight = true;
-    if (attrs.listMarker !== undefined) {
-      attrs.listMarkerHidden = true;
-    }
   }
   const hasVisibleParagraphPayload =
     (attrs.listMarker !== undefined && !attrs.listMarkerHidden) ||

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -551,6 +551,37 @@ describe("empty paragraph line-height floor", () => {
     expect(measure.lines[0]?.lineHeight).toBe(0);
   });
 
+  test("suppressed hidden text keeps a zero-height anchor", () => {
+    const measure = measureParagraph(
+      {
+        kind: "paragraph",
+        id: "hidden-text",
+        pmStart: 0,
+        pmEnd: 21,
+        runs: [
+          { kind: "text", text: "Internal ", hidden: true },
+          { kind: "text", text: "drafting note", hidden: true, italic: true },
+        ],
+        attrs: { suppressEmptyParagraphHeight: true },
+      },
+      600,
+    );
+
+    expect(measure.totalHeight).toBe(0);
+    expect(measure.lines).toEqual([
+      {
+        fromRun: 0,
+        fromChar: 0,
+        toRun: 1,
+        toChar: 13,
+        width: 0,
+        ascent: 0,
+        descent: 0,
+        lineHeight: 0,
+      },
+    ]);
+  });
+
   test("uses paragraph mark metrics for blank hard-break lines", () => {
     withFakeTextMeasure(() => {
       const measure = measureParagraph(

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -1368,27 +1368,29 @@ export function measureParagraph(
   const lines: MeasuredLine[] = [];
   let consecutiveHyphenatedLines = 0;
 
+  if (attrs?.suppressEmptyParagraphHeight) {
+    const finalRunIndex = Math.max(0, runs.length - 1);
+    const finalRun = runs.at(-1);
+    lines.push({
+      fromRun: 0,
+      fromChar: 0,
+      toRun: finalRunIndex,
+      toChar: finalRun?.kind === "text" ? finalRun.text.length : 0,
+      width: 0,
+      ascent: 0,
+      descent: 0,
+      lineHeight: 0,
+    });
+
+    return {
+      kind: "paragraph",
+      lines,
+      totalHeight: 0,
+    };
+  }
+
   // Handle empty paragraph
   if (runs.length === 0) {
-    if (attrs?.suppressEmptyParagraphHeight) {
-      lines.push({
-        fromRun: 0,
-        fromChar: 0,
-        toRun: 0,
-        toChar: 0,
-        width: 0,
-        ascent: 0,
-        descent: 0,
-        lineHeight: 0,
-      });
-
-      return {
-        kind: "paragraph",
-        lines,
-        totalHeight: 0,
-      };
-    }
-
     const emptyFontSize = attrs?.defaultFontSize ?? DEFAULT_FONT_SIZE;
     const emptyFontFamily = attrs?.defaultFontFamily ?? DEFAULT_FONT_FAMILY;
     const emptyMetrics = calculateEmptyParagraphMetrics(

--- a/packages/core/src/layout-painter/renderParagraph-empty-line-break-position.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-empty-line-break-position.test.ts
@@ -210,3 +210,49 @@ describe("blank line-break rows carry a resolvable position", () => {
     expect(marker?.dataset["pmStart"]).toBe("2");
   });
 });
+
+describe("suppressed paragraph positions", () => {
+  test("keeps every hidden source run positioned while clipping its zero-height line", () => {
+    const hiddenBlock: ParagraphBlock = {
+      kind: "paragraph",
+      id: "hidden",
+      pmStart: 0,
+      pmEnd: 14,
+      attrs: { suppressEmptyParagraphHeight: true },
+      runs: [
+        { kind: "text", text: "Hidden", hidden: true, pmStart: 1, pmEnd: 7 },
+        { kind: "text", text: " source", hidden: true, italic: true, pmStart: 7, pmEnd: 14 },
+      ],
+    };
+    const lineEl = renderLine(
+      hiddenBlock,
+      {
+        fromRun: 0,
+        fromChar: 0,
+        toRun: 1,
+        toChar: 7,
+        width: 0,
+        ascent: 0,
+        descent: 0,
+        lineHeight: 0,
+      },
+      undefined,
+      fakeDocument,
+      {
+        availableWidth: 360,
+        isLastLine: true,
+        isFirstLine: true,
+        paragraphEndsWithLineBreak: false,
+        leftIndentPx: 0,
+      },
+    ) as unknown as FakeElement;
+
+    expect(lineEl.style["overflow"]).toBe("hidden");
+    expect(
+      positionedSpans(lineEl).map((span) => [span.dataset["pmStart"], span.dataset["pmEnd"]]),
+    ).toEqual([
+      ["1", "7"],
+      ["7", "14"],
+    ]);
+  });
+});

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -2441,7 +2441,7 @@ export function renderLine(
   // are rendered visually (unlike 'nowrap' which collapses them).
   lineEl.style.whiteSpace = "pre";
 
-  lineEl.style.overflow = "visible";
+  lineEl.style.overflow = block.attrs?.suppressEmptyParagraphHeight ? "hidden" : "visible";
 
   // Per-line floating margins (leftOffset/rightOffset) are now applied by
   // renderParagraphFragment via MeasuredLine offsets from re-measurement.


### PR DESCRIPTION
Fully hidden paragraph marks now collapse when every text run is also hidden. Source runs remain available to editing and serialization, while layout retains a zero-height anchor. Mixed-visibility paragraphs continue to reserve their line.

Focused conversion and measurement regressions cover the collapsed and mixed-visibility cases.