### PR TITLE
feat(core): compare direct run font properties

### DIFF
--- a/.changeset/tracked-font-properties.md
+++ b/.changeset/tracked-font-properties.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": minor
+---
+
+Compare and track direct font family, half-point size, and RGB color changes without rewriting unchanged text.

--- a/api-reports/core/ai-edits.api.md
+++ b/api-reports/core/ai-edits.api.md
@@ -139,6 +139,7 @@ export type FolioAIBlockPreviewRun = {
     fontFamily?: string;
     fontSizePt?: number;
     color?: string;
+    directFormatting?: FolioAIInlineFormatting;
 };
 
 // @public
@@ -445,6 +446,9 @@ export type FolioAIInlineFormatting = {
     italic?: boolean;
     underline?: boolean;
     strike?: boolean;
+    fontFamily?: string | null;
+    fontSizePt?: number | null;
+    color?: string | null;
 };
 
 // @public

--- a/api-reports/core/ai-edits.api.md
+++ b/api-reports/core/ai-edits.api.md
@@ -441,11 +441,7 @@ export type FolioAIEditView = {
 };
 
 // @public (undocumented)
-export type FolioAIInlineFormatting = {
-    bold?: boolean;
-    italic?: boolean;
-    underline?: boolean;
-    strike?: boolean;
+export type FolioAIInlineFormatting = Partial<Record<"bold" | "italic" | "underline" | "strike", boolean>> & {
     fontFamily?: string | null;
     fontSizePt?: number | null;
     color?: string | null;

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -771,6 +771,7 @@ export type FolioAIBlockPreviewRun = {
     fontFamily?: string;
     fontSizePt?: number;
     color?: string;
+    directFormatting?: FolioAIInlineFormatting;
 };
 
 // @public

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -771,6 +771,7 @@ export type FolioAIBlockPreviewRun = {
     fontFamily?: string;
     fontSizePt?: number;
     color?: string;
+    directFormatting?: FolioAIInlineFormatting;
 };
 
 // @public

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -296,13 +296,11 @@ export type ParagraphPropertyChangeAttrs = Omit<import__stll_docx_core_model.Par
 };
 
 // @public (undocumented)
-export type RunFormattingOverrideAttrs = { [K in keyof Pick<import__stll_docx_core_model.TextFormatting, "bold" | "italic" | "strike" | "allCaps" | "smallCaps" | "hidden" | "emboss" | "imprint" | "shadow" | "outline">]?: boolean; } & {
+export type RunFormattingOverrideAttrs = Partial<Record<"bold" | "boldCs" | "cs" | "italic" | "italicCs" | "strike" | "allCaps" | "smallCaps" | "hidden" | "emboss" | "imprint" | "shadow" | "outline", boolean>> & {
+    directFontProperties?: readonly ("fontFamily" | "fontSize" | "color")[];
     doubleStrike?: false;
     rtl?: false;
-    boldCs?: boolean;
-    cs?: boolean;
     fontSizeCs?: number;
-    italicCs?: boolean;
     underline?: "none";
 };
 

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -511,6 +511,7 @@ export type FolioAIBlockPreviewRun = {
     fontFamily?: string;
     fontSizePt?: number;
     color?: string;
+    directFormatting?: FolioAIInlineFormatting;
 };
 
 // @public (undocumented)
@@ -749,6 +750,9 @@ export type FolioAIInlineFormatting = {
     italic?: boolean;
     underline?: boolean;
     strike?: boolean;
+    fontFamily?: string | null;
+    fontSizePt?: number | null;
+    color?: string | null;
 };
 
 // @public

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -745,11 +745,7 @@ export type FolioAIEditSnapshot = {
 };
 
 // @public (undocumented)
-export type FolioAIInlineFormatting = {
-    bold?: boolean;
-    italic?: boolean;
-    underline?: boolean;
-    strike?: boolean;
+export type FolioAIInlineFormatting = Partial<Record<"bold" | "italic" | "underline" | "strike", boolean>> & {
     fontFamily?: string | null;
     fontSizePt?: number | null;
     color?: string | null;

--- a/packages/core/src/ai-edits/aiEdits.test.ts
+++ b/packages/core/src/ai-edits/aiEdits.test.ts
@@ -697,8 +697,54 @@ describe("Folio AI edit operations", () => {
         underline: true,
         fontFamily: "Aptos",
         fontSizePt: 14,
+        directFormatting: {
+          bold: true,
+          italic: true,
+          underline: true,
+          fontFamily: "Aptos",
+          fontSizePt: 14,
+        },
       },
       { text: " No underline" },
+    ]);
+  });
+
+  test("distinguishes inherited formatting from direct run formatting", () => {
+    const fontSizeType = schema.marks["fontSize"];
+    const fontFamilyType = schema.marks["fontFamily"];
+    const state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [
+        schema.node(
+          "paragraph",
+          {
+            defaultTextFormatting: {
+              fontFamily: { ascii: "Arial", hAnsi: "Arial" },
+              fontSize: 22,
+            },
+          },
+          [
+            schema.text("Inherited ", [
+              fontSizeType.create({ size: 22 }),
+              fontFamilyType.create({ ascii: "Arial", hAnsi: "Arial" }),
+            ]),
+            schema.text("Direct", [
+              fontSizeType.create({ size: 24 }),
+              fontFamilyType.create({ ascii: "Georgia", hAnsi: "Georgia" }),
+            ]),
+          ],
+        ),
+      ]),
+    });
+
+    expect(createFolioAIEditSnapshot(state.doc).blocks.at(0)?.previewRuns).toEqual([
+      { text: "Inherited ", fontFamily: "Arial", fontSizePt: 11 },
+      {
+        text: "Direct",
+        fontFamily: "Georgia",
+        fontSizePt: 12,
+        directFormatting: { fontFamily: "Georgia", fontSizePt: 12 },
+      },
     ]);
   });
 

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -386,6 +386,7 @@ type ApplyInlineFormattingOptions = {
   from: number;
   to: number;
   formatting: InlineFormattingPatch;
+  includedProperties?: readonly string[];
 };
 
 const REPLACEMENT_BACKGROUND_CLEAR_FORMATTING = {
@@ -393,9 +394,8 @@ const REPLACEMENT_BACKGROUND_CLEAR_FORMATTING = {
   runShading: false,
 } as const;
 
-type InlineFormattingPatch =
-  | FolioAIInlineFormatting
-  | typeof REPLACEMENT_BACKGROUND_CLEAR_FORMATTING;
+type InlineFormattingPatch = FolioAIInlineFormatting &
+  Partial<typeof REPLACEMENT_BACKGROUND_CLEAR_FORMATTING>;
 
 const INLINE_FORMATTING_MARK_NAMES = {
   bold: "bold",
@@ -443,8 +443,12 @@ const applyInlineFormatting = ({
   from,
   to,
   formatting,
+  includedProperties,
 }: ApplyInlineFormattingOptions): Transaction => {
   for (const [property, value] of Object.entries(formatting)) {
+    if (includedProperties && !includedProperties.includes(property)) {
+      continue;
+    }
     const markName = formattingMarkName(property);
     const markType = markName ? schema.marks[markName] : undefined;
     if (!markType) {
@@ -459,7 +463,14 @@ const applyInlineFormatting = ({
     }
     tr.removeMark(from, to, markType);
   }
-  applyDirectFontProvenance({ tr, schema, from, to, formatting });
+  applyDirectFontProvenance({
+    tr,
+    schema,
+    from,
+    to,
+    formatting,
+    ...(includedProperties ? { includedProperties } : {}),
+  });
   return tr;
 };
 
@@ -469,16 +480,20 @@ const applyDirectFontProvenance = ({
   from,
   to,
   formatting,
+  includedProperties,
 }: ApplyInlineFormattingOptions): void => {
   if ("highlight" in formatting) {
     return;
   }
   const updates = [
-    ["fontFamily", formatting.fontFamily],
-    ["fontSize", formatting.fontSizePt],
-    ["color", formatting.color],
+    ["fontFamily", "fontFamily", formatting.fontFamily],
+    ["fontSize", "fontSizePt", formatting.fontSizePt],
+    ["color", "color", formatting.color],
   ] as const;
-  const changed = updates.filter(([, value]) => value !== undefined);
+  const changed = updates.filter(
+    ([, inputProperty, value]) =>
+      value !== undefined && (!includedProperties || includedProperties.includes(inputProperty)),
+  );
   const markType = schema.marks["runFormattingOverride"];
   if (!markType || changed.length === 0) {
     return;
@@ -493,7 +508,7 @@ const applyDirectFontProvenance = ({
     const existing = node.marks.find((mark) => mark.type === markType);
     const attrs = existing ? expectRunFormattingOverrideMarkAttrs(existing) : {};
     const directFontProperties = new Set(attrs.directFontProperties);
-    for (const [property, value] of changed) {
+    for (const [property, , value] of changed) {
       if (value === null) {
         directFontProperties.delete(property);
       } else {
@@ -520,33 +535,75 @@ const applyDirectFontProvenance = ({
   });
 };
 
-const formattingWouldChange = (
+const directFontPropertyForFormattingProperty = (
+  property: string,
+): (typeof DIRECT_FONT_PROPERTIES)[number] | null => {
+  switch (property) {
+    case "fontFamily":
+      return "fontFamily";
+    case "fontSizePt":
+      return "fontSize";
+    case "color":
+      return "color";
+    default:
+      return null;
+  }
+};
+
+const formattingPropertyWouldChange = (
+  marks: readonly Mark[],
+  property: string,
+  value: boolean | string | number | null,
+): boolean => {
+  const markName = formattingMarkName(property);
+  const mark = marks.find((candidate) => candidate.type.name === markName);
+  const directFontProperty = directFontPropertyForFormattingProperty(property);
+  if (directFontProperty) {
+    const overrideMark = marks.find((candidate) => candidate.type.name === "runFormattingOverride");
+    const isDirect = overrideMark
+      ? (expectRunFormattingOverrideMarkAttrs(overrideMark).directFontProperties ?? []).includes(
+          directFontProperty,
+        )
+      : false;
+    if (value === false || value === null) {
+      return isDirect;
+    }
+    if (!isDirect) {
+      return true;
+    }
+  } else if (value === false || value === null) {
+    return mark !== undefined;
+  }
+  if (property === "underline") {
+    return mark?.attrs["style"] !== "single";
+  }
+  if (property === "fontFamily") {
+    return mark?.attrs["ascii"] !== value || mark?.attrs["hAnsi"] !== value;
+  }
+  if (property === "fontSizePt") {
+    return Number(mark?.attrs["size"]) !== Number(value) * 2;
+  }
+  if (property === "color") {
+    const current = mark?.attrs["rgb"];
+    const normalizedCurrent =
+      typeof current === "string" ? current.replace(/^#/u, "").toUpperCase() : null;
+    return normalizedCurrent !== String(value).replace(/^#/u, "").toUpperCase();
+  }
+  return mark === undefined;
+};
+
+const formattingChangesForMarks = (
   marks: readonly Mark[],
   formatting: InlineFormattingPatch,
-): boolean =>
-  Object.entries(formatting).some(([property, value]) => {
-    const markName = formattingMarkName(property);
-    const mark = marks.find((candidate) => candidate.type.name === markName);
-    if (value === false || value === null) {
-      return mark !== undefined;
+): string[] => {
+  const changes: string[] = [];
+  for (const [property, value] of Object.entries(formatting)) {
+    if (formattingPropertyWouldChange(marks, property, value)) {
+      changes.push(property);
     }
-    if (property === "underline") {
-      return mark?.attrs["style"] !== "single";
-    }
-    if (property === "fontFamily") {
-      return mark?.attrs["ascii"] !== value || mark?.attrs["hAnsi"] !== value;
-    }
-    if (property === "fontSizePt") {
-      return Number(mark?.attrs["size"]) !== Number(value) * 2;
-    }
-    if (property === "color") {
-      const current = mark?.attrs["rgb"];
-      const normalizedCurrent =
-        typeof current === "string" ? current.replace(/^#/u, "").toUpperCase() : null;
-      return normalizedCurrent !== String(value).replace(/^#/u, "").toUpperCase();
-    }
-    return mark === undefined;
-  });
+  }
+  return changes;
+};
 
 type ApplyTrackedInlineFormattingOptions = ApplyInlineFormattingOptions & {
   doc: PMNode;
@@ -632,9 +689,18 @@ const applyTrackedInlineFormatting = ({
     return tr;
   }
 
-  const segments: { from: number; to: number; changes: RunPropertyChange[] }[] = [];
+  const segments: {
+    from: number;
+    to: number;
+    includedProperties: string[];
+    changes: RunPropertyChange[];
+  }[] = [];
   doc.nodesBetween(from, to, (node, pos) => {
-    if (!node.isText || !formattingWouldChange(node.marks, formatting)) {
+    if (!node.isText) {
+      return;
+    }
+    const includedProperties = formattingChangesForMarks(node.marks, formatting);
+    if (includedProperties.length === 0) {
       return;
     }
     const segmentFrom = Math.max(from, pos);
@@ -652,6 +718,7 @@ const applyTrackedInlineFormatting = ({
     segments.push({
       from: segmentFrom,
       to: segmentTo,
+      includedProperties,
       changes: [...existingChanges, change],
     });
   });
@@ -660,8 +727,15 @@ const applyTrackedInlineFormatting = ({
     return tr;
   }
   const suggestionAttrs = suggestionId === null ? {} : { provenance: "suggested", suggestionId };
-  applyInlineFormatting({ tr, schema, from, to, formatting });
   for (const segment of segments) {
+    applyInlineFormatting({
+      tr,
+      schema,
+      from: segment.from,
+      to: segment.to,
+      formatting,
+      includedProperties: segment.includedProperties,
+    });
     tr.addMark(
       segment.from,
       segment.to,

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -71,6 +71,7 @@ import type {
   FolioAIEditNormalization,
   FolioAIEditOperation,
   FolioAIEditSnapshot,
+  FolioAIInlineFormatting,
   FolioAIEditSkipReason,
   FolioAIEditSkippedOperation,
   FolioAISignatureParty,
@@ -392,6 +393,47 @@ type InlineFormattingPatch =
   | Extract<FolioAIEditOperation, { type: "formatRange" }>["formatting"]
   | typeof REPLACEMENT_BACKGROUND_CLEAR_FORMATTING;
 
+const INLINE_FORMATTING_MARK_NAMES = {
+  bold: "bold",
+  italic: "italic",
+  underline: "underline",
+  strike: "strike",
+  fontFamily: "fontFamily",
+  fontSizePt: "fontSize",
+  color: "textColor",
+  highlight: "highlight",
+  runShading: "runShading",
+} as const satisfies Record<
+  keyof FolioAIInlineFormatting | keyof typeof REPLACEMENT_BACKGROUND_CLEAR_FORMATTING,
+  string
+>;
+
+const formattingMarkName = (property: string): string | null => {
+  if (!Object.hasOwn(INLINE_FORMATTING_MARK_NAMES, property)) {
+    return null;
+  }
+  const name: unknown = Reflect.get(INLINE_FORMATTING_MARK_NAMES, property);
+  return typeof name === "string" ? name : null;
+};
+
+const formattingMarkAttrs = (
+  property: string,
+  value: boolean | string | number,
+): Record<string, unknown> | null => {
+  switch (property) {
+    case "underline":
+      return { style: "single" };
+    case "fontFamily":
+      return typeof value === "string" ? { ascii: value, hAnsi: value } : null;
+    case "fontSizePt":
+      return typeof value === "number" ? { size: value * 2 } : null;
+    case "color":
+      return typeof value === "string" ? { rgb: value.replace(/^#/u, "").toUpperCase() } : null;
+    default:
+      return {};
+  }
+};
+
 const applyInlineFormatting = ({
   tr,
   schema,
@@ -399,17 +441,17 @@ const applyInlineFormatting = ({
   to,
   formatting,
 }: ApplyInlineFormattingOptions): Transaction => {
-  for (const [name, enabled] of Object.entries(formatting)) {
-    const markType = schema.marks[name];
+  for (const [property, value] of Object.entries(formatting)) {
+    const markName = formattingMarkName(property);
+    const markType = markName ? schema.marks[markName] : undefined;
     if (!markType) {
       continue;
     }
-    if (enabled) {
-      tr.addMark(
-        from,
-        to,
-        name === "underline" ? markType.create({ style: "single" }) : markType.create(),
-      );
+    if (value !== false && value !== null) {
+      const attrs = formattingMarkAttrs(property, value);
+      if (attrs) {
+        tr.addMark(from, to, markType.create(attrs));
+      }
       continue;
     }
     tr.removeMark(from, to, markType);
@@ -421,13 +463,26 @@ const formattingWouldChange = (
   marks: readonly Mark[],
   formatting: InlineFormattingPatch,
 ): boolean =>
-  Object.entries(formatting).some(([name, enabled]) => {
-    const mark = marks.find((candidate) => candidate.type.name === name);
-    if (!enabled) {
+  Object.entries(formatting).some(([property, value]) => {
+    const markName = formattingMarkName(property);
+    const mark = marks.find((candidate) => candidate.type.name === markName);
+    if (value === false || value === null) {
       return mark !== undefined;
     }
-    if (name === "underline") {
+    if (property === "underline") {
       return mark?.attrs["style"] !== "single";
+    }
+    if (property === "fontFamily") {
+      return mark?.attrs["ascii"] !== value || mark?.attrs["hAnsi"] !== value;
+    }
+    if (property === "fontSizePt") {
+      return Number(mark?.attrs["size"]) !== Number(value) * 2;
+    }
+    if (property === "color") {
+      const current = mark?.attrs["rgb"];
+      const normalizedCurrent =
+        typeof current === "string" ? current.replace(/^#/u, "").toUpperCase() : null;
+      return normalizedCurrent !== String(value).replace(/^#/u, "").toUpperCase();
     }
     return mark === undefined;
   });

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -4,7 +4,11 @@ import { TableMap } from "prosemirror-tables";
 import { canJoin, canSplit } from "prosemirror-transform";
 import { panic } from "better-result";
 
-import { expectParagraphAttrs, expectRunPropertyChangeMarkAttrs } from "../prosemirror/attrs";
+import {
+  expectParagraphAttrs,
+  expectRunFormattingOverrideMarkAttrs,
+  expectRunPropertyChangeMarkAttrs,
+} from "../prosemirror/attrs";
 import { PPR_CHANGE_SCOPED_ATTR_KEYS } from "../prosemirror/commands/propertyChangeScope";
 import type { ParagraphPropertyChangeAttrs } from "../prosemirror/schema/nodes";
 import { marksToTextFormatting } from "../prosemirror/conversion/fromProseDoc";
@@ -390,7 +394,7 @@ const REPLACEMENT_BACKGROUND_CLEAR_FORMATTING = {
 } as const;
 
 type InlineFormattingPatch =
-  | Extract<FolioAIEditOperation, { type: "formatRange" }>["formatting"]
+  | FolioAIInlineFormatting
   | typeof REPLACEMENT_BACKGROUND_CLEAR_FORMATTING;
 
 const INLINE_FORMATTING_MARK_NAMES = {
@@ -403,10 +407,9 @@ const INLINE_FORMATTING_MARK_NAMES = {
   color: "textColor",
   highlight: "highlight",
   runShading: "runShading",
-} as const satisfies Record<
-  keyof FolioAIInlineFormatting | keyof typeof REPLACEMENT_BACKGROUND_CLEAR_FORMATTING,
-  string
->;
+} as const;
+
+const DIRECT_FONT_PROPERTIES = ["fontFamily", "fontSize", "color"] as const;
 
 const formattingMarkName = (property: string): string | null => {
   if (!Object.hasOwn(INLINE_FORMATTING_MARK_NAMES, property)) {
@@ -456,7 +459,65 @@ const applyInlineFormatting = ({
     }
     tr.removeMark(from, to, markType);
   }
+  applyDirectFontProvenance({ tr, schema, from, to, formatting });
   return tr;
+};
+
+const applyDirectFontProvenance = ({
+  tr,
+  schema,
+  from,
+  to,
+  formatting,
+}: ApplyInlineFormattingOptions): void => {
+  if ("highlight" in formatting) {
+    return;
+  }
+  const updates = [
+    ["fontFamily", formatting.fontFamily],
+    ["fontSize", formatting.fontSizePt],
+    ["color", formatting.color],
+  ] as const;
+  const changed = updates.filter(([, value]) => value !== undefined);
+  const markType = schema.marks["runFormattingOverride"];
+  if (!markType || changed.length === 0) {
+    return;
+  }
+
+  tr.doc.nodesBetween(from, to, (node, pos) => {
+    if (!node.isText) {
+      return;
+    }
+    const segmentFrom = Math.max(from, pos);
+    const segmentTo = Math.min(to, pos + node.nodeSize);
+    const existing = node.marks.find((mark) => mark.type === markType);
+    const attrs = existing ? expectRunFormattingOverrideMarkAttrs(existing) : {};
+    const directFontProperties = new Set(attrs.directFontProperties);
+    for (const [property, value] of changed) {
+      if (value === null) {
+        directFontProperties.delete(property);
+      } else {
+        directFontProperties.add(property);
+      }
+    }
+
+    tr.removeMark(segmentFrom, segmentTo, markType);
+    const nextAttrs = {
+      ...attrs,
+      directFontProperties: DIRECT_FONT_PROPERTIES.filter((property) =>
+        directFontProperties.has(property),
+      ),
+    };
+    if (
+      Object.entries(nextAttrs).some(([key, value]) =>
+        key === "directFontProperties"
+          ? Array.isArray(value) && value.length > 0
+          : value !== null && value !== undefined,
+      )
+    ) {
+      tr.addMark(segmentFrom, segmentTo, markType.create(nextAttrs));
+    }
+  });
 };
 
 const formattingWouldChange = (

--- a/packages/core/src/ai-edits/runPropertyFormatting.test.ts
+++ b/packages/core/src/ai-edits/runPropertyFormatting.test.ts
@@ -3,11 +3,19 @@ import JSZip from "jszip";
 
 import { parseDocx } from "../docx/parser";
 import { createDocx, repackDocx } from "../docx/rezip";
+import type { TextFormatting } from "../types/document";
 import { createEmptyDocument } from "../utils/createDocument";
 import { FolioDocxReviewer } from "./headless";
 import { createFolioAITextRangeHandle } from "./snapshot";
+import type { FolioAIInlineFormatting } from "./types";
 
-const createFormattingBaseline = async (): Promise<ArrayBuffer> => {
+type CreateFormattingBaselineOptions = {
+  formatting?: TextFormatting;
+};
+
+const createFormattingBaseline = async ({
+  formatting,
+}: CreateFormattingBaselineOptions = {}): Promise<ArrayBuffer> => {
   const document = createEmptyDocument();
   document.package.document.content = [
     {
@@ -16,12 +24,47 @@ const createFormattingBaseline = async (): Promise<ArrayBuffer> => {
       content: [
         {
           type: "run",
+          ...(formatting && { formatting }),
           content: [{ type: "text", text: "Formatting target" }],
         },
       ],
     },
   ];
   return createDocx(document);
+};
+
+type ApplyTrackedFormattingOptions = {
+  formatting: FolioAIInlineFormatting;
+  baselineFormatting?: TextFormatting;
+};
+
+const applyTrackedFormatting = async ({
+  formatting,
+  baselineFormatting,
+}: ApplyTrackedFormattingOptions): Promise<ArrayBuffer> => {
+  const reviewer = await FolioDocxReviewer.fromBuffer(
+    await createFormattingBaseline({ formatting: baselineFormatting }),
+    { author: "Reviewer" },
+  );
+  const block = reviewer.snapshot().blocks.at(0);
+  const range = block
+    ? createFolioAITextRangeHandle({
+        blockId: block.id,
+        text: block.text,
+        startOffset: 0,
+        endOffset: "Formatting".length,
+      })
+    : null;
+  if (!range) {
+    throw new Error("expected a formatting range");
+  }
+
+  const result = reviewer.applyOperations([
+    { id: "format", type: "formatRange", range, formatting },
+  ]);
+  expect(result.skipped).toEqual([]);
+  expect(result.applied.at(0)?.revisionId).toBeNumber();
+  return reviewer.toBuffer();
 };
 
 const HEADER_RELATIONSHIP_ID = "rIdFormattingHeader";
@@ -67,29 +110,7 @@ const documentXml = async (buffer: ArrayBuffer): Promise<string> => {
 };
 
 const applyTrackedBold = async (): Promise<ArrayBuffer> => {
-  const reviewer = await FolioDocxReviewer.fromBuffer(await createFormattingBaseline(), {
-    author: "Reviewer",
-  });
-  const snapshot = reviewer.snapshot();
-  const block = snapshot.blocks.at(0);
-  const range = block
-    ? createFolioAITextRangeHandle({
-        blockId: block.id,
-        text: block.text,
-        startOffset: 0,
-        endOffset: "Formatting".length,
-      })
-    : null;
-  if (!range) {
-    throw new Error("expected a formatting range");
-  }
-
-  const result = reviewer.applyOperations([
-    { id: "format", type: "formatRange", range, formatting: { bold: true } },
-  ]);
-  expect(result.skipped).toEqual([]);
-  expect(result.applied.at(0)?.revisionId).toBeNumber();
-  return reviewer.toBuffer();
+  return applyTrackedFormatting({ formatting: { bold: true } });
 };
 
 describe("tracked run formatting", () => {
@@ -156,5 +177,68 @@ describe("tracked run formatting", () => {
     expect(reopened.readReviewedStory({ story, view: "current-markup" })?.changes).toEqual([
       expect.objectContaining({ type: "formatting", text: "Header" }),
     ]);
+  });
+
+  test("tracks target font face, size, and color through save and reopen", async () => {
+    const tracked = await applyTrackedFormatting({
+      formatting: { fontFamily: "Georgia", fontSizePt: 10.5, color: "c00000" },
+    });
+    const trackedXml = await documentXml(tracked);
+    expect(trackedXml).toContain("<w:rPrChange ");
+    expect(trackedXml).toContain('<w:rFonts w:ascii="Georgia" w:hAnsi="Georgia"');
+    expect(trackedXml).toContain('<w:color w:val="C00000"');
+    expect(trackedXml).toContain('<w:sz w:val="21"');
+
+    const reopened = await FolioDocxReviewer.fromBuffer(tracked);
+    expect(
+      reopened.readReviewedStory({ view: "final" })?.snapshot.blocks.at(0)?.previewRuns?.at(0),
+    ).toMatchObject({
+      fontFamily: "Georgia",
+      fontSizePt: 10.5,
+      color: "#C00000",
+      directFormatting: {
+        fontFamily: "Georgia",
+        fontSizePt: 10.5,
+        color: "#C00000",
+      },
+    });
+    expect(
+      reopened.readReviewedStory({ view: "original" })?.snapshot.blocks.at(0)?.previewRuns?.at(0),
+    ).toMatchObject({ fontFamily: "Arial", fontSizePt: 11 });
+    expect(
+      reopened.readReviewedStory({ view: "original" })?.snapshot.blocks.at(0)?.previewRuns?.at(0)
+        ?.directFormatting,
+    ).toBeUndefined();
+  });
+
+  test("tracks clearing direct font properties", async () => {
+    const tracked = await applyTrackedFormatting({
+      formatting: { fontFamily: null, fontSizePt: null, color: null },
+      baselineFormatting: {
+        fontFamily: { ascii: "Georgia", hAnsi: "Georgia" },
+        fontSize: 21,
+        color: { rgb: "C00000" },
+      },
+    });
+    const reopened = await FolioDocxReviewer.fromBuffer(tracked);
+    expect(
+      reopened.readReviewedStory({ view: "final" })?.snapshot.blocks.at(0)?.previewRuns?.at(0),
+    ).toMatchObject({ fontFamily: "Arial", fontSizePt: 11 });
+    expect(
+      reopened.readReviewedStory({ view: "final" })?.snapshot.blocks.at(0)?.previewRuns?.at(0)
+        ?.directFormatting,
+    ).toBeUndefined();
+    expect(
+      reopened.readReviewedStory({ view: "original" })?.snapshot.blocks.at(0)?.previewRuns?.at(0),
+    ).toMatchObject({
+      fontFamily: "Georgia",
+      fontSizePt: 10.5,
+      color: "#C00000",
+      directFormatting: {
+        fontFamily: "Georgia",
+        fontSizePt: 10.5,
+        color: "#C00000",
+      },
+    });
   });
 });

--- a/packages/core/src/ai-edits/runPropertyFormatting.test.ts
+++ b/packages/core/src/ai-edits/runPropertyFormatting.test.ts
@@ -206,6 +206,86 @@ describe("tracked run formatting", () => {
     });
   });
 
+  test("tracks same-valued inherited font properties as new direct formatting", async () => {
+    const reviewer = await FolioDocxReviewer.fromBuffer(
+      await createSameValuedDirectFormattingDocument(),
+      { author: "Reviewer" },
+    );
+    const block = reviewer.snapshot().blocks.at(0);
+    const range = block
+      ? createFolioAITextRangeHandle({
+          blockId: block.id,
+          text: block.text,
+          startOffset: 0,
+          endOffset: "Inherited".length,
+        })
+      : null;
+    if (!range) {
+      throw new Error("expected an inherited formatting range");
+    }
+
+    const result = reviewer.applyOperations([
+      {
+        id: "format-inherited",
+        type: "formatRange",
+        range,
+        formatting: { fontFamily: "Georgia", fontSizePt: 10.5, color: "C00000" },
+      },
+    ]);
+
+    expect(result.skipped).toEqual([]);
+    expect(reviewer.readReviewedStory({ view: "current-markup" })?.changes).toEqual([
+      expect.objectContaining({ type: "formatting", text: "Inherited" }),
+    ]);
+    expect(
+      reviewer.readReviewedStory({ view: "final" })?.snapshot.blocks.at(0)?.previewRuns?.at(0)
+        ?.directFormatting,
+    ).toEqual({ fontFamily: "Georgia", fontSizePt: 10.5, color: "#C00000" });
+  });
+
+  test("clears only direct font properties in a mixed inherited range", async () => {
+    const reviewer = await FolioDocxReviewer.fromBuffer(
+      await createSameValuedDirectFormattingDocument(),
+      { author: "Reviewer" },
+    );
+    const block = reviewer.snapshot().blocks.at(0);
+    const range = block
+      ? createFolioAITextRangeHandle({
+          blockId: block.id,
+          text: block.text,
+          startOffset: 0,
+          endOffset: block.text.length,
+        })
+      : null;
+    if (!range) {
+      throw new Error("expected a mixed formatting range");
+    }
+
+    const result = reviewer.applyOperations([
+      {
+        id: "clear-direct",
+        type: "formatRange",
+        range,
+        formatting: { fontFamily: null, fontSizePt: null, color: null },
+      },
+    ]);
+
+    expect(result.skipped).toEqual([]);
+    expect(reviewer.readReviewedStory({ view: "current-markup" })?.changes).toEqual([
+      expect.objectContaining({ type: "formatting", text: "Direct" }),
+    ]);
+    expect(
+      reviewer.readReviewedStory({ view: "final" })?.snapshot.blocks.at(0)?.previewRuns,
+    ).toEqual([
+      {
+        text: "InheritedDirect",
+        fontFamily: "Georgia",
+        fontSizePt: 10.5,
+        color: "#C00000",
+      },
+    ]);
+  });
+
   test("saves, reopens, accepts, and rejects a formatting revision", async () => {
     const tracked = await applyTrackedBold();
     const trackedXml = await documentXml(tracked);

--- a/packages/core/src/ai-edits/runPropertyFormatting.test.ts
+++ b/packages/core/src/ai-edits/runPropertyFormatting.test.ts
@@ -33,6 +33,62 @@ const createFormattingBaseline = async ({
   return createDocx(document);
 };
 
+const createSameValuedDirectFormattingDocument = async (): Promise<ArrayBuffer> => {
+  const document = createEmptyDocument();
+  const formatting: TextFormatting = {
+    fontFamily: { ascii: "Georgia", hAnsi: "Georgia" },
+    fontSize: 21,
+    color: { rgb: "C00000" },
+  };
+  document.package.styles = {
+    ...document.package.styles,
+    docDefaults: { ...document.package.styles?.docDefaults, rPr: formatting },
+    styles: document.package.styles?.styles.map((style) =>
+      style.styleId === "Normal" ? { ...style, rPr: formatting } : style,
+    ),
+  };
+  document.package.document.content = [
+    {
+      type: "paragraph",
+      paraId: "A1000003",
+      content: [
+        { type: "run", content: [{ type: "text", text: "Inherited" }] },
+        {
+          type: "run",
+          formatting,
+          content: [{ type: "text", text: "Direct" }],
+        },
+      ],
+    },
+  ];
+  return createDocx(document);
+};
+
+const createParagraphFontWithDirectBoldDocument = async (): Promise<ArrayBuffer> => {
+  const document = createEmptyDocument();
+  document.package.document.content = [
+    {
+      type: "paragraph",
+      paraId: "A1000004",
+      formatting: {
+        runProperties: {
+          fontFamily: { ascii: "Arial", hAnsi: "Arial" },
+          fontSize: 21,
+          color: { rgb: "C00000" },
+        },
+      },
+      content: [
+        {
+          type: "run",
+          formatting: { bold: true },
+          content: [{ type: "text", text: "Direct bold" }],
+        },
+      ],
+    },
+  ];
+  return createDocx(document);
+};
+
 type ApplyTrackedFormattingOptions = {
   formatting: FolioAIInlineFormatting;
   baselineFormatting?: TextFormatting;
@@ -114,6 +170,42 @@ const applyTrackedBold = async (): Promise<ArrayBuffer> => {
 };
 
 describe("tracked run formatting", () => {
+  test("snapshot preserves same-valued direct font properties", async () => {
+    const reviewer = await FolioDocxReviewer.fromBuffer(
+      await createSameValuedDirectFormattingDocument(),
+    );
+
+    expect(reviewer.snapshot().blocks.at(0)?.previewRuns).toEqual([
+      {
+        text: "Inherited",
+        fontFamily: "Georgia",
+        fontSizePt: 10.5,
+        color: "#C00000",
+      },
+      {
+        text: "Direct",
+        fontFamily: "Georgia",
+        fontSizePt: 10.5,
+        color: "#C00000",
+        directFormatting: {
+          fontFamily: "Georgia",
+          fontSizePt: 10.5,
+          color: "#C00000",
+        },
+      },
+    ]);
+  });
+
+  test("snapshot does not promote paragraph font properties beside direct bold", async () => {
+    const reviewer = await FolioDocxReviewer.fromBuffer(
+      await createParagraphFontWithDirectBoldDocument(),
+    );
+
+    expect(reviewer.snapshot().blocks.at(0)?.previewRuns?.at(0)?.directFormatting).toEqual({
+      bold: true,
+    });
+  });
+
   test("saves, reopens, accepts, and rejects a formatting revision", async () => {
     const tracked = await applyTrackedBold();
     const trackedXml = await documentXml(tracked);

--- a/packages/core/src/ai-edits/snapshot.ts
+++ b/packages/core/src/ai-edits/snapshot.ts
@@ -1,6 +1,7 @@
 import type { Mark, Node as PMNode } from "prosemirror-model";
 import { TableMap } from "prosemirror-tables";
 
+import { expectRunFormattingOverrideMarkAttrs } from "../prosemirror/attrs";
 import { deriveBlankBlockId, deriveBlockId, type FolioBlockId } from "../types/block-id";
 import { buildCleanBlockText } from "./clean-text";
 import type {
@@ -10,6 +11,7 @@ import type {
   FolioAIBlockPreviewRun,
   FolioAIBlockTableLocation,
   FolioAIEditSnapshot,
+  FolioAIInlineFormatting,
   FolioAITextRangeHandle,
 } from "./types";
 
@@ -400,7 +402,15 @@ const getStyleId = (node: PMNode): string | undefined => {
   return typeof styleId === "string" && styleId.length > 0 ? styleId : undefined;
 };
 
-type PreviewRunStyle = Omit<FolioAIBlockPreviewRun, "text" | "directFormatting">;
+type PreviewRunStyle = {
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  strike?: boolean;
+  fontFamily?: string;
+  fontSizePt?: number;
+  color?: string;
+};
 
 const DELETION_MARK = "deletion";
 
@@ -514,6 +524,12 @@ const getDirectPreviewRunStyle = (
 ): PreviewRunStyle => {
   const markedStyle = getPreviewRunStyle(marks, {});
   const directStyle: PreviewRunStyle = {};
+  const overrideMark = marks.find(({ type }) => type.name === "runFormattingOverride");
+  const hasFormattingProvenance =
+    overrideMark !== undefined || marks.some(({ type }) => type.name === "characterStyle");
+  const directFontProperties = overrideMark
+    ? expectRunFormattingOverrideMarkAttrs(overrideMark).directFontProperties
+    : undefined;
 
   for (const property of ["bold", "italic", "underline", "strike"] as const) {
     if (Boolean(markedStyle[property]) !== Boolean(inheritedStyle[property])) {
@@ -522,17 +538,26 @@ const getDirectPreviewRunStyle = (
   }
   if (
     markedStyle.fontFamily !== undefined &&
-    markedStyle.fontFamily !== inheritedStyle.fontFamily
+    (hasFormattingProvenance
+      ? directFontProperties?.includes("fontFamily")
+      : markedStyle.fontFamily !== inheritedStyle.fontFamily)
   ) {
     directStyle.fontFamily = markedStyle.fontFamily;
   }
   if (
     markedStyle.fontSizePt !== undefined &&
-    markedStyle.fontSizePt !== inheritedStyle.fontSizePt
+    (hasFormattingProvenance
+      ? directFontProperties?.includes("fontSize")
+      : markedStyle.fontSizePt !== inheritedStyle.fontSizePt)
   ) {
     directStyle.fontSizePt = markedStyle.fontSizePt;
   }
-  if (markedStyle.color !== undefined && markedStyle.color !== inheritedStyle.color) {
+  if (
+    markedStyle.color !== undefined &&
+    (hasFormattingProvenance
+      ? directFontProperties?.includes("color")
+      : markedStyle.color !== inheritedStyle.color)
+  ) {
     directStyle.color = markedStyle.color;
   }
 
@@ -644,7 +669,7 @@ const isEmptyPreviewRunStyle = ({
   color === undefined;
 
 const sameDirectFormatting = (
-  left: FolioAIBlockPreviewRun["directFormatting"],
+  left: FolioAIInlineFormatting | undefined,
   right: PreviewRunStyle,
 ): boolean =>
   (left === undefined && isEmptyPreviewRunStyle(right)) ||

--- a/packages/core/src/ai-edits/snapshot.ts
+++ b/packages/core/src/ai-edits/snapshot.ts
@@ -400,7 +400,7 @@ const getStyleId = (node: PMNode): string | undefined => {
   return typeof styleId === "string" && styleId.length > 0 ? styleId : undefined;
 };
 
-type PreviewRunStyle = Omit<FolioAIBlockPreviewRun, "text">;
+type PreviewRunStyle = Omit<FolioAIBlockPreviewRun, "text" | "directFormatting">;
 
 const DELETION_MARK = "deletion";
 
@@ -417,13 +417,22 @@ const getPreviewRuns = (node: PMNode): FolioAIBlockPreviewRun[] | undefined => {
     }
 
     const style = getPreviewRunStyle(child.marks, defaultStyle);
+    const directFormatting = getDirectPreviewRunStyle(child.marks, defaultStyle);
     const previous = runs.at(-1);
-    if (previous && samePreviewRunStyle(previous, style)) {
+    if (
+      previous &&
+      samePreviewRunStyle(previous, style) &&
+      sameDirectFormatting(previous.directFormatting, directFormatting)
+    ) {
       previous.text += child.text;
       return false;
     }
 
-    runs.push({ text: child.text, ...style });
+    runs.push({
+      text: child.text,
+      ...style,
+      ...(!isEmptyPreviewRunStyle(directFormatting) && { directFormatting }),
+    });
     return false;
   });
 
@@ -497,6 +506,37 @@ const getPreviewRunStyle = (
   }
 
   return style;
+};
+
+const getDirectPreviewRunStyle = (
+  marks: readonly Mark[],
+  inheritedStyle: PreviewRunStyle,
+): PreviewRunStyle => {
+  const markedStyle = getPreviewRunStyle(marks, {});
+  const directStyle: PreviewRunStyle = {};
+
+  for (const property of ["bold", "italic", "underline", "strike"] as const) {
+    if (Boolean(markedStyle[property]) !== Boolean(inheritedStyle[property])) {
+      directStyle[property] = Boolean(markedStyle[property]);
+    }
+  }
+  if (
+    markedStyle.fontFamily !== undefined &&
+    markedStyle.fontFamily !== inheritedStyle.fontFamily
+  ) {
+    directStyle.fontFamily = markedStyle.fontFamily;
+  }
+  if (
+    markedStyle.fontSizePt !== undefined &&
+    markedStyle.fontSizePt !== inheritedStyle.fontSizePt
+  ) {
+    directStyle.fontSizePt = markedStyle.fontSizePt;
+  }
+  if (markedStyle.color !== undefined && markedStyle.color !== inheritedStyle.color) {
+    directStyle.color = markedStyle.color;
+  }
+
+  return directStyle;
 };
 
 const getBooleanTextFormatting = (formatting: object): PreviewRunStyle => ({
@@ -585,6 +625,37 @@ const samePreviewRunStyle = (run: FolioAIBlockPreviewRun, style: PreviewRunStyle
   run.fontFamily === style.fontFamily &&
   run.fontSizePt === style.fontSizePt &&
   run.color === style.color;
+
+const isEmptyPreviewRunStyle = ({
+  bold,
+  italic,
+  underline,
+  strike,
+  fontFamily,
+  fontSizePt,
+  color,
+}: PreviewRunStyle): boolean =>
+  bold === undefined &&
+  italic === undefined &&
+  underline === undefined &&
+  strike === undefined &&
+  fontFamily === undefined &&
+  fontSizePt === undefined &&
+  color === undefined;
+
+const sameDirectFormatting = (
+  left: FolioAIBlockPreviewRun["directFormatting"],
+  right: PreviewRunStyle,
+): boolean =>
+  (left === undefined && isEmptyPreviewRunStyle(right)) ||
+  (left !== undefined &&
+    left.bold === right.bold &&
+    left.italic === right.italic &&
+    left.underline === right.underline &&
+    left.strike === right.strike &&
+    left.fontFamily === right.fontFamily &&
+    left.fontSizePt === right.fontSizePt &&
+    left.color === right.color);
 
 const isUnstyledPreviewRun = ({
   bold,

--- a/packages/core/src/ai-edits/types.ts
+++ b/packages/core/src/ai-edits/types.ts
@@ -1,10 +1,8 @@
 export type FolioAIBlockKind = "heading" | "listItem" | "paragraph";
 
-export type FolioAIInlineFormatting = {
-  bold?: boolean;
-  italic?: boolean;
-  underline?: boolean;
-  strike?: boolean;
+export type FolioAIInlineFormatting = Partial<
+  Record<"bold" | "italic" | "underline" | "strike", boolean>
+> & {
   fontFamily?: string | null;
   fontSizePt?: number | null;
   color?: string | null;

--- a/packages/core/src/ai-edits/types.ts
+++ b/packages/core/src/ai-edits/types.ts
@@ -1,5 +1,15 @@
 export type FolioAIBlockKind = "heading" | "listItem" | "paragraph";
 
+export type FolioAIInlineFormatting = {
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  strike?: boolean;
+  fontFamily?: string | null;
+  fontSizePt?: number | null;
+  color?: string | null;
+};
+
 export type FolioAIBlockPreviewRun = {
   text: string;
   bold?: boolean;
@@ -9,6 +19,7 @@ export type FolioAIBlockPreviewRun = {
   fontFamily?: string;
   fontSizePt?: number;
   color?: string;
+  directFormatting?: FolioAIInlineFormatting;
 };
 
 /**
@@ -175,13 +186,6 @@ export type FolioDocumentSectionReadResult =
 export type FolioDocumentNavigationTarget =
   | { type: "block"; story: "main"; blockId: string }
   | FolioAITextRangeHandle;
-
-export type FolioAIInlineFormatting = {
-  bold?: boolean;
-  italic?: boolean;
-  underline?: boolean;
-  strike?: boolean;
-};
 
 /**
  * A party in an `insertSignatureTable` op. Mirrors the

--- a/packages/core/src/compare/README.md
+++ b/packages/core/src/compare/README.md
@@ -79,7 +79,9 @@ in three nested passes, each over things that can stand in for one another:
 Changed paragraphs go through `diffWordSegments` at apply time, so a redline
 marks only the divergent words. Formatting-only differences are emitted as
 `formatRange` operations and reported as `format`, never as a deletion and
-reinsertion of identical text.
+reinsertion of identical text. The tracked inline properties are bold, italic,
+underline, strike, direct font family, half-point font size and RGB color;
+clearing a direct font property is tracked as well as setting one.
 
 An LCS on its own maximises matched characters, which on a rewritten sentence
 means matching every stray "the" and comma it can reach and handing the reader

--- a/packages/core/src/compare/formatting.test.ts
+++ b/packages/core/src/compare/formatting.test.ts
@@ -39,4 +39,75 @@ describe("inlineFormattingSegments", () => {
       }),
     ).toEqual([{ startOffset: 0, endOffset: 8, formatting: { strike: true } }]);
   });
+
+  test("reports target font face, half-point size, and normalized RGB color", () => {
+    expect(
+      inlineFormattingSegments({
+        baseBlock: block([{ text: "Contract", fontFamily: "Arial", fontSizePt: 10 }]),
+        targetBlock: block([
+          {
+            text: "Contract",
+            fontFamily: "Georgia",
+            fontSizePt: 10.5,
+            color: "c00000",
+            directFormatting: {
+              fontFamily: "Georgia",
+              fontSizePt: 10.5,
+              color: "c00000",
+            },
+          },
+        ]),
+        maxSegments: 10,
+      }),
+    ).toEqual([
+      {
+        startOffset: 0,
+        endOffset: 8,
+        formatting: { fontFamily: "Georgia", fontSizePt: 10.5, color: "C00000" },
+      },
+    ]);
+  });
+
+  test("represents cleared direct font properties explicitly", () => {
+    expect(
+      inlineFormattingSegments({
+        baseBlock: block([
+          {
+            text: "Contract",
+            fontFamily: "Georgia",
+            fontSizePt: 10.5,
+            color: "C00000",
+            directFormatting: {
+              fontFamily: "Georgia",
+              fontSizePt: 10.5,
+              color: "C00000",
+            },
+          },
+        ]),
+        targetBlock: block([{ text: "Contract" }]),
+        maxSegments: 10,
+      }),
+    ).toEqual([
+      {
+        startOffset: 0,
+        endOffset: 8,
+        formatting: { fontFamily: null, fontSizePt: null, color: null },
+      },
+    ]);
+  });
+
+  test("verification distinguishes an inherited value from the same direct value", () => {
+    const inherited = block([{ text: "Contract", fontFamily: "Georgia" }]);
+    const direct = block([
+      {
+        text: "Contract",
+        fontFamily: "Georgia",
+        directFormatting: { fontFamily: "Georgia" },
+      },
+    ]);
+
+    expect(projectSupportedInlineFormatting(inherited)).not.toBe(
+      projectSupportedInlineFormatting(direct),
+    );
+  });
 });

--- a/packages/core/src/compare/formatting.ts
+++ b/packages/core/src/compare/formatting.ts
@@ -16,6 +16,30 @@ import { resolveColorToHex } from "../utils/colorResolver";
 const normalizeInlineFormattingColor = (color: string | undefined): string | undefined =>
   resolveColorToHex(color === undefined ? undefined : { rgb: color }, null);
 
+const changedStringValue = (
+  baseEffective: string | undefined,
+  targetEffective: string | undefined,
+  baseAuthored: string | null | undefined,
+  targetAuthored: string | null | undefined,
+): string | null | undefined => {
+  if (baseAuthored !== targetAuthored) {
+    return targetAuthored ?? null;
+  }
+  return baseEffective === targetEffective ? undefined : (targetEffective ?? null);
+};
+
+const changedNumberValue = (
+  baseEffective: number | undefined,
+  targetEffective: number | undefined,
+  baseAuthored: number | null | undefined,
+  targetAuthored: number | null | undefined,
+): number | null | undefined => {
+  if (baseAuthored !== targetAuthored) {
+    return targetAuthored ?? null;
+  }
+  return baseEffective === targetEffective ? undefined : (targetEffective ?? null);
+};
+
 /** One run of characters whose supported inline formatting differs. */
 export type InlineFormattingSegment = {
   /** Zero-based UTF-16 offset into the block's visible text. */
@@ -41,18 +65,6 @@ const changedSupportedFormatting = (
       ? undefined
       : Boolean(target[property]);
   };
-  const changedValue = <Value extends string | number>(
-    baseEffective: Value | undefined,
-    targetEffective: Value | undefined,
-    baseAuthored: Value | null | undefined,
-    targetAuthored: Value | null | undefined,
-  ): Value | null | undefined => {
-    if (baseAuthored !== targetAuthored) {
-      return targetAuthored ?? null;
-    }
-    return baseEffective === targetEffective ? undefined : (targetEffective ?? null);
-  };
-
   for (const property of ["bold", "italic", "underline", "strike"] as const) {
     const changed = changedBoolean(property);
     if (changed !== undefined) {
@@ -60,7 +72,7 @@ const changedSupportedFormatting = (
     }
   }
 
-  const fontFamily = changedValue(
+  const fontFamily = changedStringValue(
     base.fontFamily,
     target.fontFamily,
     baseDirect.fontFamily,
@@ -70,7 +82,7 @@ const changedSupportedFormatting = (
     formatting.fontFamily = fontFamily;
   }
 
-  const fontSizePt = changedValue(
+  const fontSizePt = changedNumberValue(
     base.fontSizePt,
     target.fontSizePt,
     baseDirect.fontSizePt,
@@ -80,7 +92,7 @@ const changedSupportedFormatting = (
     formatting.fontSizePt = fontSizePt;
   }
 
-  const color = changedValue(
+  const color = changedStringValue(
     normalizeInlineFormattingColor(base.color),
     normalizeInlineFormattingColor(target.color),
     normalizeInlineFormattingColor(baseDirect.color ?? undefined),

--- a/packages/core/src/compare/formatting.ts
+++ b/packages/core/src/compare/formatting.ts
@@ -11,6 +11,10 @@ import type {
   FolioAIBlockPreviewRun,
   FolioAIInlineFormatting,
 } from "../ai-edits/types";
+import { resolveColorToHex } from "../utils/colorResolver";
+
+const normalizeInlineFormattingColor = (color: string | undefined): string | undefined =>
+  resolveColorToHex(color === undefined ? undefined : { rgb: color }, null);
 
 /** One run of characters whose supported inline formatting differs. */
 export type InlineFormattingSegment = {
@@ -24,16 +28,70 @@ export type InlineFormattingSegment = {
 const changedSupportedFormatting = (
   base: FolioAIBlockPreviewRun,
   target: FolioAIBlockPreviewRun,
-): FolioAIInlineFormatting => ({
-  ...(Boolean(base.bold) !== Boolean(target.bold) && { bold: Boolean(target.bold) }),
-  ...(Boolean(base.italic) !== Boolean(target.italic) && { italic: Boolean(target.italic) }),
-  ...(Boolean(base.underline) !== Boolean(target.underline) && {
-    underline: Boolean(target.underline),
-  }),
-  ...(Boolean(base.strike) !== Boolean(target.strike) && {
-    strike: Boolean(target.strike),
-  }),
-});
+): FolioAIInlineFormatting => {
+  const baseDirect = base.directFormatting ?? {};
+  const targetDirect = target.directFormatting ?? {};
+  const formatting: FolioAIInlineFormatting = {};
+
+  const changedBoolean = (property: "bold" | "italic" | "underline" | "strike") => {
+    if (baseDirect[property] !== targetDirect[property]) {
+      return targetDirect[property] === true;
+    }
+    return Boolean(base[property]) === Boolean(target[property])
+      ? undefined
+      : Boolean(target[property]);
+  };
+  const changedValue = <Value extends string | number>(
+    baseEffective: Value | undefined,
+    targetEffective: Value | undefined,
+    baseAuthored: Value | null | undefined,
+    targetAuthored: Value | null | undefined,
+  ): Value | null | undefined => {
+    if (baseAuthored !== targetAuthored) {
+      return targetAuthored ?? null;
+    }
+    return baseEffective === targetEffective ? undefined : (targetEffective ?? null);
+  };
+
+  for (const property of ["bold", "italic", "underline", "strike"] as const) {
+    const changed = changedBoolean(property);
+    if (changed !== undefined) {
+      formatting[property] = changed;
+    }
+  }
+
+  const fontFamily = changedValue(
+    base.fontFamily,
+    target.fontFamily,
+    baseDirect.fontFamily,
+    targetDirect.fontFamily,
+  );
+  if (fontFamily !== undefined) {
+    formatting.fontFamily = fontFamily;
+  }
+
+  const fontSizePt = changedValue(
+    base.fontSizePt,
+    target.fontSizePt,
+    baseDirect.fontSizePt,
+    targetDirect.fontSizePt,
+  );
+  if (fontSizePt !== undefined) {
+    formatting.fontSizePt = fontSizePt;
+  }
+
+  const color = changedValue(
+    normalizeInlineFormattingColor(base.color),
+    normalizeInlineFormattingColor(target.color),
+    normalizeInlineFormattingColor(baseDirect.color ?? undefined),
+    normalizeInlineFormattingColor(targetDirect.color ?? undefined),
+  );
+  if (color !== undefined) {
+    formatting.color = color;
+  }
+
+  return formatting;
+};
 
 const sameInlineFormatting = (
   left: FolioAIInlineFormatting,
@@ -42,13 +100,19 @@ const sameInlineFormatting = (
   left.bold === right.bold &&
   left.italic === right.italic &&
   left.underline === right.underline &&
-  left.strike === right.strike;
+  left.strike === right.strike &&
+  left.fontFamily === right.fontFamily &&
+  left.fontSizePt === right.fontSizePt &&
+  left.color === right.color;
 
 const hasInlineFormatting = (formatting: FolioAIInlineFormatting): boolean =>
   formatting.bold !== undefined ||
   formatting.italic !== undefined ||
   formatting.underline !== undefined ||
-  formatting.strike !== undefined;
+  formatting.strike !== undefined ||
+  formatting.fontFamily !== undefined ||
+  formatting.fontSizePt !== undefined ||
+  formatting.color !== undefined;
 
 /**
  * A block's runs, or `null` when they cannot describe the block's text.
@@ -69,7 +133,7 @@ type InlineFormattingSegmentsOptions = {
 };
 
 /**
- * Segments where `targetBlock`'s bold / italic / underline / strike differs from
+ * Segments where `targetBlock`'s supported run formatting differs from
  * `baseBlock`'s, for two blocks that carry the same text. Returns `null` only
  * when the diff would exceed `maxSegments`.
  *

--- a/packages/core/src/compare/probes.test.ts
+++ b/packages/core/src/compare/probes.test.ts
@@ -140,6 +140,7 @@ const styledView = async (
 };
 
 type ProbeOutcome = {
+  buffer: ArrayBuffer;
   changes: readonly CompareChange[];
   kinds: readonly string[];
 };
@@ -168,7 +169,11 @@ const probe = async (base: ArrayBuffer, script: EditScript): Promise<ProbeOutcom
     await projectView(base, "final"),
   );
 
-  return { changes: result.value.changes, kinds: result.value.changes.map(({ kind }) => kind) };
+  return {
+    buffer: result.value.buffer,
+    changes: result.value.changes,
+    kinds: result.value.changes.map(({ kind }) => kind),
+  };
 };
 
 /** A block with enough words to split, edit inside, or bold part of. */
@@ -490,6 +495,96 @@ describe("single-mutation probes", () => {
     ];
     expect(acceptedBlock?.previewRuns?.at(0)?.strike).toBe(true);
     expect(rejectedBlock?.previewRuns?.at(0)?.strike).not.toBe(true);
+  });
+
+  test("format_only_font: changing face, half-point size, and color is one format", async () => {
+    const blockIndex = wordyBlockIndex(PROSE_BLOCKS, 4);
+    const { buffer, changes, kinds } = await probe(PROSE_BASE, [
+      {
+        type: "formatRange",
+        blockIndex,
+        startOffset: 0,
+        endOffset: 4,
+        formatting: { fontFamily: "Georgia", fontSizePt: 10.5, color: "C00000" },
+      },
+    ]);
+    expect(kinds).toEqual(["format"]);
+    const change = changes.at(0);
+    expect(change?.kind === "format" ? change.ranges : []).toEqual([
+      {
+        startOffset: 0,
+        endOffset: 4,
+        formatting: { fontFamily: "Georgia", fontSizePt: 10.5, color: "C00000" },
+      },
+    ]);
+    const reviewed = await FolioDocxReviewer.fromBuffer(buffer);
+    expect(
+      reviewed
+        .readReviewedStory({ view: "final" })
+        ?.snapshot.blocks[blockIndex]?.previewRuns?.at(0),
+    ).toMatchObject({
+      fontFamily: "Georgia",
+      fontSizePt: 10.5,
+      color: "#C00000",
+      directFormatting: {
+        fontFamily: "Georgia",
+        fontSizePt: 10.5,
+        color: "#C00000",
+      },
+    });
+  });
+
+  test("format_only_font_clear: clearing direct font properties is one format", async () => {
+    const blockIndex = wordyBlockIndex(PROSE_BLOCKS, 4);
+    const formatted = await applyEditScript(PROSE_BASE, [
+      {
+        type: "formatRange",
+        blockIndex,
+        startOffset: 0,
+        endOffset: 4,
+        formatting: { fontFamily: "Georgia", fontSizePt: 10.5, color: "C00000" },
+      },
+    ]);
+    if (formatted.isErr()) {
+      throw formatted.error;
+    }
+
+    const { buffer, changes, kinds } = await probe(formatted.value.buffer, [
+      {
+        type: "formatRange",
+        blockIndex,
+        startOffset: 0,
+        endOffset: 4,
+        formatting: { fontFamily: null, fontSizePt: null, color: null },
+      },
+    ]);
+    expect(kinds).toEqual(["format"]);
+    expect(changes.at(0)?.kind === "format" ? changes.at(0)?.ranges : []).toEqual([
+      {
+        startOffset: 0,
+        endOffset: 4,
+        formatting: { fontFamily: null, fontSizePt: null, color: null },
+      },
+    ]);
+    const reviewed = await FolioDocxReviewer.fromBuffer(buffer);
+    expect(
+      reviewed.readReviewedStory({ view: "final" })?.snapshot.blocks[blockIndex]?.previewRuns?.at(0)
+        ?.directFormatting,
+    ).toBeUndefined();
+    expect(
+      reviewed
+        .readReviewedStory({ view: "original" })
+        ?.snapshot.blocks[blockIndex]?.previewRuns?.at(0),
+    ).toMatchObject({
+      fontFamily: "Georgia",
+      fontSizePt: 10.5,
+      color: "#C00000",
+      directFormatting: {
+        fontFamily: "Georgia",
+        fontSizePt: 10.5,
+        color: "#C00000",
+      },
+    });
   });
 
   test("renumbering: an added list item does not report the items after it", async () => {

--- a/packages/core/src/compare/verification.ts
+++ b/packages/core/src/compare/verification.ts
@@ -17,6 +17,10 @@ import { PARAGRAPH_MARK_CHANGE_KINDS, type ParagraphMarkChangeKind } from "@stll
 
 import type { FolioDocumentStoryHandle } from "../ai-edits/headless";
 import type { FolioAIBlock, FolioAIBlockPreviewRun } from "../ai-edits/types";
+import { resolveColorToHex } from "../utils/colorResolver";
+
+const normalizeInlineFormattingColor = (color: string | undefined): string | undefined =>
+  resolveColorToHex(color === undefined ? undefined : { rgb: color }, null);
 
 /** The two directions of the round trip, each an invariant of its own. */
 export const COMPARE_VERIFICATION_INVARIANTS = Object.freeze([
@@ -85,10 +89,27 @@ const supportedInlineStyle = ({
   italic,
   underline,
   strike,
+  fontFamily,
+  fontSizePt,
+  color,
+  directFormatting,
 }: FolioAIBlockPreviewRun): string =>
-  `${bold === true ? "b" : ""}${italic === true ? "i" : ""}${underline === true ? "u" : ""}${
-    strike === true ? "s" : ""
-  }`;
+  JSON.stringify([
+    bold === true,
+    italic === true,
+    underline === true,
+    strike === true,
+    fontFamily ?? null,
+    fontSizePt ?? null,
+    normalizeInlineFormattingColor(color) ?? null,
+    directFormatting?.bold === true,
+    directFormatting?.italic === true,
+    directFormatting?.underline === true,
+    directFormatting?.strike === true,
+    directFormatting?.fontFamily ?? null,
+    directFormatting?.fontSizePt ?? null,
+    normalizeInlineFormattingColor(directFormatting?.color ?? undefined) ?? null,
+  ]);
 
 /** Effective supported formatting with equivalent adjacent runs normalized. */
 export const projectSupportedInlineFormatting = ({ text, previewRuns }: FolioAIBlock): string => {

--- a/packages/core/src/document-operations.test.ts
+++ b/packages/core/src/document-operations.test.ts
@@ -197,6 +197,50 @@ describe("document operation contract", () => {
     expect(Object.isFrozen(operation?.precondition)).toBe(true);
   });
 
+  test("validates and normalizes valued inline formatting", () => {
+    const range = {
+      type: "textRange",
+      story: "main",
+      blockId: "paragraph-2",
+      startOffset: 0,
+      endOffset: 4,
+      selectedTextHash: "h123",
+    } as const;
+    const batch = parseFolioDocumentOperationBatch({
+      version: 1,
+      operations: [
+        {
+          id: "format",
+          type: "formatRange",
+          range,
+          formatting: { fontFamily: " Georgia ", fontSizePt: 10.5, color: "c00000" },
+        },
+      ],
+    });
+    expect(batch.operations.at(0)).toMatchObject({
+      formatting: { fontFamily: "Georgia", fontSizePt: 10.5, color: "C00000" },
+    });
+
+    for (const [formatting, property] of [
+      [{ fontFamily: "" }, "fontFamily"],
+      [{ fontFamily: "  " }, "fontFamily"],
+      [{ fontSizePt: 10.25 }, "fontSizePt"],
+      [{ color: "red" }, "color"],
+    ] as const) {
+      expect(() =>
+        parseFolioDocumentOperationBatch({
+          version: 1,
+          operations: [{ id: "format", type: "formatRange", range, formatting }],
+        }),
+      ).toThrow(
+        expect.objectContaining({
+          _tag: "InvalidFolioDocumentOperationBatchError",
+          path: `$.operations[0].formatting.${property}`,
+        }),
+      );
+    }
+  });
+
   test("builds input-ordered receipts for successful affected targets", () => {
     const range = {
       type: "textRange",

--- a/packages/core/src/document-operations.ts
+++ b/packages/core/src/document-operations.ts
@@ -303,6 +303,51 @@ const readOptionalBoolean = (
   return invalidBatch(`${path}.${key}`, "expected a boolean when provided");
 };
 
+const readClearableNonEmptyString = (
+  value: Record<string, unknown>,
+  key: string,
+  path: string,
+): string | null | undefined => {
+  const candidate = value[key];
+  if (candidate === undefined || candidate === null) {
+    return candidate;
+  }
+  if (typeof candidate === "string" && candidate.trim().length > 0) {
+    return candidate.trim();
+  }
+  return invalidBatch(`${path}.${key}`, "expected a non-empty string or null when provided");
+};
+
+const readClearableFontSize = (
+  value: Record<string, unknown>,
+  key: string,
+  path: string,
+): number | null | undefined => {
+  const candidate = value[key];
+  if (candidate === undefined || candidate === null) {
+    return candidate;
+  }
+  if (typeof candidate === "number" && candidate > 0 && Number.isInteger(candidate * 2)) {
+    return candidate;
+  }
+  return invalidBatch(`${path}.${key}`, "expected a positive half-point value or null");
+};
+
+const readClearableRgbColor = (
+  value: Record<string, unknown>,
+  key: string,
+  path: string,
+): string | null | undefined => {
+  const candidate = value[key];
+  if (candidate === undefined || candidate === null) {
+    return candidate;
+  }
+  if (typeof candidate === "string" && /^#?[0-9a-fA-F]{6}$/u.test(candidate)) {
+    return candidate.replace(/^#/u, "").toUpperCase();
+  }
+  return invalidBatch(`${path}.${key}`, "expected a six-digit RGB color or null");
+};
+
 const readOptionalStringArray = (
   value: Record<string, unknown>,
   key: string,
@@ -462,16 +507,30 @@ const readInlineFormatting = (
   if (!isPlainObject(candidate)) {
     return invalidBatch(formattingPath, "expected an object");
   }
-  assertAllowedKeys(candidate, formattingPath, ["bold", "italic", "underline", "strike"]);
+  assertAllowedKeys(candidate, formattingPath, [
+    "bold",
+    "italic",
+    "underline",
+    "strike",
+    "fontFamily",
+    "fontSizePt",
+    "color",
+  ]);
   const bold = readOptionalBoolean(candidate, "bold", formattingPath);
   const italic = readOptionalBoolean(candidate, "italic", formattingPath);
   const underline = readOptionalBoolean(candidate, "underline", formattingPath);
   const strike = readOptionalBoolean(candidate, "strike", formattingPath);
+  const fontFamily = readClearableNonEmptyString(candidate, "fontFamily", formattingPath);
+  const fontSizePt = readClearableFontSize(candidate, "fontSizePt", formattingPath);
+  const color = readClearableRgbColor(candidate, "color", formattingPath);
   if (
     bold === undefined &&
     italic === undefined &&
     underline === undefined &&
-    strike === undefined
+    strike === undefined &&
+    fontFamily === undefined &&
+    fontSizePt === undefined &&
+    color === undefined
   ) {
     return invalidBatch(formattingPath, "expected at least one formatting property");
   }
@@ -480,6 +539,9 @@ const readInlineFormatting = (
     ...(italic !== undefined && { italic }),
     ...(underline !== undefined && { underline }),
     ...(strike !== undefined && { strike }),
+    ...(fontFamily !== undefined && { fontFamily }),
+    ...(fontSizePt !== undefined && { fontSizePt }),
+    ...(color !== undefined && { color }),
   };
 };
 

--- a/packages/core/src/layout-bridge/convert/complex-script-formatting-pipeline.test.ts
+++ b/packages/core/src/layout-bridge/convert/complex-script-formatting-pipeline.test.ts
@@ -156,6 +156,7 @@ describe("complex-script formatting pipeline", () => {
     const roundTripped = toProseDoc(fromProseDoc(source));
     const text = roundTripped.firstChild?.firstChild;
 
-    expect(text?.marks.some((mark) => mark.type.name === "runFormattingOverride")).toBe(false);
+    const override = text?.marks.find((mark) => mark.type.name === "runFormattingOverride");
+    expect(override?.attrs["fontSizeCs"]).toBeFalsy();
   });
 });

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -205,6 +205,8 @@ const RUN_FORMATTING_OVERRIDE_FALSE_KEYS = [
   "rtl",
 ] as const satisfies readonly (keyof RunFormattingOverrideAttrs)[];
 
+const RUN_FORMATTING_OVERRIDE_DIRECT_FONT_PROPERTIES = ["fontFamily", "fontSize", "color"] as const;
+
 const SECTION_ORIENTATIONS = ["portrait", "landscape"] as const;
 const SECTION_START_TYPES = [
   "continuous",
@@ -1188,6 +1190,23 @@ export const readRunFormattingOverrideMarkAttrs = (
   optionalNumber(attrs, "fontSizeCs", "runFormattingOverride.attrs.fontSizeCs", issues);
   optionalBoolean(attrs, "cs", "runFormattingOverride.attrs.cs", issues);
   optionalOneOf(attrs, "underline", "runFormattingOverride.attrs.underline", issues, ["none"]);
+  optionalOneOfArray(
+    attrs,
+    "directFontProperties",
+    "runFormattingOverride.attrs.directFontProperties",
+    issues,
+    RUN_FORMATTING_OVERRIDE_DIRECT_FONT_PROPERTIES,
+  );
+  const directFontProperties = attrs["directFontProperties"];
+  if (
+    Array.isArray(directFontProperties) &&
+    new Set(directFontProperties).size !== directFontProperties.length
+  ) {
+    issues.push({
+      path: "runFormattingOverride.attrs.directFontProperties",
+      message: "Expected unique direct font properties.",
+    });
+  }
 
   return attrsResult(attrs, issues);
 };

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -112,6 +112,7 @@ import { directionToBidi } from "../paragraphDirection";
 import { RUN_FORMATTING_MARK_NAMES } from "../runFormattingMarkNames";
 import { cascadeStyleTextFormatting } from "../styles/styleToggleCascade";
 import { applyRunFormattingOverrideAttrs } from "../extensions/marks/RunFormattingOverrideExtension";
+import type { RunFormattingOverrideAttrs } from "../schema/marks";
 import type {
   ParagraphAttrs,
   ParagraphPropertyChangeAttrs,
@@ -1427,12 +1428,14 @@ function extractParagraphContent(
   emptyHyperlinks?: NonNullable<ParagraphAttrs["_emptyHyperlinks"]>,
   textBoxAnchorMarkers?: Map<string, Run>,
   skipLeadingRenderedPageBreak = false,
+  inheritedFormattingOverride?: TextFormatting,
 ): ParagraphContent[] {
   const content: ParagraphContent[] = [];
   const inheritedFormatting =
-    paragraph.type.name === "paragraph"
+    inheritedFormattingOverride ??
+    (paragraph.type.name === "paragraph"
       ? (expectParagraphAttrs(paragraph).defaultTextFormatting ?? undefined)
-      : undefined;
+      : undefined);
   const sortedEmptyHyperlinks = (emptyHyperlinks ?? [])
     .map((attrs, order) => ({ attrs, order }))
     .toSorted((left, right) => left.attrs.offset - right.attrs.offset || left.order - right.order);
@@ -1811,7 +1814,7 @@ function extractParagraphContent(
     } else if (node.type.name === "sdt") {
       // SDT ends current run and emits an InlineSdt content item
       flushCurrentInline();
-      content.push(createInlineSdtFromNode(node, textBoxAnchorMarkers));
+      content.push(createInlineSdtFromNode(node, textBoxAnchorMarkers, inheritedFormatting));
     } else if (node.type.name === "math") {
       // Math ends current run and emits a MathEquation content item
       flushCurrentInline();
@@ -2421,7 +2424,11 @@ function createMathFromNode(node: PMNode): MathEquation {
 /**
  * Create an InlineSdt from a PM sdt node
  */
-function createInlineSdtFromNode(node: PMNode, textBoxAnchorMarkers?: Map<string, Run>): InlineSdt {
+function createInlineSdtFromNode(
+  node: PMNode,
+  textBoxAnchorMarkers?: Map<string, Run>,
+  inheritedFormatting?: TextFormatting,
+): InlineSdt {
   const attrs = expectSdtAttrs(node);
   const properties = sdtPropertiesFromAttrs(attrs);
 
@@ -2430,7 +2437,14 @@ function createInlineSdtFromNode(node: PMNode, textBoxAnchorMarkers?: Map<string
   // and math here. Keep all of them so docProps-bound fields and reviewed
   // template content survive a round-trip through the editor. Keep this
   // filter in sync with the exhaustive switch in `serializeInlineSdt`.
-  const sdtContent = extractParagraphContent(node, undefined, undefined, textBoxAnchorMarkers);
+  const sdtContent = extractParagraphContent(
+    node,
+    undefined,
+    undefined,
+    textBoxAnchorMarkers,
+    false,
+    inheritedFormatting,
+  );
   const content = sdtContent.filter(
     (c): c is InlineSdt["content"][number] =>
       c.type === "run" ||
@@ -2744,6 +2758,7 @@ export function marksToTextFormatting(
 ): TextFormatting {
   const formatting: TextFormatting = {};
   let directOverrideFormatting: TextFormatting | undefined;
+  let directFontProperties: RunFormattingOverrideAttrs["directFontProperties"];
   let characterStyleRPr: TextFormatting | undefined;
   let runFormattingOverrideMark: Mark | undefined;
 
@@ -2953,9 +2968,16 @@ export function marksToTextFormatting(
   // bold/font-size mark cannot overwrite their more specific OOXML values.
   if (runFormattingOverrideMark) {
     const overrideAttrs = expectRunFormattingOverrideMarkAttrs(runFormattingOverrideMark);
+    directFontProperties = overrideAttrs.directFontProperties;
     applyRunFormattingOverrideAttrs(formatting, overrideAttrs);
     directOverrideFormatting = {};
     applyRunFormattingOverrideAttrs(directOverrideFormatting, overrideAttrs);
+    for (const property of directFontProperties ?? []) {
+      const value = formatting[property];
+      if (value !== undefined) {
+        Reflect.set(directOverrideFormatting, property, value);
+      }
+    }
   }
 
   if (characterStyleRPr) {
@@ -2967,8 +2989,40 @@ export function marksToTextFormatting(
     });
   }
 
+  for (const property of ["fontFamily", "fontSize", "color"] as const) {
+    if (directFontProperties?.includes(property)) {
+      continue;
+    }
+    const value = formatting[property];
+    const inheritedValue = options?.inheritedFormatting?.[property];
+    const matchesInherited =
+      property === "fontFamily"
+        ? sameFontFamily(formatting.fontFamily, options?.inheritedFormatting?.fontFamily)
+        : JSON.stringify(value) === JSON.stringify(inheritedValue);
+    if (inheritedValue !== undefined && matchesInherited) {
+      Reflect.deleteProperty(formatting, property);
+    }
+  }
   return formatting;
 }
+
+const sameFontFamily = (
+  left: TextFormatting["fontFamily"],
+  right: TextFormatting["fontFamily"],
+): boolean =>
+  (
+    [
+      "ascii",
+      "hAnsi",
+      "eastAsia",
+      "hint",
+      "asciiTheme",
+      "hAnsiTheme",
+      "eastAsiaTheme",
+      "csTheme",
+    ] as const
+  ).every((property) => left?.[property] === right?.[property]) &&
+  (left?.cs ?? left?.ascii) === (right?.cs ?? right?.ascii);
 
 /**
  * Negatable boolean run-property keys whose serializer emits an explicit

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -2763,6 +2763,7 @@ function buildRunMarks(
   const marks = textFormattingToMarks(mergedFormatting, {
     overrideFormatting,
   });
+  addDirectFontProvenance(marks, runFormatting);
 
   if (styleId) {
     const styleRPr = characterStyleFormatting
@@ -2778,6 +2779,40 @@ function buildRunMarks(
 
   return { marks, mergedFormatting };
 }
+
+const addDirectFontProvenance = (
+  marks: ReturnType<typeof schema.mark>[],
+  directFormatting: TextFormatting | undefined,
+): void => {
+  const directFontProperties: ("fontFamily" | "fontSize" | "color")[] = [];
+  if (directFormatting?.fontFamily !== undefined) {
+    directFontProperties.push("fontFamily");
+  }
+  if (directFormatting?.fontSize !== undefined) {
+    directFontProperties.push("fontSize");
+  }
+  if (directFormatting?.color !== undefined) {
+    directFontProperties.push("color");
+  }
+  if (
+    !directFormatting ||
+    !Object.keys(directFormatting).some((property) => property !== "styleId")
+  ) {
+    return;
+  }
+
+  const index = marks.findIndex(({ type }) => type.name === "runFormattingOverride");
+  const existing = index >= 0 ? marks.at(index) : undefined;
+  const override = schema.mark("runFormattingOverride", {
+    ...existing?.attrs,
+    ...(directFontProperties.length > 0 && { directFontProperties }),
+  });
+  if (index >= 0) {
+    marks[index] = override;
+    return;
+  }
+  marks.push(override);
+};
 
 const ORDINARY_STYLE_TOGGLE_KEYS = [
   "bold",

--- a/packages/core/src/prosemirror/extensions/marks/RunFormattingOverrideExtension.ts
+++ b/packages/core/src/prosemirror/extensions/marks/RunFormattingOverrideExtension.ts
@@ -143,6 +143,7 @@ export const RunFormattingOverrideExtension = createMarkExtension({
   schemaMarkName: "runFormattingOverride",
   markSpec: {
     attrs: {
+      directFontProperties: { default: null },
       bold: { default: null },
       italic: { default: null },
       underline: { default: null },

--- a/packages/core/src/prosemirror/schema/marks.ts
+++ b/packages/core/src/prosemirror/schema/marks.ts
@@ -152,11 +152,13 @@ export type RunPropertyChangeMarkAttrs = {
   suggestionId?: string;
 };
 
-export type RunFormattingOverrideAttrs = {
-  [K in keyof Pick<
-    TextFormatting,
+export type RunFormattingOverrideAttrs = Partial<
+  Record<
     | "bold"
+    | "boldCs"
+    | "cs"
     | "italic"
+    | "italicCs"
     | "strike"
     | "allCaps"
     | "smallCaps"
@@ -164,19 +166,14 @@ export type RunFormattingOverrideAttrs = {
     | "emboss"
     | "imprint"
     | "shadow"
-    | "outline"
-  >]?: boolean;
-} & {
+    | "outline",
+    boolean
+  >
+> & {
+  directFontProperties?: readonly ("fontFamily" | "fontSize" | "color")[];
   doubleStrike?: false;
   rtl?: false;
-  /** Independent complex-script weight (`w:bCs`). */
-  boldCs?: boolean;
-  /** Force complex-script formatting for the full run (`w:cs`). */
-  cs?: boolean;
-  /** Independent complex-script size in half-points (`w:szCs`). */
   fontSizeCs?: number;
-  /** Independent complex-script slant (`w:iCs`). */
-  italicCs?: boolean;
   underline?: "none";
 };
 

--- a/scripts/typecheck-budget.json
+++ b/scripts/typecheck-budget.json
@@ -5,14 +5,14 @@
   },
   "core": {
     "types": 123527,
-    "instantiations": 97311
+    "instantiations": 97453
   },
   "react": {
     "types": 139563,
     "instantiations": 289321
   },
   "agents": {
-    "types": 71542,
+    "types": 71642,
     "instantiations": 61574
   },
   "vue": {

--- a/scripts/typecheck-budget.json
+++ b/scripts/typecheck-budget.json
@@ -5,14 +5,14 @@
   },
   "core": {
     "types": 123527,
-    "instantiations": 97453
+    "instantiations": 97474
   },
   "react": {
     "types": 139563,
     "instantiations": 289321
   },
   "agents": {
-    "types": 71642,
+    "types": 71655,
     "instantiations": 61574
   },
   "vue": {


### PR DESCRIPTION
## Summary

- compare direct font family, half-point font size and RGB color changes without rewriting text
- track both setting and clearing these run properties through the document-operation contract
- distinguish inherited values from authored run formatting in snapshots and round-trip verification

## Verification

- focused operation-contract, snapshot, run-property and comparison tests pass
- set and clear probes preserve the target when accepted and the base when rejected
- focused formatting and lint checks pass
- the built declaration surface remains within the repository budget
- the compiler-work baseline rises 0.17% for core instantiations and 0.16% for agent types: the public formatting contract adds three typed scalar properties, and per-property provenance checks ensure mixed inherited and direct ranges only change authored formatting; all other compiler-work baselines remain unchanged and measured workloads stay within the 5% guard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Inline formatting tracking now includes font family, half-point font size and RGB colour, including clearing these properties.
  - Preview results distinguish directly applied formatting from inherited styles.
  - Formatting changes are preserved through document revisions and can be restored when rejected.

- **Bug Fixes**
  - Improved detection of formatting changes when direct and inherited values are identical.
  - Added validation and normalisation for font names, sizes and colours.

- **Documentation**
  - Updated guidance to cover the expanded inline formatting support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->