### PR TITLE
fix: retain bounded justified final words

### DIFF
--- a/.changeset/bright-justified-lines.md
+++ b/.changeset/bright-justified-lines.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep bounded final words on modern indented justified lines.

--- a/packages/core/src/layout-engine/justifiedLineFit.ts
+++ b/packages/core/src/layout-engine/justifiedLineFit.ts
@@ -1,8 +1,9 @@
 import type { ParagraphBlock } from "./types";
 
-export const JUSTIFIED_LIST_FINAL_LINE_MAX_SHRINK_RATIO = 0.025;
-export const JUSTIFIED_LIST_SPACE_CONTRACTION_RATIO = 0.32;
+export const JUSTIFIED_FINAL_LINE_MAX_SHRINK_RATIO = 0.025;
+export const JUSTIFIED_FINAL_LINE_SPACE_CONTRACTION_RATIO = 0.32;
 
-export const supportsJustifiedListFinalLineContraction = (block: ParagraphBlock): boolean =>
-  block.attrs?.justificationCompatibility?.type !== "legacy" &&
-  block.attrs?.listMarker !== undefined;
+export const supportsJustifiedFinalLineContraction = (block: ParagraphBlock): boolean =>
+  block.attrs?.alignment === "justify" &&
+  block.attrs.justificationCompatibility?.type !== "legacy" &&
+  (block.attrs.listMarker !== undefined || (block.attrs.indent?.left ?? 0) > 0);

--- a/packages/core/src/layout-engine/measure/measureParagraph.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.test.ts
@@ -1357,6 +1357,73 @@ describe("measureParagraph justified shrink tolerance", () => {
     );
   });
 
+  test.each([
+    {
+      label: "accepts modern indented justified prose within the bound",
+      overflow: 2.4,
+      attrs: { alignment: "justify", indent: { left: 36 } } satisfies ParagraphAttrs,
+      maxWidth: 136,
+      expectedLines: 1,
+      expectedPaint: true,
+    },
+    {
+      label: "rejects modern indented justified prose beyond the bound",
+      overflow: 2.6,
+      attrs: { alignment: "justify", indent: { left: 36 } } satisfies ParagraphAttrs,
+      maxWidth: 136,
+      expectedLines: 2,
+      expectedPaint: false,
+    },
+    {
+      label: "rejects legacy indented justified prose",
+      overflow: 2.4,
+      attrs: {
+        alignment: "justify",
+        indent: { left: 36 },
+        justificationCompatibility: { type: "legacy" },
+      } satisfies ParagraphAttrs,
+      maxWidth: 136,
+      expectedLines: 2,
+      expectedPaint: false,
+    },
+    {
+      label: "rejects non-justified indented prose",
+      overflow: 2.4,
+      attrs: { alignment: "left", indent: { left: 36 } } satisfies ParagraphAttrs,
+      maxWidth: 136,
+      expectedLines: 2,
+      expectedPaint: false,
+    },
+    {
+      label: "rejects zero-indent non-list justified prose",
+      overflow: 2.4,
+      attrs: { alignment: "justify", indent: { left: 0 } } satisfies ParagraphAttrs,
+      maxWidth: 100,
+      expectedLines: 2,
+      expectedPaint: false,
+    },
+  ])("$label", ({ overflow, attrs, maxWidth, expectedLines, expectedPaint }) => {
+    withFakeTextMeasure(
+      () => {
+        const measure = measureParagraph(
+          {
+            kind: "paragraph",
+            id: "justified-prose-final-line-contraction",
+            runs: [{ kind: "text", text: `${"aaaaaaaaa ".repeat(10)}bbb` }],
+            attrs,
+          },
+          maxWidth,
+        );
+
+        expect(measure.lines).toHaveLength(expectedLines);
+        expect(measure.lines[0]?.justificationPaint?.type === "space-contraction").toBe(
+          expectedPaint,
+        );
+      },
+      { charWidth: (char) => (char === "b" ? overflow / 3 : 1) },
+    );
+  });
+
   test("ignores unused tab stops when choosing justified prose shrink tolerance", () => {
     withFakeTextMeasure(
       () => {

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -18,9 +18,9 @@ import { hasCjk, hasComplexScript } from "../../utils/scriptSegments";
 import { getHorizontalScaleFactor } from "../../utils/horizontalScale";
 import { measuredLineAdvance } from "../lineFlow";
 import {
-  JUSTIFIED_LIST_FINAL_LINE_MAX_SHRINK_RATIO,
-  JUSTIFIED_LIST_SPACE_CONTRACTION_RATIO,
-  supportsJustifiedListFinalLineContraction,
+  JUSTIFIED_FINAL_LINE_MAX_SHRINK_RATIO,
+  JUSTIFIED_FINAL_LINE_SPACE_CONTRACTION_RATIO,
+  supportsJustifiedFinalLineContraction,
 } from "../justifiedLineFit";
 import type {
   ParagraphBlock,
@@ -680,7 +680,7 @@ function resolveJustifyFitStrategy(
     }
     return {
       type: "space",
-      ratio: JUSTIFIED_LIST_SPACE_CONTRACTION_RATIO,
+      ratio: JUSTIFIED_FINAL_LINE_SPACE_CONTRACTION_RATIO,
       maxWidthRatio: JUSTIFY_SHRINK_TOLERANCE_RATIO,
     };
   }
@@ -711,11 +711,11 @@ function resolveFinalLineJustifyFitStrategy(
   block: ParagraphBlock,
   profile: JustificationProfile,
 ): JustifyFitStrategy {
-  if (supportsJustifiedListFinalLineContraction(block)) {
+  if (supportsJustifiedFinalLineContraction(block)) {
     return {
       type: "space",
-      ratio: JUSTIFIED_LIST_SPACE_CONTRACTION_RATIO,
-      maxWidthRatio: JUSTIFIED_LIST_FINAL_LINE_MAX_SHRINK_RATIO,
+      ratio: JUSTIFIED_FINAL_LINE_SPACE_CONTRACTION_RATIO,
+      maxWidthRatio: JUSTIFIED_FINAL_LINE_MAX_SHRINK_RATIO,
     };
   }
   return resolveJustifyFitStrategy(block, false, profile);
@@ -795,11 +795,13 @@ function resolveTextCandidateFit({
   continuationStrategy,
   finalStrategy,
 }: ResolveTextCandidateFitOptions): TextCandidateFit {
-  if (isFirstLine || !isFinalCandidate || !supportsJustifiedListFinalLineContraction(block)) {
+  if (!isFinalCandidate || !supportsJustifiedFinalLineContraction(block)) {
     return { type: "ordinary", tolerancePx: fallbackTolerancePx };
   }
 
-  const ordinaryTolerancePx = justifyFitTolerance(line, continuationStrategy, candidateSpaceWidth);
+  const ordinaryTolerancePx = isFirstLine
+    ? fallbackTolerancePx
+    : justifyFitTolerance(line, continuationStrategy, candidateSpaceWidth);
   if (candidateWidth <= line.availableWidth + ordinaryTolerancePx) {
     return { type: "ordinary", tolerancePx: ordinaryTolerancePx };
   }


### PR DESCRIPTION
## Summary

- extend bounded final-line space contraction to modern indented justified paragraphs
- preserve legacy, non-justified, and zero-indent prose behavior
- test both the accepted compression bound and its guard branches