### PR TITLE
fix(core): honor table cell line grid compatibility

### DIFF
--- a/.changeset/table-cell-line-grid.md
+++ b/.changeset/table-cell-line-grid.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Apply section line grids to table cells when the document compatibility setting requests it.

--- a/.changeset/table-cell-line-grid.md
+++ b/.changeset/table-cell-line-grid.md
@@ -1,5 +1,6 @@
 ---
 "@stll/folio-core": patch
+"@stll/docx-core": patch
 ---
 
 Apply section line grids to table cells when the document compatibility setting requests it.

--- a/api-reports/docx-core/model.api.md
+++ b/api-reports/docx-core/model.api.md
@@ -179,6 +179,7 @@ export type DocumentSettings = {
     compatibilityMode?: number;
     defaultTabStop: number;
     evenAndOddHeaders?: boolean;
+    adjustLineHeightInTable?: true;
     updateFields?: boolean;
     themeFontLang?: {
         eastAsia?: string;

--- a/packages/core/src/docx/settingsParser.test.ts
+++ b/packages/core/src/docx/settingsParser.test.ts
@@ -165,6 +165,27 @@ describe("parseSettings — application compatibility generation", () => {
   });
 });
 
+describe("parseSettings — table line-grid compatibility", () => {
+  test("records only an enabled adjustLineHeightInTable flag", () => {
+    expect(parseSettings(wrap(`<w:compat><w:adjustLineHeightInTable/></w:compat>`))).toMatchObject({
+      adjustLineHeightInTable: true,
+    });
+    expect(
+      parseSettings(wrap(`<w:compat><w:adjustLineHeightInTable w:val="0"/></w:compat>`)),
+    ).not.toHaveProperty("adjustLineHeightInTable");
+    expect(parseSettings(wrap(""))).not.toHaveProperty("adjustLineHeightInTable");
+  });
+
+  test("resolves the setting by namespace URI", () => {
+    const strictNamespace = "http://purl.oclc.org/ooxml/wordprocessingml/main";
+    const alternatePrefix = `<?xml version="1.0"?><q:settings xmlns:q="${strictNamespace}"><q:compat><q:adjustLineHeightInTable/></q:compat></q:settings>`;
+    const foreignChild = `<?xml version="1.0"?><w:settings xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:x="urn:example:foreign"><w:compat><x:adjustLineHeightInTable/></w:compat></w:settings>`;
+
+    expect(parseSettings(alternatePrefix)).toMatchObject({ adjustLineHeightInTable: true });
+    expect(parseSettings(foreignChild)).not.toHaveProperty("adjustLineHeightInTable");
+  });
+});
+
 describe("parseSettings — document automatic hyphenation", () => {
   test("reads the Word hyphenation controls", () => {
     expect(

--- a/packages/core/src/docx/settingsParser.ts
+++ b/packages/core/src/docx/settingsParser.ts
@@ -26,6 +26,11 @@ export type FolioDocumentSettings = DocumentSettings & {
   mirrorMargins?: boolean;
 };
 
+type ParsedDocumentSettings = FolioDocumentSettings & {
+  /** Apply section line-grid pitch to paragraphs inside table cells. */
+  adjustLineHeightInTable?: true;
+};
+
 /** OOXML default per §17.6.13 when `w:defaultTabStop` is absent. */
 export const DEFAULT_TAB_STOP_TWIPS = 720;
 
@@ -55,7 +60,7 @@ const MAX_KINSOKU_CHARACTERS_LENGTH = 128;
 
 export function parseSettings(xml: string | null): FolioDocumentSettings {
   const root = xml ? (parseXmlDocument(xml) as XmlElement | null) : null;
-  const settings: FolioDocumentSettings = {
+  const settings: ParsedDocumentSettings = {
     defaultTabStop: parseDefaultTabStop(root),
   };
   // On/off flags are resolved by namespace URI: a foreign-namespace element
@@ -131,6 +136,19 @@ export function parseSettings(xml: string | null): FolioDocumentSettings {
     : null;
   if (splitPageBreakAndParagraphMark && parseBooleanElement(splitPageBreakAndParagraphMark)) {
     settings.splitPageBreakAndParagraphMark = true;
+  }
+  const wordprocessingCompat = root
+    ? findChildByNamespaceUri(root, WORDPROCESSINGML_NAMESPACE_URIS, "compat")
+    : null;
+  const adjustLineHeightInTable = wordprocessingCompat
+    ? findChildByNamespaceUri(
+        wordprocessingCompat,
+        WORDPROCESSINGML_NAMESPACE_URIS,
+        "adjustLineHeightInTable",
+      )
+    : null;
+  if (adjustLineHeightInTable && parseBooleanElement(adjustLineHeightInTable)) {
+    settings.adjustLineHeightInTable = true;
   }
   const applyBreakingRules = compat ? findChild(compat, "w", "applyBreakingRules") : null;
   const useLegacyEthiopicAmharicRules =

--- a/packages/core/src/docx/settingsParser.ts
+++ b/packages/core/src/docx/settingsParser.ts
@@ -26,11 +26,6 @@ export type FolioDocumentSettings = DocumentSettings & {
   mirrorMargins?: boolean;
 };
 
-type ParsedDocumentSettings = FolioDocumentSettings & {
-  /** Apply section line-grid pitch to paragraphs inside table cells. */
-  adjustLineHeightInTable?: true;
-};
-
 /** OOXML default per §17.6.13 when `w:defaultTabStop` is absent. */
 export const DEFAULT_TAB_STOP_TWIPS = 720;
 
@@ -60,7 +55,7 @@ const MAX_KINSOKU_CHARACTERS_LENGTH = 128;
 
 export function parseSettings(xml: string | null): FolioDocumentSettings {
   const root = xml ? (parseXmlDocument(xml) as XmlElement | null) : null;
-  const settings: ParsedDocumentSettings = {
+  const settings: FolioDocumentSettings = {
     defaultTabStop: parseDefaultTabStop(root),
   };
   // On/off flags are resolved by namespace URI: a foreign-namespace element

--- a/packages/core/src/headless-layout.ts
+++ b/packages/core/src/headless-layout.ts
@@ -35,6 +35,7 @@ import { createHash } from "node:crypto";
 import { Result, TaggedError } from "better-result";
 import type { Node as PMNode } from "prosemirror-model";
 
+import { resolveDocumentGridLinePitch } from "./docx/documentGrid";
 import { parseDocx } from "./docx/parser";
 import { formatOoxmlCounter } from "./docx/ooxmlCounterFormatter";
 import { toArrayBuffer, type DocxInput } from "./utils/docxInput";
@@ -220,6 +221,12 @@ const buildFlowOptions = (document: Document, pageContentHeight: number): ToFlow
         ? {}
         : { hyphenationZoneTwips: settings.hyphenationZoneTwips }),
     };
+  }
+  const finalSectionDocumentGridLinePitchTwips = resolveDocumentGridLinePitch(
+    document.package.document.sections?.at(-1)?.properties.docGrid,
+  );
+  if (finalSectionDocumentGridLinePitchTwips !== undefined) {
+    options.finalSectionDocumentGridLinePitchTwips = finalSectionDocumentGridLinePitchTwips;
   }
   return options;
 };

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -86,6 +86,45 @@ describe("toFlowBlocks paragraph formatting", () => {
     expect(cellParagraph.attrs?.documentGridLinePitch).toBeUndefined();
   });
 
+  test("applies the section line grid to nested table cells when requested", () => {
+    const nestedTable = schema.node("table", null, [
+      schema.node("tableRow", null, [
+        schema.node("tableCell", null, [schema.node("paragraph", null, [schema.text("Nested")])]),
+      ]),
+    ]);
+    const table = schema.node("table", null, [
+      schema.node("tableRow", null, [
+        schema.node("tableCell", null, [
+          schema.node("paragraph", null, [schema.text("Cell")]),
+          nestedTable,
+        ]),
+      ]),
+    ]);
+    const blocks = toFlowBlocks(schema.node("doc", { _adjustLineHeightInTable: true }, [table]), {
+      finalSectionDocumentGridLinePitchTwips: 360,
+    });
+    const tableBlock = blocks.at(0);
+
+    expect(tableBlock?.kind).toBe("table");
+    if (tableBlock?.kind !== "table") {
+      return;
+    }
+    const cellBlocks = tableBlock.rows.at(0)?.cells.at(0)?.blocks;
+    const cellParagraph = cellBlocks?.at(0);
+    const nestedTableBlock = cellBlocks?.at(1);
+    expect(cellParagraph?.kind).toBe("paragraph");
+    expect(nestedTableBlock?.kind).toBe("table");
+    if (cellParagraph?.kind !== "paragraph" || nestedTableBlock?.kind !== "table") {
+      return;
+    }
+    expect(cellParagraph.attrs?.documentGridLinePitch).toBe(24);
+    const nestedParagraph = nestedTableBlock.rows.at(0)?.cells.at(0)?.blocks.at(0);
+    expect(nestedParagraph?.kind).toBe("paragraph");
+    if (nestedParagraph?.kind === "paragraph") {
+      expect(nestedParagraph.attrs?.documentGridLinePitch).toBe(24);
+    }
+  });
+
   test("lays out a trailing page-break section mark on the following page", () => {
     const doc = schema.node("doc", null, [
       schema.node(

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -3173,17 +3173,24 @@ export function toFlowBlocks(doc: PMNode, options: ToFlowBlocksOptions = {}): Fl
   suppressFinalEmptyParagraphAfterTable(blocks);
   suppressFinalParagraphInRepeatedEmptySuffix(blocks);
   const mergedBlocks = mergeRunInParagraphs(blocks);
-  const griddedBlocks = applySectionDocumentGrid(
-    mergedBlocks,
-    opts.finalSectionDocumentGridLinePitchTwips,
-  );
+  const tableCellLinePitch =
+    doc.attrs["_adjustLineHeightInTable"] === true ? "sectionGrid" : undefined;
+  const griddedBlocks = applySectionDocumentGrid(mergedBlocks, {
+    finalLinePitchTwips: opts.finalSectionDocumentGridLinePitchTwips,
+    tableCellLinePitch,
+  });
   const boundaryBlocks = applySectionStartsToBoundaries(griddedBlocks, readFinalSectionStart(doc));
   return groupParagraphFrames(boundaryBlocks, nextBlockId);
 }
 
+type SectionDocumentGridOptions = {
+  finalLinePitchTwips: number | undefined;
+  tableCellLinePitch: "sectionGrid" | undefined;
+};
+
 function applySectionDocumentGrid(
   blocks: FlowBlock[],
-  finalLinePitchTwips: number | undefined,
+  { finalLinePitchTwips, tableCellLinePitch }: SectionDocumentGridOptions,
 ): FlowBlock[] {
   const result = [...blocks];
   let sectionStart = 0;
@@ -3193,15 +3200,33 @@ function applySectionDocumentGrid(
       return;
     }
     const linePitch = twipsToPixels(linePitchTwips);
+    const stampBlock = (block: FlowBlock): FlowBlock => {
+      if (block.kind === "paragraph") {
+        return {
+          ...block,
+          attrs: { ...block.attrs, documentGridLinePitch: linePitch },
+        };
+      }
+      if (block.kind !== "table" || tableCellLinePitch !== "sectionGrid") {
+        return block;
+      }
+      return {
+        ...block,
+        rows: block.rows.map((row) => ({
+          ...row,
+          cells: row.cells.map((cell) => ({
+            ...cell,
+            blocks: cell.blocks.map(stampBlock),
+          })),
+        })),
+      };
+    };
     for (let index = sectionStart; index < end; index += 1) {
       const block = result[index];
-      if (block?.kind !== "paragraph") {
+      if (!block) {
         continue;
       }
-      result[index] = {
-        ...block,
-        attrs: { ...block.attrs, documentGridLinePitch: linePitch },
-      };
+      result[index] = stampBlock(block);
     }
   };
 

--- a/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { toFlowBlocks } from "../../layout-bridge/convert/toFlowBlocks";
+import { parseSettings } from "../../docx/settingsParser";
 import type { Document, ShadingProperties, TableCell, Theme } from "../../types/document";
 import { fromProseDoc } from "./fromProseDoc";
 import { toProseDoc } from "./toProseDoc";
@@ -59,6 +60,19 @@ describe("toProseDoc", () => {
     };
 
     expect(toProseDoc(document).attrs["_finalSectionStart"]).toBe("oddPage");
+  });
+
+  test("keeps the table line-grid compatibility policy on the internal document node", () => {
+    const settingsXml =
+      '<w:settings xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:compat><w:adjustLineHeightInTable/></w:compat></w:settings>';
+    const document: Document = {
+      package: {
+        document: { content: [{ type: "paragraph", content: [] }] },
+        settings: parseSettings(settingsXml),
+      },
+    };
+
+    expect(toProseDoc(document).attrs["_adjustLineHeightInTable"]).toBe(true);
   });
 
   test("renders OOXML symbol characters with their declared font", () => {

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -344,11 +344,7 @@ export function toProseDoc(document: Document, options?: ToProseDocOptions): PMN
 
   const finalSectionStart =
     document.package.document.sections?.at(-1)?.properties.sectionStart ?? null;
-  const settings = document.package.settings;
-  const adjustLineHeightInTable =
-    settings !== undefined &&
-    "adjustLineHeightInTable" in settings &&
-    settings.adjustLineHeightInTable === true;
+  const adjustLineHeightInTable = document.package.settings?.adjustLineHeightInTable === true;
   const pmDoc = stampNumberedRefFieldBaselines(
     schema.node(
       "doc",

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -344,8 +344,20 @@ export function toProseDoc(document: Document, options?: ToProseDocOptions): PMN
 
   const finalSectionStart =
     document.package.document.sections?.at(-1)?.properties.sectionStart ?? null;
+  const settings = document.package.settings;
+  const adjustLineHeightInTable =
+    settings !== undefined &&
+    "adjustLineHeightInTable" in settings &&
+    settings.adjustLineHeightInTable === true;
   const pmDoc = stampNumberedRefFieldBaselines(
-    schema.node("doc", { _finalSectionStart: finalSectionStart }, nodes),
+    schema.node(
+      "doc",
+      {
+        _finalSectionStart: finalSectionStart,
+        _adjustLineHeightInTable: adjustLineHeightInTable,
+      },
+      nodes,
+    ),
   );
   assertValidProseMirrorDocument(
     pmDoc,

--- a/packages/core/src/prosemirror/extensions/core/DocExtension.ts
+++ b/packages/core/src/prosemirror/extensions/core/DocExtension.ts
@@ -10,6 +10,7 @@ export const DocExtension = createNodeExtension({
   nodeSpec: {
     attrs: {
       _finalSectionStart: { default: null },
+      _adjustLineHeightInTable: { default: false },
     },
     content: "(paragraph | horizontalRule | pageBreak | table | textBox | blockSdt)+",
   },

--- a/packages/docx-core/src/model/document.ts
+++ b/packages/docx-core/src/model/document.ts
@@ -214,6 +214,11 @@ export type DocumentSettings = {
    */
   evenAndOddHeaders?: boolean;
   /**
+   * `w:adjustLineHeightInTable` (§17.15.3.1): apply the section line-grid
+   * pitch to paragraphs inside table cells.
+   */
+  adjustLineHeightInTable?: true;
+  /**
    * `w:updateFields` (§17.15.1.93) — ask the consuming application to
    * recompute every field when the document opens. Set by generators that
    * emit a TOC or cross-references without computed results.


### PR DESCRIPTION
## Summary

- parse the table line-grid compatibility setting by namespace URI
- carry the setting through browser and headless layout
- apply section line pitch recursively to table-cell paragraphs when enabled

CC on behalf of sok0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DOCX documents now apply section line-grid spacing to paragraphs within table cells when the document settings request it.
  * This behaviour also applies to nested tables.

* **Bug Fixes**
  * Improved handling of table-cell line spacing based on document compatibility settings.

* **Tests**
  * Added coverage for enabled, disabled, missing, and namespace-specific compatibility settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->