### PR TITLE
fix(core): render picture watermarks at authored size

### DIFF
--- a/.changeset/fuzzy-dodos-draw.md
+++ b/.changeset/fuzzy-dodos-draw.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Render package-owned picture watermarks at their authored shape size.

--- a/packages/core/src/controller/layoutPipeline.test.ts
+++ b/packages/core/src/controller/layoutPipeline.test.ts
@@ -874,6 +874,98 @@ describe("runLayoutPipeline", () => {
     });
   });
 
+  test("paints package-owned picture watermarks", () => {
+    const imageTarget = "word/media/watermark.png";
+    const imageSrc = "data:image/png;base64,iVBORw0KGgo=";
+    const document = createEmptyDocument();
+    document.package.media = new Map([
+      [
+        imageTarget,
+        {
+          path: imageTarget,
+          mimeType: "image/png",
+          data: new ArrayBuffer(0),
+          dataUrl: imageSrc,
+        },
+      ],
+    ]);
+    document.package.headers = new Map([
+      [
+        "rId1",
+        {
+          type: "header",
+          hdrFtrType: "default",
+          content: [],
+          watermark: {
+            kind: "picture",
+            imageRId: "rId1",
+            imageTarget,
+          },
+        },
+      ],
+    ]);
+    const pagesContainer = new FakeElement("div");
+
+    runLayoutPipeline(
+      makeDeps(createLayoutSession(), {
+        document,
+        painter: new LayoutPainter(),
+        pagesContainer: asContainer(pagesContainer),
+      }),
+      makeState(),
+    );
+
+    const watermarkLayer = pagesContainer.querySelector(".layout-page-watermark");
+    expect(watermarkLayer?.children.at(0)).toMatchObject({
+      src: imageSrc,
+      tagName: "img",
+    });
+  });
+
+  test("does not resolve linked picture watermarks through package media", () => {
+    const imageTarget = "https://example.com/watermark.png";
+    const document = createEmptyDocument();
+    document.package.media = new Map([
+      [
+        imageTarget,
+        {
+          path: imageTarget,
+          mimeType: "image/png",
+          data: new ArrayBuffer(0),
+          dataUrl: "data:image/png;base64,iVBORw0KGgo=",
+        },
+      ],
+    ]);
+    document.package.headers = new Map([
+      [
+        "rId1",
+        {
+          type: "header",
+          hdrFtrType: "default",
+          content: [],
+          watermark: {
+            kind: "picture",
+            imageRId: "rId1",
+            imageTarget,
+            imageTargetExternal: true,
+          },
+        },
+      ],
+    ]);
+    const pagesContainer = new FakeElement("div");
+
+    runLayoutPipeline(
+      makeDeps(createLayoutSession(), {
+        document,
+        painter: new LayoutPainter(),
+        pagesContainer: asContainer(pagesContainer),
+      }),
+      makeState(),
+    );
+
+    expect(pagesContainer.querySelector(".layout-page-watermark")).toBeNull();
+  });
+
   test("applies the final section start mode at its preceding implicit boundary", () => {
     const continuous = runLayoutPipeline(
       makeDeps(createLayoutSession(), {

--- a/packages/core/src/controller/layoutPipeline.ts
+++ b/packages/core/src/controller/layoutPipeline.ts
@@ -117,6 +117,18 @@ export type LayoutOutcome = {
   blockLookup?: BlockLookup;
 };
 
+/** Resolve only package-owned picture-watermark bytes for the DOM painter. */
+const resolveWatermarkImageSrc = (
+  document: Document,
+  watermark: Watermark | undefined,
+): string | undefined => {
+  if (watermark?.kind !== "picture" || watermark.imageTargetExternal === true) {
+    return undefined;
+  }
+  const target = watermark.imageTarget;
+  return target === undefined ? undefined : document.package.media?.get(target)?.dataUrl;
+};
+
 // Everything the compute reads from the React adapter's scope. The adapter
 // rebuilds this on every call from current props/refs/handlers, so plain values
 // (not accessors) are safe: there is no stale-closure risk. `THfPMs` keeps the
@@ -1120,18 +1132,17 @@ export function runLayoutPipeline<THfPMs>(
       // per-header-rId map so titlePg / even-odd / per-section
       // header parts each paint their own watermark; the painter
       // falls back to `renderOpts.watermark` for documents that
-      // share one header. Picture watermarks need an image-rId →
-      // asset URL resolver that currently lives outside the
-      // editor; until that's wired in, the painter silently skips
-      // them.
+      // share one header. Picture watermarks use package-owned media
+      // bytes only; linked targets remain unavailable to the painter.
       if (document) {
         const watermark = getDocumentWatermark(document);
         if (watermark) {
           renderOpts.watermark = watermark;
         }
+        let watermarkByHeaderRId: Map<string, Watermark> | undefined;
         const headers = document.package.headers;
         if (headers) {
-          const watermarkByHeaderRId = new Map<string, Watermark>();
+          watermarkByHeaderRId = new Map<string, Watermark>();
           for (const [rId, header] of headers) {
             if (header.watermark) {
               watermarkByHeaderRId.set(rId, header.watermark);
@@ -1140,6 +1151,18 @@ export function runLayoutPipeline<THfPMs>(
           if (watermarkByHeaderRId.size > 0) {
             renderOpts.watermarkByHeaderRId = watermarkByHeaderRId;
           }
+        }
+        // The renderer currently accepts one image source for all pages. Only
+        // provide it when every active watermark resolves to that same source;
+        // otherwise a page could paint another header's picture.
+        const pictureSources = new Set(
+          [watermark, ...(watermarkByHeaderRId?.values() ?? [])]
+            .filter((candidate) => candidate !== undefined)
+            .map((candidate) => resolveWatermarkImageSrc(document, candidate)),
+        );
+        const watermarkImageSrc = pictureSources.size === 1 ? [...pictureSources].at(0) : undefined;
+        if (watermarkImageSrc !== undefined) {
+          renderOpts.watermarkImageSrc = watermarkImageSrc;
         }
       }
       if (pageRenderer === PAGE_RENDERER.displayList) {

--- a/packages/core/src/display-list/build/furniture.test.ts
+++ b/packages/core/src/display-list/build/furniture.test.ts
@@ -244,6 +244,37 @@ describe("watermark", () => {
     }, fakeMeasure);
   });
 
+  test("a picture watermark uses its authored shape box", () => {
+    withFakeTextMeasure(() => {
+      const list = buildDisplayList({
+        ...buildLayout([para("a", "A")]),
+        watermark: {
+          kind: "picture",
+          imageRId: "rId7",
+          widthPt: 300,
+          heightPt: 120,
+        },
+        watermarkImageSrc:
+          "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+      });
+      const image = (list.pages.at(0)?.primitives ?? []).find(
+        (primitive) => primitive.kind === "image",
+      );
+
+      expect(image?.kind).toBe("image");
+      if (image?.kind !== "image") {
+        return;
+      }
+      expect(image.rect).toEqual({
+        xPx: 208,
+        yPx: 448,
+        widthPx: 400,
+        heightPx: 160,
+      });
+      expect(image.opacity).toBe(0.18);
+    }, fakeMeasure);
+  });
+
   test("a document that has a watermark the caller withheld is reported", () => {
     withFakeTextMeasure(() => {
       const list = buildDisplayList({

--- a/packages/core/src/display-list/build/watermarkPrimitives.ts
+++ b/packages/core/src/display-list/build/watermarkPrimitives.ts
@@ -13,7 +13,7 @@
  * its watermark and a page that never had one must not look alike.
  */
 
-import { pxToPt } from "../../layout-engine/measure/measureHelpers";
+import { ptToPx, pxToPt } from "../../layout-engine/measure/measureHelpers";
 import { getFontMetrics } from "../../layout-engine/measure/measureProvider";
 import type { FontStyle } from "../../layout-engine/measure/measureTypes";
 import type { Page } from "../../layout-engine/types";
@@ -34,7 +34,7 @@ const TEXT_DEFAULT_COLOR = "#C0C0C0";
 const TEXT_DEFAULT_OPACITY = 0.5;
 const TEXT_DIAGONAL_DEGREES = -45;
 const PICTURE_NATIVE_SCALE = 1;
-const PICTURE_WASHOUT_OPACITY = 0.4;
+const PICTURE_WASHOUT_OPACITY = 0.18;
 
 const paintTextWatermark = (
   watermark: Extract<Watermark, { kind: "text" }>,
@@ -137,6 +137,25 @@ const containedRect = (
   };
 };
 
+/** The centred VML shape box, when both authored dimensions survived parsing. */
+const authoredPictureRect = (
+  page: Page,
+  widthPt: number | undefined,
+  heightPt: number | undefined,
+): DisplayRect | undefined => {
+  if (widthPt === undefined || heightPt === undefined) {
+    return undefined;
+  }
+  const widthPx = ptToPx(widthPt);
+  const heightPx = ptToPx(heightPt);
+  return {
+    xPx: (page.size.w - widthPx) / 2,
+    yPx: (page.size.h - heightPx) / 2,
+    widthPx,
+    heightPx,
+  };
+};
+
 const paintPictureWatermark = (
   watermark: Extract<Watermark, { kind: "picture" }>,
   page: Page,
@@ -169,12 +188,14 @@ const paintPictureWatermark = (
   const image: DisplayImagePrimitive = {
     kind: "image",
     image: ref,
-    rect: containedRect(
-      page,
-      watermark.scale ?? PICTURE_NATIVE_SCALE,
-      source?.pixelWidth ?? 0,
-      source?.pixelHeight ?? 0,
-    ),
+    rect:
+      authoredPictureRect(page, watermark.widthPt, watermark.heightPt) ??
+      containedRect(
+        page,
+        watermark.scale ?? PICTURE_NATIVE_SCALE,
+        source?.pixelWidth ?? 0,
+        source?.pixelHeight ?? 0,
+      ),
     opacity: watermark.washout === false ? 1 : PICTURE_WASHOUT_OPACITY,
   };
   return [image];

--- a/packages/core/src/layout-painter/renderWatermark.test.ts
+++ b/packages/core/src/layout-painter/renderWatermark.test.ts
@@ -117,7 +117,25 @@ describe("renderWatermarkLayer", () => {
     expect(img?.src).toBe("data:image/png;base64,iVBORw0KGgo=");
     expect(img?.alt).toBe("");
     expect(img?.getAttribute("aria-hidden")).toBe("true");
-    expect(img?.style["opacity"]).toBe("0.4");
+    expect(img?.style["opacity"]).toBe("0.18");
+  });
+
+  test("uses the authored picture shape box without preserving source aspect ratio", () => {
+    const layer = renderWatermarkLayer(
+      {
+        kind: "picture",
+        imageRId: "rId42",
+        widthPt: 300,
+        heightPt: 120,
+      },
+      pageFixture(),
+      fakeDocument,
+      { imageSrc: "data:image/png;base64,iVBORw0KGgo=" },
+    ) as unknown as FakeElement;
+    const img = layer.firstElementChild;
+    expect(img?.style["width"]).toBe("400px");
+    expect(img?.style["height"]).toBe("160px");
+    expect(img?.style["maxWidth"]).toBeUndefined();
   });
 
   test("returns null for a picture watermark without a resolved src", () => {

--- a/packages/core/src/layout-painter/renderWatermark.ts
+++ b/packages/core/src/layout-painter/renderWatermark.ts
@@ -13,8 +13,10 @@ import type { Page } from "../layout-engine/types";
 import type { Watermark } from "../types/document";
 import { resolveFontFamily } from "../utils/fontResolver";
 import { applySanitizedImageSrc } from "../utils/sanitizeImageSrc";
+import { pointsToPixels } from "../utils/units";
 
 const WATERMARK_CLASS = "layout-page-watermark";
+const PICTURE_WASHOUT_OPACITY = 0.18;
 
 export type RenderWatermarkOptions = {
   /** Resolved image src for picture watermarks (`data:` / `blob:` only). */
@@ -108,13 +110,19 @@ function renderPictureWatermark(
   img.alt = "";
   // Decorative — never announced.
   img.setAttribute("aria-hidden", "true");
-  // `PictureWatermark.scale` is documented as a factor (1.0 = native,
-  // 0.5 = half-size). Convert to a CSS percentage for max-width/height.
-  // A nil scale defaults to 1.0 (native).
-  const scalePct = (watermark.scale ?? 1) * 100;
-  img.style.maxWidth = `${scalePct}%`;
-  img.style.maxHeight = `${scalePct}%`;
-  img.style.opacity = watermark.washout === false ? "1" : "0.4";
+  if (watermark.widthPt !== undefined && watermark.heightPt !== undefined) {
+    // VML stretches the source into its authored shape box, including a
+    // deliberate aspect-ratio change. The flex parent centres that box.
+    img.style.width = `${pointsToPixels(watermark.widthPt)}px`;
+    img.style.height = `${pointsToPixels(watermark.heightPt)}px`;
+  } else {
+    // Synthesized watermarks have no authored box. Preserve the page-relative
+    // scale fallback (1.0 = native, 0.5 = half-size).
+    const scalePct = (watermark.scale ?? 1) * 100;
+    img.style.maxWidth = `${scalePct}%`;
+    img.style.maxHeight = `${scalePct}%`;
+  }
+  img.style.opacity = String(watermark.washout === false ? 1 : PICTURE_WASHOUT_OPACITY);
   img.style.objectFit = "contain";
   return img;
 }


### PR DESCRIPTION
## Summary
- resolve embedded picture-watermark media for editor page rendering
- center and stretch parsed picture watermarks to their authored VML shape box in both paint paths
- align the default washout blend while preserving full-contrast and synthesized-size behavior
- reject linked image targets and conflicting per-header sources

## Validation
- `bun test packages/core/src/controller/layoutPipeline.test.ts packages/core/src/layout-painter/renderWatermark.test.ts packages/core/src/display-list/build/furniture.test.ts`
- `bunx ultracite check packages/core/src/controller/layoutPipeline.ts packages/core/src/controller/layoutPipeline.test.ts packages/core/src/display-list/build/watermarkPrimitives.ts packages/core/src/display-list/build/furniture.test.ts packages/core/src/layout-painter/renderWatermark.ts packages/core/src/layout-painter/renderWatermark.test.ts`
- `git diff --check`
- `bun audit`

Stacked on #745.