### PR TITLE
fix(core): use David font metrics for line spacing

### DIFF
--- a/.changeset/calm-davids-align.md
+++ b/.changeset/calm-davids-align.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Use David's font metrics when calculating automatic line spacing.

--- a/packages/core/src/utils/fontResolver.test.ts
+++ b/packages/core/src/utils/fontResolver.test.ts
@@ -35,6 +35,7 @@ describe("fontResolver — single-line ratios are derived from real hhea metrics
     ["montserrat", 1.219],
     ["trebuchet ms", 1.1611],
     ["courier new", 1.1328],
+    ["david", 0.9839],
     ["consolas", 1.1709],
     ["comic sans ms", 1.3936],
     ["impact", 1.2197],
@@ -67,6 +68,18 @@ describe("fontResolver — Aptos falls back to bundled Lato", () => {
     expect(resolved.googleFont).toBe("Lato");
     expect(resolved.cssFallback).toContain("Lato");
     expect(resolved.hasGoogleEquivalent).toBe(true);
+  });
+});
+
+describe("fontResolver — David uses a Hebrew serif fallback", () => {
+  test("keeps the authored face first and loads Noto Serif Hebrew", () => {
+    const resolved = resolveFontFamily("David");
+
+    expect(resolved.googleFont).toBe("Noto Serif Hebrew");
+    expect(parseFontFamilyList(resolved.cssFallback).slice(0, 2)).toEqual([
+      "David",
+      "Noto Serif Hebrew",
+    ]);
   });
 });
 

--- a/packages/core/src/utils/fontResolver.ts
+++ b/packages/core/src/utils/fontResolver.ts
@@ -229,6 +229,18 @@ const FONT_MAPPINGS: Record<string, FontMapping> = {
       unitsPerEm: 2048,
     }), // 1.1328
   },
+  david: {
+    googleFont: "Noto Serif Hebrew",
+    category: "serif",
+    fallbackStack: ["David", "Noto Serif Hebrew", "Times New Roman", "serif"],
+    singleLineRatio: singleLineRatioOf({
+      source: "hhea",
+      hheaAscent: 1505,
+      hheaDescent: -510,
+      hheaLineGap: 0,
+      unitsPerEm: 2048,
+    }), // 0.9839
+  },
 
   // Additional common fonts
   georgia: {

--- a/parity/__tests__/wordFonts.test.ts
+++ b/parity/__tests__/wordFonts.test.ts
@@ -24,6 +24,23 @@ describe("wordFontDefinitions", () => {
     });
   });
 
+  test("includes the Hebrew faces used by reference documents", () => {
+    expect(wordFontDefinitions("/word-fonts")).toEqual(
+      expect.arrayContaining([
+        {
+          family: "David",
+          filePath: "/word-fonts/david.ttf",
+          weight: 400,
+        },
+        {
+          family: "David",
+          filePath: "/word-fonts/davidbd.ttf",
+          weight: 700,
+        },
+      ]),
+    );
+  });
+
   test("uses one unique source file for each declared face", () => {
     const paths = wordFontDefinitions("/word-fonts").map(({ filePath }) => filePath);
     expect(new Set(paths).size).toBe(paths.length);

--- a/parity/wordFonts.ts
+++ b/parity/wordFonts.ts
@@ -36,8 +36,15 @@ const APTOS_FACES = [
   },
 ] as const satisfies ReadonlyArray<WordFontFace>;
 
+const HEBREW_FACES = [
+  { fileName: "david.ttf", family: "David", weight: 400 },
+  { fileName: "davidbd.ttf", family: "David", weight: 700 },
+] as const satisfies ReadonlyArray<WordFontFace>;
+
+const WORD_FONT_FACES = [...APTOS_FACES, ...HEBREW_FACES];
+
 export const wordFontDefinitions = (fontDirectory: string): LocalFontDefinition[] =>
-  APTOS_FACES.map((face) => {
+  WORD_FONT_FACES.map((face) => {
     const font: LocalFontDefinition = {
       family: face.family,
       filePath: path.join(fontDirectory, face.fileName),


### PR DESCRIPTION
## Summary

- use verified David font metrics for automatic line spacing
- keep the authored face first with a Hebrew serif fallback
- load available David faces in focused parity runs