### PR TITLE
fix(core): resolve Hebrew document fonts

### DIFF
--- a/.changeset/calm-lemons-read.md
+++ b/.changeset/calm-lemons-read.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Resolve FrankRuehl and Miriam with compatible Hebrew fallbacks and verified line metrics.

--- a/packages/core/src/utils/fontResolver.test.ts
+++ b/packages/core/src/utils/fontResolver.test.ts
@@ -52,6 +52,8 @@ describe("fontResolver — single-line ratios are derived from real hhea metrics
     ["constantia", 1.2207],
     ["corbel", 1.2075],
     ["dubai", 1.688],
+    ["frankruehl", 0.9297],
+    ["miriam", 1.0049],
   ];
 
   for (const [font, expectedRatio] of verifiedRatios) {
@@ -59,6 +61,20 @@ describe("fontResolver — single-line ratios are derived from real hhea metrics
       expect(resolveFontFamily(font).singleLineRatio).toBeCloseTo(expectedRatio, 4);
     });
   }
+});
+
+describe("fontResolver — Hebrew document faces", () => {
+  test.each([
+    ["FrankRuehl", "Frank Ruhl Libre", "serif"],
+    ["Miriam", "Miriam Libre", "sans-serif"],
+  ])("%s uses a script-compatible fallback", (font, googleFont, category) => {
+    const resolved = resolveFontFamily(font);
+
+    expect(resolved.googleFont).toBe(googleFont);
+    expect(parseFontFamilyList(resolved.cssFallback)).toEqual(
+      expect.arrayContaining([font, googleFont, category]),
+    );
+  });
 });
 
 describe("fontResolver — Aptos falls back to bundled Lato", () => {

--- a/packages/core/src/utils/fontResolver.ts
+++ b/packages/core/src/utils/fontResolver.ts
@@ -550,6 +550,32 @@ const FONT_MAPPINGS: Record<string, FontMapping> = {
     }),
   },
 
