### PR TITLE
fix(core): render legacy form checkboxes

### DIFF
--- a/.changeset/bright-boxes-smile.md
+++ b/.changeset/bright-boxes-smile.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Render legacy form checkboxes without cached field results.

--- a/packages/core/src/docx/paragraphParser.test.ts
+++ b/packages/core/src/docx/paragraphParser.test.ts
@@ -768,6 +768,94 @@ describe("parseParagraph complex field formatting (#909)", () => {
   });
 });
 
+describe("parseParagraph legacy form checkboxes", () => {
+  test.each([
+    {
+      name: "unchecked default",
+      properties: '<w:sizeAuto/><w:default w:val="0"/>',
+      expected: "☐",
+      expectedFontSize: 20,
+    },
+    {
+      name: "checked default",
+      properties: '<w:sizeAuto/><w:default w:val="1"/>',
+      expected: "☒",
+      expectedFontSize: 20,
+    },
+    {
+      name: "checked current state",
+      properties: '<w:sizeAuto/><w:default w:val="0"/><w:checked/>',
+      expected: "☒",
+      expectedFontSize: 20,
+    },
+    {
+      name: "unchecked current state",
+      properties: '<w:sizeAuto/><w:default w:val="1"/><w:checked w:val="0"/>',
+      expected: "☐",
+      expectedFontSize: 20,
+    },
+    {
+      name: "explicit checkbox size",
+      properties: '<w:size w:val="24"/><w:default w:val="0"/>',
+      expected: "☐",
+      expectedFontSize: 24,
+    },
+  ])(
+    "synthesizes the $name when the field has no cached result",
+    ({ properties, expected, expectedFontSize }) => {
+      const paragraph = parseParagraphXml(`
+        <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+          <w:r>
+            <w:rPr><w:sz w:val="20"/></w:rPr>
+            <w:fldChar w:fldCharType="begin">
+              <w:ffData><w:checkBox>${properties}</w:checkBox></w:ffData>
+            </w:fldChar>
+          </w:r>
+          <w:r><w:instrText xml:space="preserve"> FORMCHECKBOX </w:instrText></w:r>
+          <w:r><w:fldChar w:fldCharType="separate"/></w:r>
+          <w:r><w:fldChar w:fldCharType="end"/></w:r>
+        </w:p>
+      `);
+
+      const field = paragraph.content.find((content) => content.type === "complexField");
+      expect(field?.type).toBe("complexField");
+      if (field?.type !== "complexField") {
+        return;
+      }
+      expect(field.fieldResult).toEqual([
+        {
+          type: "run",
+          formatting: { fontSize: expectedFontSize },
+          content: [{ type: "text", text: expected }],
+        },
+      ]);
+      expect(serializeParagraph(paragraph)).toContain(`<w:t>${expected}</w:t>`);
+    },
+  );
+
+  test("ignores checkbox metadata on a different field instruction", () => {
+    const paragraph = parseParagraphXml(`
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:r>
+          <w:fldChar w:fldCharType="begin">
+            <w:ffData><w:checkBox><w:checked/></w:checkBox></w:ffData>
+          </w:fldChar>
+        </w:r>
+        <w:r><w:instrText xml:space="preserve"> FORMTEXT </w:instrText></w:r>
+        <w:r><w:fldChar w:fldCharType="separate"/></w:r>
+        <w:r><w:fldChar w:fldCharType="end"/></w:r>
+      </w:p>
+    `);
+
+    const field = paragraph.content.find((content) => content.type === "complexField");
+    expect(field?.type).toBe("complexField");
+    if (field?.type !== "complexField") {
+      return;
+    }
+    expect(field.fieldResult).toEqual([]);
+  });
+});
+
 describe("parseParagraph smartTag wrapper", () => {
   test("recurses into w:smartTag instead of dropping wrapped runs", () => {
     const paragraph = parseParagraphXml(`

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -1433,7 +1433,7 @@ function getLegacyFormCheckboxDisplay(
   const text = isChecked
     ? LEGACY_FORM_CHECKBOX_GLYPHS.checked
     : LEGACY_FORM_CHECKBOX_GLYPHS.unchecked;
-  if (explicitSize === null || explicitSize === undefined) {
+  if (explicitSize === undefined) {
     return { text };
   }
 
@@ -1441,6 +1441,28 @@ function getLegacyFormCheckboxDisplay(
     text,
     fontSize: explicitSize,
   };
+}
+
+function createLegacyFormCheckboxResultRun(
+  display: LegacyFormCheckboxDisplay,
+  inheritedFormatting: TextFormatting | undefined,
+): Run {
+  const run: Run = {
+    type: "run",
+    content: [{ type: "text", text: display.text }],
+  };
+  const hasInheritedFormatting =
+    inheritedFormatting !== undefined && Object.keys(inheritedFormatting).length > 0;
+
+  if (display.fontSize !== undefined) {
+    run.formatting = hasInheritedFormatting
+      ? { ...inheritedFormatting, fontSize: display.fontSize }
+      : { fontSize: display.fontSize };
+  } else if (hasInheritedFormatting) {
+    run.formatting = inheritedFormatting;
+  }
+
+  return run;
 }
 
 function isLegacyFormCheckboxInstruction(instruction: string): boolean {
@@ -1607,18 +1629,11 @@ function parseParagraphContents(
               complexFieldFallbackDisplay !== undefined &&
               isLegacyFormCheckboxInstruction(complexFieldInstr)
             ) {
-              const formatting = {
-                ...complexFieldFormatting,
-                ...(complexFieldFallbackDisplay.fontSize !== undefined
-                  ? { fontSize: complexFieldFallbackDisplay.fontSize }
-                  : {}),
-              };
               resultRuns = [
-                {
-                  type: "run",
-                  ...(Object.keys(formatting).length > 0 ? { formatting } : {}),
-                  content: [{ type: "text", text: complexFieldFallbackDisplay.text }],
-                },
+                createLegacyFormCheckboxResultRun(
+                  complexFieldFallbackDisplay,
+                  complexFieldFormatting,
+                ),
               ];
             }
             // Self-numbering fields (LISTNUM, AUTONUM, …) often skip the

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -1402,6 +1402,51 @@ function hasRunPayloadElement(runElement: XmlElement): boolean {
   return getChildElements(runElement).some((child) => !matchesName(child, "w", "rPr"));
 }
 
+const LEGACY_FORM_CHECKBOX_GLYPHS = {
+  checked: "☒",
+  unchecked: "☐",
+} as const;
+const LEGACY_FORM_CHECKBOX_INSTRUCTION = "FORMCHECKBOX";
+
+type LegacyFormCheckboxDisplay = {
+  text: string;
+  fontSize?: number;
+};
+
+function getLegacyFormCheckboxDisplay(
+  runElement: XmlElement,
+): LegacyFormCheckboxDisplay | undefined {
+  const fieldChar = findChild(runElement, "w", "fldChar");
+  const fieldData = fieldChar ? findChild(fieldChar, "w", "ffData") : null;
+  const checkBox = fieldData ? findChild(fieldData, "w", "checkBox") : null;
+  if (!checkBox) {
+    return undefined;
+  }
+
+  const checked = findChild(checkBox, "w", "checked");
+  const defaultChecked = findChild(checkBox, "w", "default");
+  let isChecked = defaultChecked ? parseBooleanElement(defaultChecked) : false;
+  if (checked) {
+    isChecked = parseBooleanElement(checked);
+  }
+  const explicitSize = parseNumericAttribute(
+    findChild(checkBox, "w", "size"),
+    "w",
+    "val",
+  );
+  return {
+    text: isChecked
+      ? LEGACY_FORM_CHECKBOX_GLYPHS.checked
+      : LEGACY_FORM_CHECKBOX_GLYPHS.unchecked,
+    ...(explicitSize !== null ? { fontSize: explicitSize } : {}),
+  };
+}
+
+function isLegacyFormCheckboxInstruction(instruction: string): boolean {
+  const instructionName = instruction.trim().split(/\s+/u).at(0)?.toUpperCase();
+  return instructionName === LEGACY_FORM_CHECKBOX_INSTRUCTION;
+}
+
 /**
  * Parse all content within a paragraph
  *
@@ -1432,6 +1477,7 @@ function parseParagraphContents(
   let afterSeparator = false;
   let complexFieldLock = false;
   let complexFieldDirty = false;
+  let complexFieldFallbackDisplay: LegacyFormCheckboxDisplay | undefined;
   // Run formatting (w:rPr) carried on the field's structural runs, used as a
   // fallback when the field has no separate result run (eigenpal/docx-editor#909).
   let complexFieldFormatting: TextFormatting | undefined;
@@ -1451,6 +1497,7 @@ function parseParagraphContents(
         let hasFieldBegin = false;
         let beginFldLock = false;
         let beginDirty = false;
+        const beginFallbackDisplay = getLegacyFormCheckboxDisplay(runElement);
         let hasFieldSeparate = false;
         let hasFieldEnd = false;
         let endOriginalValue: string | undefined;
@@ -1496,6 +1543,7 @@ function parseParagraphContents(
           // `w:fldLock` / `w:dirty` live on the begin fldChar of this field.
           complexFieldLock = beginFldLock;
           complexFieldDirty = beginDirty;
+          complexFieldFallbackDisplay = beginFallbackDisplay;
           // The structural run carrying `begin` often holds the field's run
           // formatting (e.g. a footer PAGE field collapsed into one run).
           complexFieldFormatting = run.formatting;
@@ -1550,13 +1598,35 @@ function parseParagraphContents(
           }
 
           if (hasFieldEnd) {
-            // Self-numbering fields (LISTNUM, AUTONUM, …) often skip the
-            // `separate` and stash their last-rendered display on the end
-            // fldChar's `<w:numberingChange w:original="…"/>`. Without this
-            // synthesized result run, the field renders empty and any tab
-            // that follows pushes the body text into the wrong column.
             let resultRuns = complexFieldResultRuns;
-            if (resultRuns.length === 0 && !afterSeparator && endOriginalValue !== undefined) {
+            // Legacy form checkboxes are rendered from `w:ffData`; they often
+            // have a separator but no cached result run of their own.
+            if (
+              resultRuns.length === 0 &&
+              complexFieldFallbackDisplay !== undefined &&
+              isLegacyFormCheckboxInstruction(complexFieldInstr)
+            ) {
+              const formatting = {
+                ...complexFieldFormatting,
+                ...(complexFieldFallbackDisplay.fontSize !== undefined
+                  ? { fontSize: complexFieldFallbackDisplay.fontSize }
+                  : {}),
+              };
+              resultRuns = [
+                {
+                  type: "run",
+                  ...(Object.keys(formatting).length > 0 ? { formatting } : {}),
+                  content: [{ type: "text", text: complexFieldFallbackDisplay.text }],
+                },
+              ];
+            }
+            // Self-numbering fields (LISTNUM, AUTONUM, …) often skip the
+            // separator and stash their display on the end field character.
+            if (
+              resultRuns.length === 0 &&
+              !afterSeparator &&
+              endOriginalValue !== undefined
+            ) {
               resultRuns = [
                 {
                   type: "run",

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -1429,16 +1429,17 @@ function getLegacyFormCheckboxDisplay(
   if (checked) {
     isChecked = parseBooleanElement(checked);
   }
-  const explicitSize = parseNumericAttribute(
-    findChild(checkBox, "w", "size"),
-    "w",
-    "val",
-  );
+  const explicitSize = parseNumericAttribute(findChild(checkBox, "w", "size"), "w", "val");
+  const text = isChecked
+    ? LEGACY_FORM_CHECKBOX_GLYPHS.checked
+    : LEGACY_FORM_CHECKBOX_GLYPHS.unchecked;
+  if (explicitSize === null) {
+    return { text };
+  }
+
   return {
-    text: isChecked
-      ? LEGACY_FORM_CHECKBOX_GLYPHS.checked
-      : LEGACY_FORM_CHECKBOX_GLYPHS.unchecked,
-    ...(explicitSize !== null ? { fontSize: explicitSize } : {}),
+    text,
+    fontSize: explicitSize,
   };
 }
 
@@ -1622,11 +1623,7 @@ function parseParagraphContents(
             }
             // Self-numbering fields (LISTNUM, AUTONUM, …) often skip the
             // separator and stash their display on the end field character.
-            if (
-              resultRuns.length === 0 &&
-              !afterSeparator &&
-              endOriginalValue !== undefined
-            ) {
+            if (resultRuns.length === 0 && !afterSeparator && endOriginalValue !== undefined) {
               resultRuns = [
                 {
                   type: "run",

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -1433,7 +1433,7 @@ function getLegacyFormCheckboxDisplay(
   const text = isChecked
     ? LEGACY_FORM_CHECKBOX_GLYPHS.checked
     : LEGACY_FORM_CHECKBOX_GLYPHS.unchecked;
-  if (explicitSize === null) {
+  if (explicitSize === null || explicitSize === undefined) {
     return { text };
   }
 


### PR DESCRIPTION
## Summary

- synthesize checked and unchecked display glyphs for legacy form fields without cached results
- honor current state over the default state
- preserve explicit checkbox sizes while automatic sizes inherit field-character formatting

## Verification

- `bun test packages/core/src/docx/paragraphParser.test.ts`
- `bun audit`