### PR TITLE
fix(core): apply section starts at preceding boundaries

### DIFF
--- a/.changeset/calm-section-starts.md
+++ b/.changeset/calm-section-starts.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Apply odd, even, and continuous section starts at their preceding section boundaries.

--- a/packages/core/src/controller/layoutPipeline.test.ts
+++ b/packages/core/src/controller/layoutPipeline.test.ts
@@ -331,9 +331,11 @@ const makeSectionedState = (): EditorState =>
     ]),
   });
 
-const makeImplicitSectionBoundaryState = (): EditorState =>
+const makeImplicitSectionBoundaryState = (
+  finalSectionStart?: "continuous" | "nextPage",
+): EditorState =>
   EditorState.create({
-    doc: schema.node("doc", null, [
+    doc: schema.node("doc", { _finalSectionStart: finalSectionStart ?? null }, [
       schema.node(
         "paragraph",
         {
@@ -872,25 +874,36 @@ describe("runLayoutPipeline", () => {
     });
   });
 
-  test("does not apply the final section start mode to an earlier implicit boundary", () => {
-    const state = makeImplicitSectionBoundaryState();
+  test("applies the final section start mode at its preceding implicit boundary", () => {
     const continuous = runLayoutPipeline(
       makeDeps(createLayoutSession(), {
         document: makeSectionBoundaryDocument("continuous"),
         sectionProperties: {},
       }),
-      state,
+      makeImplicitSectionBoundaryState("continuous"),
     );
     const nextPage = runLayoutPipeline(
       makeDeps(createLayoutSession(), {
         document: makeSectionBoundaryDocument("nextPage"),
         sectionProperties: {},
       }),
-      state,
+      makeImplicitSectionBoundaryState("nextPage"),
     );
 
-    expect(continuous.layout?.pages).toHaveLength(2);
+    expect(continuous.layout?.pages).toHaveLength(1);
     expect(nextPage.layout?.pages).toHaveLength(2);
+  });
+
+  test("uses the supplied section start when document metadata is unavailable", () => {
+    const outcome = runLayoutPipeline(
+      makeDeps(createLayoutSession(), {
+        document: null,
+        sectionProperties: { sectionStart: "continuous" },
+      }),
+      makeImplicitSectionBoundaryState(),
+    );
+
+    expect(outcome.layout?.pages).toHaveLength(1);
   });
 
   test("uses the referenced final-section footer for body clearance", () => {

--- a/packages/core/src/controller/layoutPipeline.ts
+++ b/packages/core/src/controller/layoutPipeline.ts
@@ -414,7 +414,18 @@ export function runLayoutPipeline<THfPMs>(
     if (finalSectionDocumentGridLinePitchTwips !== undefined) {
       flowOpts.finalSectionDocumentGridLinePitchTwips = finalSectionDocumentGridLinePitchTwips;
     }
-    let newBlocks = toFlowBlocks(state.doc, flowOpts);
+    const flowDoc =
+      document === null
+        ? state.doc.type.create(
+            {
+              ...state.doc.attrs,
+              _finalSectionStart: sectionProperties?.sectionStart ?? null,
+            },
+            state.doc.content,
+            state.doc.marks,
+          )
+        : state.doc;
+    let newBlocks = toFlowBlocks(flowDoc, flowOpts);
     // Template fill preview: substitute each matched {{marker}} range
     // with its typed value at the flow-block level so the pages lay out
     // (wrap, paginate) as if the value were the document text. View-only:

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -9,6 +9,30 @@ import { AUTO_PARAGRAPH_SPACING_PX } from "../../utils/units";
 import { toFlowBlocks } from "./toFlowBlocks";
 
 describe("toFlowBlocks paragraph formatting", () => {
+  test("moves each section-owned start mode to its preceding boundary", () => {
+    const doc = schema.node("doc", { _finalSectionStart: "evenPage" }, [
+      schema.node("paragraph", { _sectionProperties: { sectionStart: "continuous" } }),
+      schema.node("paragraph", { _sectionProperties: { sectionStart: "oddPage" } }),
+      schema.node("paragraph"),
+    ]);
+
+    const breaks = toFlowBlocks(doc).filter((block) => block.kind === "sectionBreak");
+
+    expect(breaks.map((block) => block.type)).toEqual(["oddPage", "evenPage"]);
+  });
+
+  test("keeps an omitted following section start omitted", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", { _sectionProperties: { sectionStart: "continuous" } }),
+      schema.node("paragraph", { _sectionProperties: {} }),
+      schema.node("paragraph"),
+    ]);
+
+    const breaks = toFlowBlocks(doc).filter((block) => block.kind === "sectionBreak");
+
+    expect(breaks.map((block) => block.type)).toEqual([undefined, undefined]);
+  });
+
   test("projects authored section page-number restarts", () => {
     const doc = schema.node("doc", null, [
       schema.node("paragraph", {

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -2656,6 +2656,62 @@ function getLastMapKey<K, V>(map: ReadonlyMap<K, V>): K | undefined {
 }
 
 /**
+ * Translate section-owned start modes into the boundary-owned values consumed
+ * by the paginator. Each flow section break carries the properties for the
+ * section it ends, so its start mode belongs on the preceding boundary.
+ */
+function applySectionStartsToBoundaries(
+  blocks: readonly FlowBlock[],
+  finalSectionStart: NonNullable<SectionBreakBlock["type"]> | undefined,
+): FlowBlock[] {
+  const breakIndexes: number[] = [];
+  for (let index = 0; index < blocks.length; index += 1) {
+    if (blocks[index]?.kind === "sectionBreak") {
+      breakIndexes.push(index);
+    }
+  }
+  if (breakIndexes.length === 0) {
+    return [...blocks];
+  }
+
+  const result = [...blocks];
+  for (let index = 0; index < breakIndexes.length; index += 1) {
+    const boundaryIndex = breakIndexes[index];
+    if (boundaryIndex === undefined) {
+      continue;
+    }
+    const boundary = blocks[boundaryIndex];
+    if (boundary?.kind !== "sectionBreak") {
+      continue;
+    }
+    const nextBoundaryIndex = breakIndexes[index + 1];
+    const nextBoundary = nextBoundaryIndex === undefined ? undefined : blocks[nextBoundaryIndex];
+    const nextStart = nextBoundary?.kind === "sectionBreak" ? nextBoundary.type : finalSectionStart;
+    const translated = { ...boundary };
+    if (nextStart === undefined) {
+      delete translated.type;
+    } else {
+      translated.type = nextStart;
+    }
+    result[boundaryIndex] = translated;
+  }
+  return result;
+}
+
+function readFinalSectionStart(doc: PMNode): NonNullable<SectionBreakBlock["type"]> | undefined {
+  const sectionStart = doc.attrs["_finalSectionStart"];
+  switch (sectionStart) {
+    case "continuous":
+    case "nextPage":
+    case "oddPage":
+    case "evenPage":
+      return sectionStart;
+    default:
+      return undefined;
+  }
+}
+
+/**
  * Convert a ProseMirror document to FlowBlock array.
  *
  * Walks the document tree, converting each node to the appropriate block type.
@@ -3072,7 +3128,8 @@ export function toFlowBlocks(doc: PMNode, options: ToFlowBlocksOptions = {}): Fl
     mergedBlocks,
     opts.finalSectionDocumentGridLinePitchTwips,
   );
-  return groupParagraphFrames(griddedBlocks, nextBlockId);
+  const boundaryBlocks = applySectionStartsToBoundaries(griddedBlocks, readFinalSectionStart(doc));
+  return groupParagraphFrames(boundaryBlocks, nextBlockId);
 }
 
 function applySectionDocumentGrid(

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -508,9 +508,6 @@ function layoutDocumentPass(
         break;
 
       case "sectionBreak": {
-        // A section-break block carries the transition authored at that
-        // boundary. Looking ahead shifts every transition by one section,
-        // which moves odd/even filler pages to the wrong boundary.
         const nextSectionConfig = sectionConfigs[sectionIdx + 1] ?? initialConfig;
         const nextType = normalizeSectionBreakType(sectionBreakTypes[sectionIdx]);
         handleSectionBreak(

--- a/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
@@ -45,6 +45,22 @@ function firstTableCellAttrs(doc: Document): Record<string, unknown> {
 }
 
 describe("toProseDoc", () => {
+  test("keeps the final section start on the internal document node", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [{ type: "paragraph", content: [] }],
+          sections: [
+            { properties: {}, content: [] },
+            { properties: { sectionStart: "oddPage" }, content: [] },
+          ],
+        },
+      },
+    };
+
+    expect(toProseDoc(document).attrs["_finalSectionStart"]).toBe("oddPage");
+  });
+
   test("renders OOXML symbol characters with their declared font", () => {
     const document: Document = {
       package: {

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -342,7 +342,11 @@ export function toProseDoc(document: Document, options?: ToProseDocOptions): PMN
     nodes.push(schema.node("paragraph", {}, []));
   }
 
-  const pmDoc = stampNumberedRefFieldBaselines(schema.node("doc", null, nodes));
+  const finalSectionStart =
+    document.package.document.sections?.at(-1)?.properties.sectionStart ?? null;
+  const pmDoc = stampNumberedRefFieldBaselines(
+    schema.node("doc", { _finalSectionStart: finalSectionStart }, nodes),
+  );
   assertValidProseMirrorDocument(
     pmDoc,
     "Document conversion produced an invalid ProseMirror document",

--- a/packages/core/src/prosemirror/extensions/core/DocExtension.ts
+++ b/packages/core/src/prosemirror/extensions/core/DocExtension.ts
@@ -8,6 +8,9 @@ export const DocExtension = createNodeExtension({
   name: "doc",
   schemaNodeName: "doc",
   nodeSpec: {
+    attrs: {
+      _finalSectionStart: { default: null },
+    },
     content: "(paragraph | horizontalRule | pageBreak | table | textBox | blockSdt)+",
   },
 });


### PR DESCRIPTION
Section properties describe the section ending at each marker, so their start placement now applies at the preceding boundary. The final body section threads its placement into browser and headless layout.

Odd- and even-page fillers remain in the preceding section; continuous starts can share the current page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected section-start handling so **odd-page**, **even-page**, and **continuous** section breaks are applied at the appropriate preceding section boundaries.
  - Improved pagination for final sections, ensuring continuous sections remain on the same page while odd- and even-page sections begin on the required page.
  - Preserved section-start settings when document metadata is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->