### PR TITLE
perf(core): coalesce bulk tracked-change resolution

### DIFF
--- a/.changeset/swift-lines-resolve.md
+++ b/.changeset/swift-lines-resolve.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Resolve bulk tracked changes with fewer document steps.

--- a/packages/core/src/prosemirror/commands/comments.test.ts
+++ b/packages/core/src/prosemirror/commands/comments.test.ts
@@ -178,6 +178,68 @@ describe("AI revision accept/reject scoping", () => {
   });
 });
 
+describe("bulk revision resolution cost", () => {
+  const paragraphCount = 3;
+  const stateWithFormattedInsertion = () => {
+    const revision = schema.marks["insertion"]!.create(REV_A_ATTRS);
+    const bold = schema.marks["bold"]!.create();
+    return EditorState.create({
+      schema,
+      doc: schema.node(
+        "doc",
+        null,
+        Array.from({ length: paragraphCount }, () =>
+          schema.node("paragraph", null, [
+            schema.text("plain", [revision]),
+            schema.text("bold", [revision, bold]),
+            schema.text("plain", [revision]),
+          ]),
+        ),
+      ),
+    });
+  };
+
+  test("bulk acceptance clears formatted revisions with one mark-removal step", () => {
+    const state = stateWithFormattedInsertion();
+    const dispatched: Transaction[] = [];
+
+    expect(
+      acceptAllChanges()(state, (transaction) => {
+        dispatched.push(transaction);
+      }),
+    ).toBe(true);
+
+    const transaction = dispatched.at(0);
+    expect(transaction).toBeDefined();
+    if (!transaction) {
+      return;
+    }
+    const resolvedState = state.apply(transaction);
+    expect(transaction.steps).toHaveLength(1);
+    expect(resolvedState.doc.textContent).toBe("plainboldplain".repeat(paragraphCount));
+    expect(insertionRevisionsAt(resolvedState)).toEqual([]);
+  });
+
+  test("bulk rejection coalesces formatted revisions within each paragraph", () => {
+    const state = stateWithFormattedInsertion();
+    const dispatched: Transaction[] = [];
+
+    expect(
+      rejectAllChanges()(state, (transaction) => {
+        dispatched.push(transaction);
+      }),
+    ).toBe(true);
+
+    const transaction = dispatched.at(0);
+    expect(transaction).toBeDefined();
+    if (!transaction) {
+      return;
+    }
+    expect(transaction.steps).toHaveLength(paragraphCount);
+    expect(state.apply(transaction).doc.textContent).toBe("");
+  });
+});
+
 describe("table row structural revision resolution", () => {
   const row = (
     text: string,

--- a/packages/core/src/prosemirror/commands/comments.ts
+++ b/packages/core/src/prosemirror/commands/comments.ts
@@ -117,6 +117,9 @@ function resolveChange(
     const keepType = mode === "accept" ? insertionType : deletionType;
     const removeType = mode === "accept" ? deletionType : insertionType;
     const revisionSet = revisionIds === undefined ? null : new Set<number>(revisionIds);
+    // A range-wide removal lets ProseMirror coalesce one revision split by
+    // inline formatting. The id-scoped path must keep matching each mark.
+    const removeKeptMarksInBulk = revisionSet === null && keepType !== undefined;
     const matchesRevision = (mark: { attrs: Record<string, unknown> }) =>
       revisionSet === null ||
       (typeof mark.attrs["revisionId"] === "number" && revisionSet.has(mark.attrs["revisionId"]));
@@ -277,15 +280,36 @@ function resolveChange(
           deleteRanges.push({ from: rangeFrom, to: rangeTo });
         }
 
-        for (const mark of node.marks) {
-          if (keepType && mark.type === keepType && matchesRevision(mark)) {
-            tr.removeMark(rangeFrom, rangeTo, mark);
+        if (!removeKeptMarksInBulk) {
+          for (const mark of node.marks) {
+            if (keepType && mark.type === keepType && matchesRevision(mark)) {
+              tr.removeMark(rangeFrom, rangeTo, mark);
+            }
           }
         }
         return true;
       });
 
-      for (const range of deleteRanges.toReversed()) {
+      if (removeKeptMarksInBulk) {
+        tr.removeMark(from, to, keepType);
+      }
+
+      let rangesToDelete = deleteRanges;
+      if (revisionSet === null) {
+        // Adjacent inline ranges have no paragraph boundary between them, so
+        // one replacement has the same mapping outside the deleted content.
+        const coalescedDeleteRanges: { from: number; to: number }[] = [];
+        for (const range of deleteRanges) {
+          const previous = coalescedDeleteRanges.at(-1);
+          if (previous && range.from <= previous.to) {
+            previous.to = Math.max(previous.to, range.to);
+            continue;
+          }
+          coalescedDeleteRanges.push({ from: range.from, to: range.to });
+        }
+        rangesToDelete = coalescedDeleteRanges;
+      }
+      for (const range of rangesToDelete.toReversed()) {
         tr.delete(range.from, range.to);
       }
 


### PR DESCRIPTION
## Summary

- remove accepted or rejected retained revision marks across the whole requested range during bulk resolution
- coalesce adjacent removed-revision ranges before deleting them
- keep revision-ID-scoped resolution on its existing per-mark path

## Verification

- focused bulk and targeted revision tests pass
- a synthetic three-paragraph invariant reduces bulk accept to one transaction step and bulk reject to one step per paragraph
- focused formatting and lint checks pass
