### PR TITLE
fix(core): honor table style cascade precedence

### DIFF
--- a/.changeset/small-wolves-listen.md
+++ b/.changeset/small-wolves-listen.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Honor paragraph and conditional-region precedence in table style cascades.

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks-style-cascade.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks-style-cascade.test.ts
@@ -626,6 +626,113 @@ describe("toFlowBlocks style cascade", () => {
     expect(firstTableRun(blocks).fontFamily).toBe("Arial");
   });
 
+  test("a paragraph style color overrides table conditional run formatting", () => {
+    const styles: StyleDefinitions = {
+      styles: [
+        {
+          styleId: "BodyText",
+          type: "paragraph",
+          name: "Body Text",
+          rPr: { color: { rgb: "22272B" } },
+        },
+        {
+          styleId: "AccentTable",
+          type: "table",
+          name: "Accent Table",
+          rPr: { color: { rgb: "CBEDFD" } },
+          tblStylePr: [
+            {
+              type: "firstCol",
+              tcPr: { shading: { fill: { rgb: "FFFFFF" } } },
+            },
+            {
+              type: "firstRow",
+              rPr: { color: { rgb: "FFFFFF" } },
+              tcPr: { shading: { fill: { rgb: "CBEDFD" } } },
+            },
+          ],
+        },
+      ],
+    };
+    const table: Table = {
+      type: "table",
+      formatting: { styleId: "AccentTable", look: { firstRow: true, firstColumn: true } },
+      rows: [
+        {
+          type: "tableRow",
+          cells: [
+            {
+              type: "tableCell",
+              content: [
+                {
+                  type: "paragraph",
+                  formatting: { styleId: "BodyText" },
+                  content: [{ type: "run", content: [{ type: "text", text: "body" }] }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const proseDoc = toProseDoc(
+      { package: { document: { content: [table] }, styles } },
+      { styles },
+    );
+    const blocks = toFlowBlocks(proseDoc, {});
+
+    expect(firstTableRun(blocks).color).toBe("#22272B");
+    expect(proseDoc.firstChild?.firstChild?.firstChild?.attrs["backgroundColor"]).toBe("CBEDFD");
+  });
+
+  test("table conditional color overrides the implicit default paragraph style", () => {
+    const styles: StyleDefinitions = {
+      styles: [
+        {
+          styleId: "Normal",
+          type: "paragraph",
+          default: true,
+          name: "Normal",
+          rPr: { color: { rgb: "22272B" } },
+        },
+        {
+          styleId: "HeaderTable",
+          type: "table",
+          name: "Header Table",
+          tblStylePr: [{ type: "firstRow", rPr: { color: { rgb: "FFFFFF" } } }],
+        },
+      ],
+    };
+    const table: Table = {
+      type: "table",
+      formatting: { styleId: "HeaderTable", look: { firstRow: true } },
+      rows: [
+        {
+          type: "tableRow",
+          cells: [
+            {
+              type: "tableCell",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "run", content: [{ type: "text", text: "header" }] }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const blocks = toFlowBlocks(
+      toProseDoc({ package: { document: { content: [table] }, styles } }, { styles }),
+      {},
+    );
+
+    expect(firstTableRun(blocks).color).toBe("#FFFFFF");
+  });
+
   test("paragraph style toggles apply above an explicit table-style off", () => {
     const styles: StyleDefinitions = {
       styles: [

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -466,6 +466,10 @@ function convertParagraph(
     inheritableParagraphRunFormatting =
       stripParagraphMarkFormattingForBodyRuns(paragraphRunFormatting);
   }
+  const ordinaryStyleFormatting =
+    paragraph.formatting?.styleId === undefined
+      ? mergeTextFormatting(styleRunFormatting, extraRunFormatting)
+      : mergeTextFormatting(extraRunFormatting, styleRunFormatting);
   const orderedToggleFormatting = cascadeStyleTextFormatting(
     [
       { formatting: styleResolver?.getDocDefaults()?.rPr, type: "defaults" },
@@ -473,15 +477,13 @@ function convertParagraph(
       { formatting: paragraphStyleRunFormatting, type: "style" },
     ],
     {
-      ordinaryFormatting: mergeTextFormatting(styleRunFormatting, extraRunFormatting),
+      ordinaryFormatting: ordinaryStyleFormatting,
     },
   );
   let baseRunFormatting = orderedToggleFormatting.formatting;
   // A table style can carry legacy theme/fallback fonts from the template
-  // that created it. Word keeps the paragraph style's authored font in that
-  // case while still applying the table style's color, emphasis, and size.
-  // Preserve the paragraph-style font slots over the table contribution;
-  // direct run formatting still wins later in getInheritedRunFormatting.
+  // that created it. Preserve the paragraph style's authored font slots over
+  // the table contribution; direct run formatting still wins later.
   if (paragraphStyleFontFamily) {
     baseRunFormatting = mergeTextFormatting(baseRunFormatting, {
       fontFamily: paragraphStyleFontFamily,
@@ -2141,22 +2143,10 @@ function convertTableRow(
       effectiveRowBandStyle = conditionalStyles?.band2Horz;
     }
 
-    // Build conditional style precedence (wholeTable -> banding -> row/col -> corners)
+    // Build conditional style precedence (wholeTable -> banding -> columns -> rows -> corners)
     let cellConditionalStyle = conditionalStyles?.wholeTable;
     cellConditionalStyle = mergeConditionalStyles(cellConditionalStyle, effectiveRowBandStyle);
     cellConditionalStyle = mergeConditionalStyles(cellConditionalStyle, vertBandStyle);
-    if (cellIsFirstRow && (tableLook?.firstRow || rowCnf?.firstRow || cellCnf?.firstRow)) {
-      cellConditionalStyle = mergeConditionalStyles(
-        cellConditionalStyle,
-        conditionalStyles?.firstRow,
-      );
-    }
-    if (cellIsLastRow && (tableLook?.lastRow || rowCnf?.lastRow || cellCnf?.lastRow)) {
-      cellConditionalStyle = mergeConditionalStyles(
-        cellConditionalStyle,
-        conditionalStyles?.lastRow,
-      );
-    }
     if (cellIsFirstCol && (tableLook?.firstColumn || rowCnf?.firstColumn || cellCnf?.firstColumn)) {
       cellConditionalStyle = mergeConditionalStyles(
         cellConditionalStyle,
@@ -2167,6 +2157,18 @@ function convertTableRow(
       cellConditionalStyle = mergeConditionalStyles(
         cellConditionalStyle,
         conditionalStyles?.lastCol,
+      );
+    }
+    if (cellIsFirstRow && (tableLook?.firstRow || rowCnf?.firstRow || cellCnf?.firstRow)) {
+      cellConditionalStyle = mergeConditionalStyles(
+        cellConditionalStyle,
+        conditionalStyles?.firstRow,
+      );
+    }
+    if (cellIsLastRow && (tableLook?.lastRow || rowCnf?.lastRow || cellCnf?.lastRow)) {
+      cellConditionalStyle = mergeConditionalStyles(
+        cellConditionalStyle,
+        conditionalStyles?.lastRow,
       );
     }
     if (


### PR DESCRIPTION
## Summary

- let named paragraph styles override ordinary table-style run properties
- apply row conditional formatting after column formatting and before corner formatting
- retain table conditional run colors for style-less cell paragraphs

## Verification

- `bun test packages/core/src/layout-bridge/convert/toFlowBlocks-style-cascade.test.ts packages/core/src/layout-bridge/convert/toFlowBlocks-run-marks.test.ts`
- `bun audit`