### PR TITLE
fix(core): preserve terminal footnote paragraphs

### DIFF
--- a/.changeset/preserve-footnote-terminal-paragraph.md
+++ b/.changeset/preserve-footnote-terminal-paragraph.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve the height of authored terminal footnote paragraphs after tables.

--- a/packages/core/src/layout-bridge/convert/footnoteLayout-table.test.ts
+++ b/packages/core/src/layout-bridge/convert/footnoteLayout-table.test.ts
@@ -248,6 +248,45 @@ describe("footnote layout", () => {
     expect(content.height).toBe(36);
   });
 
+  test("preserves an authored terminal empty paragraph after a table", () => {
+    const content = convertFootnoteToContent(
+      {
+        ...footnoteWithTable,
+        content: [...footnoteWithTable.content, { type: "paragraph", content: [] }],
+      },
+      3,
+      400,
+      {
+        measureBlocks(blocks) {
+          return blocks.map((block) => {
+            if (block.kind === "table") {
+              return {
+                kind: "table",
+                rows: [],
+                columnWidths: [400],
+                totalWidth: 400,
+                totalHeight: 24,
+              };
+            }
+            return {
+              kind: "paragraph",
+              lines: [],
+              totalHeight: block.attrs?.suppressEmptyParagraphHeight ? 0 : 12,
+            };
+          });
+        },
+      },
+    );
+
+    const trailingParagraph = content.blocks.at(-1);
+    expect(trailingParagraph).toMatchObject({ kind: "paragraph", runs: [] });
+    if (trailingParagraph?.kind !== "paragraph") {
+      throw new Error("Expected a trailing paragraph");
+    }
+    expect(trailingParagraph.attrs?.suppressEmptyParagraphHeight).toBeUndefined();
+    expect(content.height).toBe(48);
+  });
+
   test("renders paragraphs nested inside footnote block SDTs", () => {
     const content = convertFootnoteToContent(footnoteWithBlockSdt, 10, 400, {
       measureBlocks(blocks) {

--- a/packages/core/src/layout-bridge/convert/footnoteLayout.ts
+++ b/packages/core/src/layout-bridge/convert/footnoteLayout.ts
@@ -359,7 +359,10 @@ export function convertFootnoteToContent(
   if (options.automaticHyphenation) {
     flowOptions.automaticHyphenation = options.automaticHyphenation;
   }
-  const blocks = applyFootnotePresentation(toFlowBlocks(pmDoc, flowOptions), displayNumber);
+  const blocks = applyFootnotePresentation(
+    preserveAuthoredFootnoteTerminalParagraph(toFlowBlocks(pmDoc, flowOptions)),
+    displayNumber,
+  );
 
   const measures = options.measureBlocks
     ? options.measureBlocks(blocks, contentWidth)
@@ -383,6 +386,23 @@ export function convertFootnoteToContent(
     measures,
     height: totalHeight,
   };
+}
+
+/** Restore an authored footnote line that the body-only terminal-table policy collapsed. */
+function preserveAuthoredFootnoteTerminalParagraph(blocks: FlowBlock[]): FlowBlock[] {
+  const finalBlock = blocks.at(-1);
+  const precedingBlock = blocks.at(-2);
+  if (
+    precedingBlock?.kind !== "table" ||
+    finalBlock?.kind !== "paragraph" ||
+    finalBlock.attrs?.suppressEmptyParagraphHeight !== true
+  ) {
+    return blocks;
+  }
+
+  const attrs = { ...finalBlock.attrs };
+  delete attrs.suppressEmptyParagraphHeight;
+  return [...blocks.slice(0, -1), { ...finalBlock, attrs }];
 }
 
 function measureFootnoteBlocks(blocks: FlowBlock[], contentWidth: number): Measure[] {


### PR DESCRIPTION
## Summary

- preserve an authored terminal paragraph after a table in footnote stories
- keep the body-only terminal table caret policy scoped out of footnote measurement
- reserve the restored paragraph height when positioning the footnote band

## Tests

- `bun test packages/core/src/layout-bridge/convert/footnoteLayout-table.test.ts`
- `bun audit`