### PR TITLE
fix(core): a section break precedes the recorded property change in w:pPr

### DIFF
--- a/.changeset/section-break-before-change.md
+++ b/.changeset/section-break-before-change.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Write a section break where the schema places it in a paragraph's properties: after the mark's run properties and before a recorded property change. A paragraph that ended a section and also recorded a property change had its break written after the change, and a consumer refused the part.

--- a/packages/core/src/docx/serializer/paragraphSerializer.test.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer.test.ts
@@ -536,4 +536,25 @@ describe("pPr children follow the schema's sequence", () => {
     expect(order).not.toContain(-1);
     expect(order).toEqual([...order].toSorted((left, right) => left - right));
   });
+
+  // `CT_PPr` ends with `rPr`, `sectPr`, `pPrChange`. A section break on a
+  // paragraph whose properties also record a change used to be appended after
+  // the change, and a consumer refused the part.
+  test("a section break precedes the recorded property change", () => {
+    const paragraph = parseProperties(
+      `<w:pStyle w:val="Heading1"/><w:rPr><w:rFonts w:hint="eastAsia"/></w:rPr>` +
+        `<w:sectPr><w:pgSz w:w="15840" w:h="12240" w:orient="landscape"/></w:sectPr>` +
+        `<w:pPrChange w:id="410" w:author="Reviewer" w:date="2000-01-01T00:00:00Z">` +
+        `<w:pPr><w:spacing w:after="200"/></w:pPr></w:pPrChange>`,
+    );
+
+    const xml = serializeParagraph(paragraph);
+    const order = ["<w:pStyle", "<w:rPr>", "<w:sectPr>", "<w:pPrChange"].map((element) =>
+      xml.indexOf(element),
+    );
+
+    expect(order).not.toContain(-1);
+    expect(order).toEqual([...order].toSorted((left, right) => left - right));
+    expect(xml.indexOf("<w:sectPr>")).toBeLessThan(xml.indexOf("</w:pPr>"));
+  });
 });

--- a/packages/core/src/docx/serializer/paragraphSerializer.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer.ts
@@ -29,6 +29,7 @@ import type {
   MoveFromRangeStart,
   MoveToRangeStart,
   ParagraphPropertyChange,
+  SectionProperties,
   SdtProperties,
   TabStop,
   ShadingProperties,
@@ -389,11 +390,20 @@ function serializeParagraphMarkChange(mark: ParagraphMarkChange): string {
   return `<w:${mark.kind} ${attrs}/>`;
 }
 
-export function serializeParagraphFormatting(
+type SerializeParagraphFormattingOptions = {
+  propertyChanges?: ParagraphPropertyChange[] | undefined;
+  paragraphMarkChange?: ParagraphMarkChange | undefined;
+  sectionProperties?: SectionProperties | undefined;
+};
+
+const serializeParagraphFormattingWithOptions = (
   formatting: ParagraphFormatting | undefined,
-  propertyChanges?: ParagraphPropertyChange[],
-  pPrMark?: ParagraphMarkChange,
-): string {
+  {
+    propertyChanges,
+    paragraphMarkChange,
+    sectionProperties,
+  }: SerializeParagraphFormattingOptions = {},
+): string => {
   const parts: string[] = [];
 
   // Emit a boolean toggle: a bare element for true, `w:val="0"` for an explicit
@@ -510,8 +520,10 @@ export function serializeParagraphFormatting(
     // EG_ParaRPrTrackChanges (ECMA-376 §17.13.5 / wml.xsd:1837) puts
     // <w:ins>/<w:del> FIRST inside the paragraph mark's rPr; strict
     // readers reject other orderings.
-    if (pPrMark || formatting.runProperties || formatting.runInWithNext) {
-      const pPrMarkXml = pPrMark ? serializeParagraphMarkChange(pPrMark) : "";
+    if (paragraphMarkChange || formatting.runProperties || formatting.runInWithNext) {
+      const pPrMarkXml = paragraphMarkChange
+        ? serializeParagraphMarkChange(paragraphMarkChange)
+        : "";
       const innerRPr = formatting.runProperties
         ? extractRPrInner(serializeTextFormatting(formatting.runProperties))
         : "";
@@ -521,19 +533,36 @@ export function serializeParagraphFormatting(
         parts.push(`<w:rPr>${fullInner}</w:rPr>`);
       }
     }
-  } else if (pPrMark) {
-    parts.push(`<w:rPr>${serializeParagraphMarkChange(pPrMark)}</w:rPr>`);
+  } else if (paragraphMarkChange) {
+    parts.push(`<w:rPr>${serializeParagraphMarkChange(paragraphMarkChange)}</w:rPr>`);
   }
+
+  // `CT_PPr` closes with `rPr`, `sectPr`, `pPrChange` in that order: a section
+  // break sits between the mark's run properties and the recorded change, so
+  // it is placed here rather than appended after the properties are built.
+  parts.push(serializeSectionProperties(sectionProperties));
 
   if (propertyChanges && propertyChanges.length > 0) {
     parts.push(...propertyChanges.map((change) => serializeParagraphPropertyChange(change)));
   }
 
-  if (parts.length === 0) {
+  const inner = parts.join("");
+  if (inner.length === 0) {
     return "";
   }
 
-  return `<w:pPr>${parts.join("")}</w:pPr>`;
+  return `<w:pPr>${inner}</w:pPr>`;
+};
+
+export function serializeParagraphFormatting(
+  formatting: ParagraphFormatting | undefined,
+  propertyChanges?: ParagraphPropertyChange[],
+  paragraphMarkChange?: ParagraphMarkChange,
+): string {
+  return serializeParagraphFormattingWithOptions(formatting, {
+    propertyChanges,
+    paragraphMarkChange,
+  });
 }
 
 function extractPPrInner(pPrXml: string): string {
@@ -1159,15 +1188,13 @@ export function serializeParagraph(paragraph: Paragraph): string {
   const attrsStr = attrs.length > 0 ? ` ${attrs.join(" ")}` : "";
 
   // Add paragraph properties if present
-  const pPrXml = serializeParagraphFormatting(
-    paragraph.formatting,
-    paragraph.propertyChanges,
-    paragraph.pPrMark,
+  parts.push(
+    serializeParagraphFormattingWithOptions(paragraph.formatting, {
+      propertyChanges: paragraph.propertyChanges,
+      paragraphMarkChange: paragraph.pPrMark,
+      sectionProperties: paragraph.sectionProperties,
+    }),
   );
-  const sectionPropertiesXml = serializeSectionProperties(paragraph.sectionProperties);
-  if (pPrXml || sectionPropertiesXml) {
-    parts.push(`<w:pPr>${extractPPrInner(pPrXml)}${sectionPropertiesXml}</w:pPr>`);
-  }
 
   // Comment ids whose reference run is modeled explicitly (parsed-from-Word),
   // so the matching commentRangeEnd does not double-emit it (see


### PR DESCRIPTION
`CT_PPr` ends with `rPr`, `sectPr`, `pPrChange` in that order. The section break was appended after the assembled paragraph properties, so a paragraph that ended a section and also recorded a property change carried its break after the change, and a consumer refused the part as unreadable.

The break is now placed where the properties are built, between the mark's run properties and the recorded change. A test pins the order for a paragraph carrying a style, run properties, a section break and a property change.

Changeset included. Digests: the Benchmarks job says whether any generated case carries this shape.