### PR TITLE
fix: scope line-edge defaults to East Asian text

### DIFF
--- a/.changeset/calm-line-edges.md
+++ b/.changeset/calm-line-edges.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Scope default line-edge punctuation restrictions to East Asian text.

--- a/packages/core/src/layout-engine/measure/lineBreakProvider.ts
+++ b/packages/core/src/layout-engine/measure/lineBreakProvider.ts
@@ -269,6 +269,14 @@ const allowsBreak = (
 ): boolean => {
   const previous = previousCodePoint(text, index);
   const next = nextLineStart ?? firstCodePoint(text, index);
+  const appliesLineEdgeRestrictions =
+    usesEastAsianRules ||
+    policy?.kinsoku === true ||
+    policy?.noLineBreaksBefore !== undefined ||
+    policy?.noLineBreaksAfter !== undefined;
+  if (!appliesLineEdgeRestrictions) {
+    return true;
+  }
   const permitsSpacedPercentage =
     previous === " " &&
     next === "%" &&

--- a/packages/core/src/layout-engine/measure/lineBreaks.test.ts
+++ b/packages/core/src/layout-engine/measure/lineBreaks.test.ts
@@ -60,6 +60,11 @@ describe("findWordBreaks", () => {
     expect(findWordBreaks("text a text", { locale: "cs-CZ" })).toEqual([5, 7]);
   });
 
+  test("does not apply East-Asian line-edge punctuation defaults to Arabic text", () => {
+    expect(findWordBreaks("بنك ………………..", { locale: "ar-SA" })).toEqual([4]);
+    expect(findWordBreaks("بنك ………………..", { locale: "ar-SA", kinsoku: true })).toEqual([]);
+  });
+
   test("allows a spaced percentage to wrap in non-East-Asian text", () => {
     expect(findWordBreaks("10 %. Pro", { locale: "cs-CZ" })).toEqual([3, 6]);
     expect(findWordBreaks("10 %. Next", { locale: "en-US" })).toEqual([3, 6]);


### PR DESCRIPTION
## Summary

- apply default prohibited line-edge punctuation only to East Asian text
- preserve explicit `kinsoku` and document-specific replacement lists
- cover Arabic punctuation-leader wrapping with a focused regression test

## Testing

- `bun test packages/core/src/layout-engine/measure/lineBreaks.test.ts`
- targeted formatting and lint checks