### PR TITLE
fix(core): preserve unpaintable image layout

### DIFF
--- a/.changeset/wise-otters-wave.md
+++ b/.changeset/wise-otters-wave.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve layout space for relationship-backed images whose format cannot be painted.

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks-sdt.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks-sdt.test.ts
@@ -99,6 +99,35 @@ describe("toFlowBlocks — blockSdt grouping", () => {
     expect(innermost).toEqual(["only"]);
   });
 
+  test("keeps a picture control's authored line box when its package image cannot paint", () => {
+    const image = schema.nodes.image.create({
+      src: "",
+      rId: "rId4",
+      width: 200,
+      height: 159,
+      wrapType: "inline",
+    });
+    const picture = schema.node("blockSdt", { sdtType: "picture" }, [
+      schema.node("paragraph", {}, [image]),
+    ]);
+
+    const paragraph = toFlowBlocks(schema.node("doc", null, [picture])).at(0);
+
+    expect(paragraph?.kind).toBe("paragraph");
+    if (paragraph?.kind !== "paragraph") {
+      return;
+    }
+    expect(paragraph.sdtGroups?.at(0)?.sdtType).toBe("picture");
+    expect(paragraph.runs).toEqual([
+      expect.objectContaining({
+        kind: "image",
+        src: "",
+        width: 200,
+        height: 159,
+      }),
+    ]);
+  });
+
   test("outer SDT does not overwrite inner SDT's first/middle/last", () => {
     // Outer SDT has `[pre, inner SDT containing two paragraphs, post]`.
     // The outer's position-stamping pass must update ITS own group

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks-sdt.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks-sdt.test.ts
@@ -99,34 +99,37 @@ describe("toFlowBlocks — blockSdt grouping", () => {
     expect(innermost).toEqual(["only"]);
   });
 
-  test("keeps a picture control's authored line box when its package image cannot paint", () => {
-    const image = schema.nodes.image.create({
-      src: "",
-      rId: "rId4",
-      width: 200,
-      height: 159,
-      wrapType: "inline",
-    });
-    const picture = schema.node("blockSdt", { sdtType: "picture" }, [
-      schema.node("paragraph", {}, [image]),
-    ]);
-
-    const paragraph = toFlowBlocks(schema.node("doc", null, [picture])).at(0);
-
-    expect(paragraph?.kind).toBe("paragraph");
-    if (paragraph?.kind !== "paragraph") {
-      return;
-    }
-    expect(paragraph.sdtGroups?.at(0)?.sdtType).toBe("picture");
-    expect(paragraph.runs).toEqual([
-      expect.objectContaining({
-        kind: "image",
-        src: "",
+  test.each(["", "  ", "https://example.invalid/image.png"])(
+    "keeps a picture control's authored line box for rejected source %j",
+    (src) => {
+      const image = schema.nodes.image.create({
+        src,
+        rId: "rId4",
         width: 200,
         height: 159,
-      }),
-    ]);
-  });
+        wrapType: "inline",
+      });
+      const picture = schema.node("blockSdt", { sdtType: "picture" }, [
+        schema.node("paragraph", {}, [image]),
+      ]);
+
+      const paragraph = toFlowBlocks(schema.node("doc", null, [picture])).at(0);
+
+      expect(paragraph?.kind).toBe("paragraph");
+      if (paragraph?.kind !== "paragraph") {
+        return;
+      }
+      expect(paragraph.sdtGroups?.at(0)?.sdtType).toBe("picture");
+      expect(paragraph.runs).toEqual([
+        expect.objectContaining({
+          kind: "image",
+          src,
+          width: 200,
+          height: 159,
+        }),
+      ]);
+    },
+  );
 
   test("outer SDT does not overwrite inner SDT's first/middle/last", () => {
     // Outer SDT has `[pre, inner SDT containing two paragraphs, post]`.

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -2509,30 +2509,45 @@ describe("toFlowBlocks list numbering", () => {
 // carry rounded OOXML dimensions, where zero is a valid subpixel result rather
 // than an absent value that should receive the default size.
 describe("toFlowBlocks image attribute normalization", () => {
-  test("omits inline image nodes without a paintable source", () => {
-    const doc = schema.node("doc", null, [
-      schema.node("paragraph", null, [
-        schema.nodes.image.create({
-          src: "",
-          width: 100,
-          height: 100,
-        }),
-      ]),
-    ]);
+  const paintableImageSource = "data:image/png;base64,";
 
-    const paragraph = toFlowBlocks(doc).at(0);
+  test.each(["", "  ", "https://example.invalid/image.png"])(
+    "omits inline image nodes with rejected source %j",
+    (src) => {
+      const doc = schema.node("doc", null, [
+        schema.node("paragraph", null, [
+          schema.nodes.image.create({
+            src,
+            width: 100,
+            height: 100,
+          }),
+        ]),
+      ]);
 
-    expect(paragraph?.kind).toBe("paragraph");
-    if (paragraph?.kind === "paragraph") {
-      expect(paragraph.runs).toEqual([]);
-    }
-  });
+      const paragraph = toFlowBlocks(doc).at(0);
+
+      expect(paragraph?.kind).toBe("paragraph");
+      if (paragraph?.kind === "paragraph") {
+        expect(paragraph.runs).toEqual([]);
+      }
+    },
+  );
+
+  test.each(["  ", "https://example.invalid/image.png"])(
+    "omits standalone image nodes with rejected source %j",
+    (src) => {
+      const image = schema.nodes.image.create({ src });
+      const doc = schema.topNodeType.create(null, [image]);
+
+      expect(toFlowBlocks(doc)).toEqual([]);
+    },
+  );
 
   test("preserves zero-sized inline image dimensions", () => {
     const doc = schema.node("doc", null, [
       schema.node("paragraph", null, [
         schema.nodes.image.create({
-          src: "media/subpixel-placeholder.png",
+          src: paintableImageSource,
           width: 1,
           height: 0,
         }),
@@ -2550,7 +2565,7 @@ describe("toFlowBlocks image attribute normalization", () => {
 
   test("preserves zero-sized standalone image dimensions", () => {
     const image = schema.nodes.image.create({
-      src: "media/subpixel-placeholder.png",
+      src: paintableImageSource,
       width: 1,
       height: 0,
     });
@@ -2570,7 +2585,7 @@ describe("toFlowBlocks image attribute normalization", () => {
     const doc = schema.node("doc", null, [
       schema.node("paragraph", null, [
         schema.nodes.image.create({
-          src: "media/image.png",
+          src: paintableImageSource,
           width: 100,
           height: 100,
         }),
@@ -2596,7 +2611,7 @@ describe("toFlowBlocks image attribute normalization", () => {
     const doc = schema.node("doc", null, [
       schema.node("paragraph", null, [
         schema.nodes.image.create({
-          src: "media/image.png",
+          src: paintableImageSource,
           width: 100,
           height: 100,
           opacity: 0.5,
@@ -2620,7 +2635,7 @@ describe("toFlowBlocks image attribute normalization", () => {
     const doc = schema.node("doc", null, [
       schema.node("paragraph", null, [
         schema.nodes.image.create({
-          src: "media/image.png",
+          src: paintableImageSource,
           width: 100,
           height: 100,
           wrapType: "square",
@@ -2643,7 +2658,7 @@ describe("toFlowBlocks image attribute normalization", () => {
     const doc = schema.node("doc", null, [
       schema.node("paragraph", null, [
         schema.nodes.image.create({
-          src: "media/preview.png",
+          src: paintableImageSource,
           width: 20,
           height: 18,
           _docxObjectPreview: true,

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -94,6 +94,7 @@ import { normalizeShapeTextAnchor } from "../../types/documentEnumValues";
 import { resolveColor, resolveHighlightToCss } from "../../utils/colorResolver";
 import { resolveThemeFont } from "../../utils/fontResolver";
 import { resolveShadingFill } from "../../utils/formatToStyle";
+import { sanitizeImageSrc } from "../../utils/sanitizeImageSrc";
 import { decodeOoxmlSymbolCharacter } from "../../utils/ooxmlSymbol";
 import { tableOfContentsStyleLevel } from "../../utils/tableOfContentsStyle";
 import {
@@ -997,13 +998,15 @@ function buildImageRun(
 /** A package image whose bytes cannot paint still owns its authored line box. */
 const hasRelationshipBackedImageBox = (attrs: ImageAttrs): boolean =>
   typeof attrs.rId === "string" &&
-  attrs.rId.length > 0 &&
+  attrs.rId.trim().length > 0 &&
   typeof attrs.width === "number" &&
   Number.isFinite(attrs.width) &&
   attrs.width >= 0 &&
   typeof attrs.height === "number" &&
   Number.isFinite(attrs.height) &&
   attrs.height >= 0;
+
+const hasPaintableImageSource = (src: string): boolean => sanitizeImageSrc(src) !== undefined;
 
 /**
  * In TOC paragraphs, strip the resolved Hyperlink character-style colour and
@@ -1127,7 +1130,7 @@ function paragraphToRuns(node: PMNode, startPos: number, _options: FlowConversio
     }
     if (child.type.name === "image") {
       const attrs = expectImageAttrs(child);
-      if (!attrs.src && !hasRelationshipBackedImageBox(attrs)) {
+      if (!hasPaintableImageSource(attrs.src) && !hasRelationshipBackedImageBox(attrs)) {
         // Unsupported DrawingML shapes can survive the parser as image nodes
         // without a relationship target or authored extent. They have no
         // paintable payload; a 100x100 fallback box would incorrectly consume
@@ -2482,8 +2485,15 @@ function convertTable(node: PMNode, startPos: number, options: FlowConversionOpt
 /**
  * Convert an image node to an ImageBlock.
  */
-function convertImage(node: PMNode, startPos: number, pageContentHeight?: number): ImageBlock {
+function convertImage(
+  node: PMNode,
+  startPos: number,
+  pageContentHeight?: number,
+): ImageBlock | undefined {
   const attrs = expectImageAttrs(node);
+  if (!hasPaintableImageSource(attrs.src) && !hasRelationshipBackedImageBox(attrs)) {
+    return undefined;
+  }
   const wrapType = attrs.wrapType;
 
   // Only anchor images with 'behind' or 'inFront' wrap types
@@ -3043,10 +3053,14 @@ export function toFlowBlocks(doc: PMNode, options: ToFlowBlocksOptions = {}): Fl
         trackedPush(convertTable(node, pos, opts));
         break;
 
-      case "image":
+      case "image": {
         // Standalone image block (if not inline)
-        trackedPush(convertImage(node, pos, opts.pageContentHeight));
+        const image = convertImage(node, pos, opts.pageContentHeight);
+        if (image !== undefined) {
+          trackedPush(image);
+        }
         break;
+      }
 
       case "textBox":
         trackedPush(convertTextBoxNode(node, pos, opts));

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -994,6 +994,17 @@ function buildImageRun(
   return run;
 }
 
+/** A package image whose bytes cannot paint still owns its authored line box. */
+const hasRelationshipBackedImageBox = (attrs: ImageAttrs): boolean =>
+  typeof attrs.rId === "string" &&
+  attrs.rId.length > 0 &&
+  typeof attrs.width === "number" &&
+  Number.isFinite(attrs.width) &&
+  attrs.width >= 0 &&
+  typeof attrs.height === "number" &&
+  Number.isFinite(attrs.height) &&
+  attrs.height >= 0;
+
 /**
  * In TOC paragraphs, strip the resolved Hyperlink character-style colour and
  * underline so the painter's link fallback doesn't fire. The PM doc keeps the
@@ -1116,11 +1127,12 @@ function paragraphToRuns(node: PMNode, startPos: number, _options: FlowConversio
     }
     if (child.type.name === "image") {
       const attrs = expectImageAttrs(child);
-      if (!attrs.src) {
+      if (!attrs.src && !hasRelationshipBackedImageBox(attrs)) {
         // Unsupported DrawingML shapes can survive the parser as image nodes
-        // without a relationship target. They have no paintable payload; a
-        // 100x100 fallback box would render a broken image and incorrectly
-        // consume paragraph flow. Keep the host paragraph, but omit the run.
+        // without a relationship target or authored extent. They have no
+        // paintable payload; a 100x100 fallback box would incorrectly consume
+        // paragraph flow. Relationship-backed package images keep their real
+        // line box even when the browser cannot paint that image format.
         return;
       }
       const constrained = constrainImageToPage(

--- a/packages/core/src/layout-painter/renderParagraph-inline-image.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-inline-image.test.ts
@@ -102,6 +102,41 @@ const TEST_EXPLICIT_BLACK_COLOR = " #000000 ";
 const TEST_EXPLICIT_TEXT_COLOR = "#C00000";
 
 describe("renderLine inline image handling", () => {
+  test("hides an unpaintable image while preserving its authored line box", () => {
+    const imageRun: ImageRun = {
+      kind: "image",
+      src: "",
+      width: 200,
+      height: 159,
+      pmStart: 1,
+      pmEnd: 2,
+    };
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "paintless-picture",
+      runs: [imageRun],
+      pmStart: 0,
+      pmEnd: 3,
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 1,
+      width: 200,
+      ascent: 159,
+      descent: 0,
+      lineHeight: 159,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const imageEl = lineEl.children.at(0);
+
+    expect(imageEl?.style.visibility).toBe("hidden");
+    expect(imageEl?.style.width).toBe("200px");
+    expect(imageEl?.style.aspectRatio).toBe("200 / 159");
+  });
+
   // The plain inline image fits to its container's content width while keeping
   // the run's aspect ratio: width is pinned but `max-width: 100%` + `aspect-ratio`
   // let a wide image scale down inside a narrow column/cell instead of squashing

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -57,7 +57,7 @@ import { planCursiveJoiners, withCursiveJoiners } from "./cursiveJoiners";
 import { resolveFontFamily } from "../utils/fontResolver";
 import { DOCX_BOLD_FONT_WEIGHT } from "../utils/fontWeights";
 import { getHorizontalScaleFactor } from "../utils/horizontalScale";
-import { applySanitizedImageSrc } from "../utils/sanitizeImageSrc";
+import { sanitizeImageSrc } from "../utils/sanitizeImageSrc";
 import { sanitizeExternalUrl } from "../utils/urlSecurity";
 import {
   inlineImageBoundingBox,
@@ -95,6 +95,17 @@ export const PARAGRAPH_CLASS_NAMES = {
   tab: "layout-run-tab",
   image: "layout-run-image",
   lineBreak: "layout-run-linebreak",
+};
+
+const applyImageRunSource = (img: HTMLImageElement, src: string): void => {
+  const safeSrc = sanitizeImageSrc(src);
+  if (safeSrc === undefined) {
+    // Keep an authored image's layout box without showing the browser's broken
+    // image icon when its package format cannot be painted.
+    img.style.visibility = "hidden";
+    return;
+  }
+  img.src = safeSrc;
 };
 
 const LEFT_TO_RIGHT_DIRECTION = "ltr";
@@ -954,7 +965,7 @@ function renderInlineImageRun(run: ImageRun, doc: Document): HTMLElement {
   const img = doc.createElement("img");
   img.className = `${PARAGRAPH_CLASS_NAMES.run} ${PARAGRAPH_CLASS_NAMES.image}`;
 
-  applySanitizedImageSrc(img, run.src);
+  applyImageRunSource(img, run.src);
   img.width = run.width;
   img.height = run.height;
   img.style.width = `${run.width}px`;
@@ -1082,7 +1093,7 @@ function renderBlockImage(run: ImageRun, doc: Document): HTMLElement {
   container.style.marginBottom = `${run.distBottom ?? 6}px`;
 
   const img = doc.createElement("img");
-  applySanitizedImageSrc(img, run.src);
+  applyImageRunSource(img, run.src);
   img.width = run.width;
   img.height = run.height;
   if (run.alt) {


### PR DESCRIPTION
## Summary

- retain authored line boxes for relationship-backed package images when their payload cannot be painted
- keep source-less shape placeholders without authored geometry out of document flow
- hide unavailable image elements while preserving their dimensions, avoiding browser broken-image decoration

## Validation

- `bun test packages/core/src/layout-bridge/convert/toFlowBlocks-sdt.test.ts packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts`
- `bun test packages/core/src/layout-painter/renderParagraph-inline-image.test.ts -t "hides an unpaintable image"`
- focused oxlint and oxfmt checks on changed source and test files
- visual comparison confirms the following content retains its authored vertical position

CC on behalf of sok0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Relationship-backed images that cannot be displayed now preserve their authored layout space and dimensions.
  - Unavailable or invalid images remain hidden without showing a broken-image icon.
  - Inline and block images now maintain their intended aspect ratio and positioning when their source cannot be rendered.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->