+  // Hebrew faces
+  frankruehl: {
+    googleFont: "Frank Ruhl Libre",
+    category: "serif",
+    fallbackStack: ["FrankRuehl", "Frank Ruhl Libre", "Times New Roman", "serif"],
+    singleLineRatio: singleLineRatioOf({
+      source: "hhea",
+      hheaAscent: 1462,
+      hheaDescent: -442,
+      hheaLineGap: 0,
+      unitsPerEm: 2048,
+    }), // 0.9297
+  },
+  miriam: {
+    googleFont: "Miriam Libre",
+    category: "sans-serif",
+    fallbackStack: ["Miriam", "Miriam Libre", "Arial", "sans-serif"],
+    singleLineRatio: singleLineRatioOf({
+      source: "hhea",
+      hheaAscent: 1546,
+      hheaDescent: -512,
+      hheaLineGap: 0,
+      unitsPerEm: 2048,
+    }), // 1.0049
+  },
+
   // CJK fonts
   "ms mincho": {
     googleFont: "Noto Serif JP",

--- a/parity/__tests__/wordFonts.test.ts
+++ b/parity/__tests__/wordFonts.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { getReferenceLocalFonts, wordFontDefinitions } from "../wordFonts";
+import { cloudFontDefinitions, getReferenceLocalFonts, wordFontDefinitions } from "../wordFonts";
 
 describe("wordFontDefinitions", () => {
   test("maps Aptos regular, bold, and italic faces to explicit CSS descriptors", () => {
@@ -44,6 +44,28 @@ describe("wordFontDefinitions", () => {
   test("uses one unique source file for each declared face", () => {
     const paths = wordFontDefinitions("/word-fonts").map(({ filePath }) => filePath);
     expect(new Set(paths).size).toBe(paths.length);
+  });
+});
+
+describe("cloudFontDefinitions", () => {
+  test("discovers cached Hebrew faces without depending on generated filenames", () => {
+    expect(
+      cloudFontDefinitions("/cloud-fonts", {
+        FrankRuehl: ["metadata.json", "300.ttf", "200.ttf"],
+        Miriam: ["regular.TTF"],
+      }),
+    ).toEqual([
+      {
+        family: "FrankRuehl",
+        filePath: "/cloud-fonts/FrankRuehl/200.ttf",
+        weight: 400,
+      },
+      {
+        family: "Miriam",
+        filePath: "/cloud-fonts/Miriam/regular.TTF",
+        weight: 400,
+      },
+    ]);
   });
 });
 

--- a/parity/wordFonts.ts
+++ b/parity/wordFonts.ts
@@ -1,9 +1,15 @@
+import { readdir } from "node:fs/promises";
+import { homedir } from "node:os";
 import path from "node:path";
 
 import type { LocalFontDefinition } from "./folioExtract";
 import type { ReferenceRendererId } from "./types";
 
 const WORD_FONT_DIR = "/Applications/Microsoft Word.app/Contents/Resources/DFonts";
+const WORD_CLOUD_FONT_DIR = path.join(
+  homedir(),
+  "Library/Group Containers/UBF8T346G9.Office/FontCache/4/CloudFonts",
+);
 
 type WordFontFace = Omit<LocalFontDefinition, "filePath"> & { fileName: string };
 
@@ -43,6 +49,11 @@ const HEBREW_FACES = [
 
 const WORD_FONT_FACES = [...APTOS_FACES, ...HEBREW_FACES];
 
+const CLOUD_FONT_FACES = [
+  { directory: "FrankRuehl", family: "FrankRuehl", weight: 400 },
+  { directory: "Miriam", family: "Miriam", weight: 400 },
+] as const satisfies ReadonlyArray<Omit<WordFontFace, "fileName"> & { directory: string }>;
+
 export const wordFontDefinitions = (fontDirectory: string): LocalFontDefinition[] =>
   WORD_FONT_FACES.map((face) => {
     const font: LocalFontDefinition = {
@@ -56,15 +67,50 @@ export const wordFontDefinitions = (fontDirectory: string): LocalFontDefinition[
     return font;
   });
 
+export const cloudFontDefinitions = (
+  fontDirectory: string,
+  filesByDirectory: Readonly<Record<string, readonly string[]>>,
+): LocalFontDefinition[] =>
+  CLOUD_FONT_FACES.flatMap((face) => {
+    const file = filesByDirectory[face.directory]
+      ?.filter((name) => name.toLowerCase().endsWith(".ttf"))
+      .toSorted()
+      .at(0);
+    return file === undefined
+      ? []
+      : [
+          {
+            family: face.family,
+            filePath: path.join(fontDirectory, face.directory, file),
+            weight: face.weight,
+          },
+        ];
+  });
+
+const getAvailableCloudFonts = async (): Promise<LocalFontDefinition[]> => {
+  const entries = await Promise.all(
+    CLOUD_FONT_FACES.map(async ({ directory }) => {
+      const files = await readdir(path.join(WORD_CLOUD_FONT_DIR, directory), {
+        withFileTypes: true,
+      }).catch(() => []);
+      return [directory, files.filter((file) => file.isFile()).map(({ name }) => name)] as const;
+    }),
+  );
+  return cloudFontDefinitions(WORD_CLOUD_FONT_DIR, Object.fromEntries(entries));
+};
+
 /** Fonts bundled with Word but not normally visible to Chromium. Missing
  * faces are skipped so an older Word installation remains usable. */
 export const getAvailableWordFonts = async (): Promise<LocalFontDefinition[]> => {
-  const available = await Promise.all(
-    wordFontDefinitions(WORD_FONT_DIR).map(async (font) =>
-      (await Bun.file(font.filePath).exists()) ? [font] : [],
+  const [bundled, cloud] = await Promise.all([
+    Promise.all(
+      wordFontDefinitions(WORD_FONT_DIR).map(async (font) =>
+        (await Bun.file(font.filePath).exists()) ? [font] : [],
+      ),
     ),
-  );
-  return available.flat();
+    getAvailableCloudFonts(),
+  ]);
+  return [...bundled.flat(), ...cloud];
 };
 
 type LoadWordFonts = () => Promise<LocalFontDefinition[]>;


### PR DESCRIPTION
## Summary

- resolve FrankRuehl and Miriam to script-compatible fallback families
- derive their single-line ratios from verified hhea metrics
- load optional cached local faces in parity runs without depending on generated filenames

## Testing

- `bun test packages/core/src/utils/fontResolver.test.ts parity/__tests__/wordFonts.test.ts`
- `bun audit`