### PR TITLE
fix(core): honor endnote number formats

### DIFF
--- a/.changeset/format-endnote-markers.md
+++ b/.changeset/format-endnote-markers.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Render endnote reference markers with their configured number format and the standard lower-Roman default.

--- a/packages/core/src/controller/layoutPipeline.test.ts
+++ b/packages/core/src/controller/layoutPipeline.test.ts
@@ -558,7 +558,7 @@ describe("runLayoutPipeline", () => {
       { noteId: 5, text: "1" },
       { noteId: 2, text: "2" },
       { noteId: 9, text: "3" },
-      { noteId: 8, text: "1" },
+      { noteId: 8, text: "i" },
     ]);
 
     // The footnote area numbering comes from the same map as the body markers.

--- a/packages/core/src/controller/layoutPipeline.ts
+++ b/packages/core/src/controller/layoutPipeline.ts
@@ -91,6 +91,17 @@ import type {
 import { getDocumentWatermark } from "../watermark";
 import type { LayoutArtifacts, LayoutSession, LayoutTemplatePreview } from "./layoutSession";
 
+const formatEndnoteTexts = (
+  numbers: ReadonlyMap<number, number>,
+  formatNumber: (displayNumber: number) => string,
+): ReadonlyMap<number, string> => {
+  const texts = new Map<number, string>();
+  for (const [id, displayNumber] of numbers) {
+    texts.set(id, formatNumber(displayNumber));
+  }
+  return texts;
+};
+
 export type LayoutRunOptions = {
   dirtyRange?: DirtyRange;
   forceFull?: boolean;
@@ -463,12 +474,8 @@ export function runLayoutPipeline<THfPMs>(
     const endnoteNumberFormat =
       document?.package.document.sections?.at(-1)?.properties.endnotePr?.numFmt ?? "lowerRoman";
     const endnoteTexts = endnoteDisplayNumbers
-      ? new Map(
-          Array.from(
-            endnoteDisplayNumbers,
-            ([id, displayNumber]) =>
-              [id, formatOoxmlCounter(displayNumber, endnoteNumberFormat)] as const,
-          ),
+      ? formatEndnoteTexts(endnoteDisplayNumbers, (displayNumber) =>
+          formatOoxmlCounter(displayNumber, endnoteNumberFormat),
         )
       : undefined;
     newBlocks = remapNoteMarkerText(newBlocks, {

--- a/packages/core/src/controller/layoutPipeline.ts
+++ b/packages/core/src/controller/layoutPipeline.ts
@@ -1,6 +1,7 @@
 import type { EditorState } from "prosemirror-state";
 
 import { resolveDocumentGridLinePitch } from "../docx/documentGrid";
+import { formatOoxmlCounter } from "../docx/ooxmlCounterFormatter";
 import { buildBookmarkPageMap } from "../fields/bookmarkPages";
 import { buildBookmarkText } from "../fields/bookmarkText";
 import {
@@ -459,11 +460,20 @@ export function runLayoutPipeline<THfPMs>(
           collectEndnoteRefs(newBlocks).map((ref) => ref.endnoteId),
         )
       : undefined;
+    const endnoteNumberFormat =
+      document?.package.document.sections?.at(-1)?.properties.endnotePr?.numFmt ?? "lowerRoman";
+    const endnoteTexts = endnoteDisplayNumbers
+      ? new Map(
+          Array.from(
+            endnoteDisplayNumbers,
+            ([id, displayNumber]) =>
+              [id, formatOoxmlCounter(displayNumber, endnoteNumberFormat)] as const,
+          ),
+        )
+      : undefined;
     newBlocks = remapNoteMarkerText(newBlocks, {
       ...(footnoteDisplayNumbers ? { footnoteNumbers: footnoteDisplayNumbers } : {}),
-      ...(endnoteDisplayNumbers ? { endnoteNumbers: endnoteDisplayNumbers } : {}),
-      endnoteNumberFormat:
-        document?.package.document.sections?.at(-1)?.properties.endnotePr?.numFmt ?? "lowerRoman",
+      ...(endnoteTexts ? { endnoteTexts } : {}),
     });
     outcome.blocks = newBlocks;
 

--- a/packages/core/src/controller/layoutPipeline.ts
+++ b/packages/core/src/controller/layoutPipeline.ts
@@ -462,6 +462,8 @@ export function runLayoutPipeline<THfPMs>(
     newBlocks = remapNoteMarkerText(newBlocks, {
       ...(footnoteDisplayNumbers ? { footnoteNumbers: footnoteDisplayNumbers } : {}),
       ...(endnoteDisplayNumbers ? { endnoteNumbers: endnoteDisplayNumbers } : {}),
+      endnoteNumberFormat:
+        document?.package.document.sections?.at(-1)?.properties.endnotePr?.numFmt ?? "lowerRoman",
     });
     outcome.blocks = newBlocks;
 

--- a/packages/core/src/headless-layout.ts
+++ b/packages/core/src/headless-layout.ts
@@ -480,7 +480,11 @@ export const layoutDocxHeadless = async (
       endnotes,
       collectEndnoteRefs(authored).map((ref) => ref.endnoteId),
     );
-    const blocks = remapNoteMarkerText(authored, { footnoteNumbers, endnoteNumbers });
+    const blocks = remapNoteMarkerText(authored, {
+      footnoteNumbers,
+      endnoteNumbers,
+      endnoteNumberFormat: finalSection?.endnotePr?.numFmt ?? "lowerRoman",
+    });
 
     const measures = measureBlocks(blocks, contentWidth);
 

--- a/packages/core/src/headless-layout.ts
+++ b/packages/core/src/headless-layout.ts
@@ -36,6 +36,7 @@ import { Result, TaggedError } from "better-result";
 import type { Node as PMNode } from "prosemirror-model";
 
 import { parseDocx } from "./docx/parser";
+import { formatOoxmlCounter } from "./docx/ooxmlCounterFormatter";
 import { toArrayBuffer, type DocxInput } from "./utils/docxInput";
 import { buildFontAlternates } from "./fonts/fontAlternates";
 import { extractEmbeddedFonts, type EmbeddedFont } from "./fonts/embeddedFonts";
@@ -480,10 +481,17 @@ export const layoutDocxHeadless = async (
       endnotes,
       collectEndnoteRefs(authored).map((ref) => ref.endnoteId),
     );
+    const endnoteNumberFormat = finalSection?.endnotePr?.numFmt ?? "lowerRoman";
+    const endnoteTexts = new Map(
+      Array.from(
+        endnoteNumbers,
+        ([id, displayNumber]) =>
+          [id, formatOoxmlCounter(displayNumber, endnoteNumberFormat)] as const,
+      ),
+    );
     const blocks = remapNoteMarkerText(authored, {
       footnoteNumbers,
-      endnoteNumbers,
-      endnoteNumberFormat: finalSection?.endnotePr?.numFmt ?? "lowerRoman",
+      endnoteTexts,
     });
 
     const measures = measureBlocks(blocks, contentWidth);

--- a/packages/core/src/headless-layout.ts
+++ b/packages/core/src/headless-layout.ts
@@ -78,6 +78,17 @@ import { toProseDoc } from "./prosemirror/conversion/toProseDoc";
 import { getDocumentWatermark } from "./watermark/index";
 import type { Document, HeaderFooter, Watermark } from "./types/document";
 
+const formatEndnoteTexts = (
+  numbers: ReadonlyMap<number, number>,
+  formatNumber: (displayNumber: number) => string,
+): ReadonlyMap<number, string> => {
+  const texts = new Map<number, string>();
+  for (const [id, displayNumber] of numbers) {
+    texts.set(id, formatNumber(displayNumber));
+  }
+  return texts;
+};
+
 /**
  * Constructs the painter takes from render options rather than from `Layout`.
  *
@@ -482,12 +493,8 @@ export const layoutDocxHeadless = async (
       collectEndnoteRefs(authored).map((ref) => ref.endnoteId),
     );
     const endnoteNumberFormat = finalSection?.endnotePr?.numFmt ?? "lowerRoman";
-    const endnoteTexts = new Map(
-      Array.from(
-        endnoteNumbers,
-        ([id, displayNumber]) =>
-          [id, formatOoxmlCounter(displayNumber, endnoteNumberFormat)] as const,
-      ),
+    const endnoteTexts = formatEndnoteTexts(endnoteNumbers, (displayNumber) =>
+      formatOoxmlCounter(displayNumber, endnoteNumberFormat),
     );
     const blocks = remapNoteMarkerText(authored, {
       footnoteNumbers,

--- a/packages/core/src/layout-bridge/convert/footnoteLayout-numbering.test.ts
+++ b/packages/core/src/layout-bridge/convert/footnoteLayout-numbering.test.ts
@@ -205,7 +205,28 @@ describe("remapNoteMarkerText", () => {
       throw new Error("Expected paragraph blocks");
     }
     expect(footnoteParagraph.runs.at(0)).toMatchObject({ text: "1", footnoteRefId: 5 });
-    expect(endnoteParagraph.runs.at(0)).toMatchObject({ text: "1", endnoteRefId: 8 });
+    expect(endnoteParagraph.runs.at(0)).toMatchObject({ text: "i", endnoteRefId: 8 });
+  });
+
+  test("uses the configured endnote number format", () => {
+    const blocks: FlowBlock[] = [
+      {
+        kind: "paragraph",
+        id: "en",
+        runs: [{ kind: "text", text: "8", endnoteRefId: 8 }],
+      },
+    ];
+
+    const remapped = remapNoteMarkerText(blocks, {
+      endnoteNumbers: new Map([[8, 3]]),
+      endnoteNumberFormat: "upperLetter",
+    });
+
+    const endnoteParagraph = remapped.at(0);
+    if (endnoteParagraph?.kind !== "paragraph") {
+      throw new Error("Expected a paragraph block");
+    }
+    expect(endnoteParagraph.runs.at(0)).toMatchObject({ text: "C", endnoteRefId: 8 });
   });
 });
 

--- a/packages/core/src/layout-bridge/convert/footnoteLayout-numbering.test.ts
+++ b/packages/core/src/layout-bridge/convert/footnoteLayout-numbering.test.ts
@@ -196,7 +196,7 @@ describe("remapNoteMarkerText", () => {
 
     const remapped = remapNoteMarkerText(blocks, {
       footnoteNumbers: new Map([[5, 1]]),
-      endnoteNumbers: new Map([[8, 1]]),
+      endnoteTexts: new Map([[8, "i"]]),
     });
 
     const footnoteParagraph = remapped.at(0);
@@ -208,7 +208,7 @@ describe("remapNoteMarkerText", () => {
     expect(endnoteParagraph.runs.at(0)).toMatchObject({ text: "i", endnoteRefId: 8 });
   });
 
-  test("uses the configured endnote number format", () => {
+  test("uses preformatted endnote display text", () => {
     const blocks: FlowBlock[] = [
       {
         kind: "paragraph",
@@ -218,8 +218,7 @@ describe("remapNoteMarkerText", () => {
     ];
 
     const remapped = remapNoteMarkerText(blocks, {
-      endnoteNumbers: new Map([[8, 3]]),
-      endnoteNumberFormat: "upperLetter",
+      endnoteTexts: new Map([[8, "C"]]),
     });
 
     const endnoteParagraph = remapped.at(0);

--- a/packages/core/src/layout-bridge/convert/footnoteLayout.ts
+++ b/packages/core/src/layout-bridge/convert/footnoteLayout.ts
@@ -27,7 +27,8 @@ import {
   FOOTNOTE_SEPARATOR_HEIGHT,
 } from "../../layout-engine/types";
 import { footnoteToProseDoc } from "../../prosemirror/conversion/toProseDoc";
-import type { Footnote, StyleDefinitions, Theme } from "../../types/document";
+import type { Footnote, NumberFormat, StyleDefinitions, Theme } from "../../types/document";
+import { formatOoxmlCounter } from "../../docx/ooxmlCounterFormatter";
 import { measureParagraph } from "../engine/measuring";
 import { layoutTextBoxContent } from "../../layout-engine/measure/textBoxParagraphLayout";
 import { toFlowBlocks } from "./toFlowBlocks";
@@ -165,6 +166,8 @@ export type NoteDisplayNumberMaps = {
   footnoteNumbers?: ReadonlyMap<number, number>;
   /** endnote `w:id` → sequential display number */
   endnoteNumbers?: ReadonlyMap<number, number>;
+  /** Number format for endnote reference markers. Defaults to lower Roman. */
+  endnoteNumberFormat?: NumberFormat;
 };
 
 /**
@@ -250,20 +253,23 @@ function remapNoteMarkerRun(run: Run, maps: NoteDisplayNumberMaps): Run {
   if (run.kind !== "text") {
     return run;
   }
-  const displayNumber = getRunDisplayNumber(run, maps);
-  if (displayNumber === undefined) {
+  const displayText = getRunDisplayText(run, maps);
+  if (displayText === undefined) {
     return run;
   }
-  const text = String(displayNumber);
-  return run.text === text ? run : { ...run, text };
+  return run.text === displayText ? run : { ...run, text: displayText };
 }
 
-function getRunDisplayNumber(run: TextRun, maps: NoteDisplayNumberMaps): number | undefined {
+function getRunDisplayText(run: TextRun, maps: NoteDisplayNumberMaps): string | undefined {
   if (run.footnoteRefId !== undefined) {
-    return maps.footnoteNumbers?.get(run.footnoteRefId);
+    const displayNumber = maps.footnoteNumbers?.get(run.footnoteRefId);
+    return displayNumber === undefined ? undefined : String(displayNumber);
   }
   if (run.endnoteRefId !== undefined) {
-    return maps.endnoteNumbers?.get(run.endnoteRefId);
+    const displayNumber = maps.endnoteNumbers?.get(run.endnoteRefId);
+    return displayNumber === undefined
+      ? undefined
+      : formatOoxmlCounter(displayNumber, maps.endnoteNumberFormat ?? "lowerRoman");
   }
   return undefined;
 }

--- a/packages/core/src/layout-bridge/convert/footnoteLayout.ts
+++ b/packages/core/src/layout-bridge/convert/footnoteLayout.ts
@@ -6,6 +6,9 @@
  * per-page footnote area heights for layout space reservation.
  */
 
+import type { NumberFormat } from "@stll/docx-core/model";
+
+import { formatOoxmlCounter } from "../../docx/ooxmlCounterFormatter";
 import type {
   FlowBlock,
   Measure,
@@ -27,8 +30,7 @@ import {
   FOOTNOTE_SEPARATOR_HEIGHT,
 } from "../../layout-engine/types";
 import { footnoteToProseDoc } from "../../prosemirror/conversion/toProseDoc";
-import type { Footnote, NumberFormat, StyleDefinitions, Theme } from "../../types/document";
-import { formatOoxmlCounter } from "../../docx/ooxmlCounterFormatter";
+import type { Footnote, StyleDefinitions, Theme } from "../../types/document";
 import { measureParagraph } from "../engine/measuring";
 import { layoutTextBoxContent } from "../../layout-engine/measure/textBoxParagraphLayout";
 import { toFlowBlocks } from "./toFlowBlocks";

--- a/packages/core/src/layout-bridge/convert/footnoteLayout.ts
+++ b/packages/core/src/layout-bridge/convert/footnoteLayout.ts
@@ -6,9 +6,6 @@
  * per-page footnote area heights for layout space reservation.
  */
 
-import type { NumberFormat } from "@stll/docx-core/model";
-
-import { formatOoxmlCounter } from "../../docx/ooxmlCounterFormatter";
 import type {
   FlowBlock,
   Measure,
@@ -166,10 +163,8 @@ export function computeNoteDisplayNumbers(
 export type NoteDisplayNumberMaps = {
   /** footnote `w:id` → sequential display number */
   footnoteNumbers?: ReadonlyMap<number, number>;
-  /** endnote `w:id` → sequential display number */
-  endnoteNumbers?: ReadonlyMap<number, number>;
-  /** Number format for endnote reference markers. Defaults to lower Roman. */
-  endnoteNumberFormat?: NumberFormat;
+  /** endnote `w:id` → formatted display text */
+  endnoteTexts?: ReadonlyMap<number, string>;
 };
 
 /**
@@ -184,7 +179,7 @@ export type NoteDisplayNumberMaps = {
  * template preview substitution).
  */
 export function remapNoteMarkerText(blocks: FlowBlock[], maps: NoteDisplayNumberMaps): FlowBlock[] {
-  if ((maps.footnoteNumbers?.size ?? 0) === 0 && (maps.endnoteNumbers?.size ?? 0) === 0) {
+  if ((maps.footnoteNumbers?.size ?? 0) === 0 && (maps.endnoteTexts?.size ?? 0) === 0) {
     return blocks;
   }
 
@@ -268,10 +263,7 @@ function getRunDisplayText(run: TextRun, maps: NoteDisplayNumberMaps): string | 
     return displayNumber === undefined ? undefined : String(displayNumber);
   }
   if (run.endnoteRefId !== undefined) {
-    const displayNumber = maps.endnoteNumbers?.get(run.endnoteRefId);
-    return displayNumber === undefined
-      ? undefined
-      : formatOoxmlCounter(displayNumber, maps.endnoteNumberFormat ?? "lowerRoman");
+    return maps.endnoteTexts?.get(run.endnoteRefId);
   }
   return undefined;
 }


### PR DESCRIPTION
## Summary

- format endnote reference markers through the shared OOXML counter formatter
- use the lower-Roman endnote default while preserving an explicit section format
- keep browser and headless layout behavior aligned

## Tests

- `bun test packages/core/src/layout-bridge/convert/footnoteLayout-numbering.test.ts`
- `bun audit`