### PR TITLE
fix(core): anchor text boxes to host paragraphs

### DIFF
--- a/.changeset/tidy-textboxes-anchor.md
+++ b/.changeset/tidy-textboxes-anchor.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Position floating text boxes from their exact host paragraph.

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -153,6 +153,35 @@ describe("toFlowBlocks paragraph formatting", () => {
     ]);
   });
 
+  test("retains the exact host paragraph for an extracted text box", () => {
+    const anchorId = "paragraph:0";
+    const blocks = toFlowBlocks(
+      schema.node("doc", null, [
+        schema.node("paragraph", null, [
+          schema.text("Before"),
+          schema.node("textBoxAnchor", { anchorId }),
+          schema.text("After"),
+        ]),
+        schema.node(
+          "textBox",
+          {
+            width: 100,
+            _docxPlacement: "inlineWithPrevious",
+            _docxAnchorId: anchorId,
+          },
+          [schema.node("paragraph")],
+        ),
+      ]),
+    );
+    const paragraph = blocks.at(0);
+    const textBox = blocks.at(1);
+    if (paragraph?.kind !== "paragraph" || textBox?.kind !== "textBox") {
+      throw new Error("Expected an owned text box after its host paragraph");
+    }
+
+    expect(Reflect.get(textBox, Symbol.for("stll.textBoxAnchorBlockId"))).toBe(paragraph.id);
+  });
+
   test("retains paragraph suppression and stamps the document hyphenation policy", () => {
     const paragraph = toFlowBlocks(
       schema.node("doc", null, [

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -72,6 +72,7 @@ import {
 import { autospacingMatchesBase } from "../../prosemirror/autospacingBase";
 import { runShadingAttrsToShading } from "../../prosemirror/conversion/runShadingMark";
 import { directionToBidi } from "../../prosemirror/paragraphDirection";
+import { expectTextBoxAnchorAttrs } from "../../prosemirror/textBoxAnchorAttrs";
 import { cascadeStyleTextFormatting } from "../../prosemirror/styles/styleToggleCascade";
 import { getPageNumbering } from "../../paged-layout/sectionGeometry";
 import type { RunFormattingOverrideAttrs } from "../../prosemirror/schema/marks";
@@ -165,9 +166,11 @@ export type ToFlowBlocksOptions = {
 type FlowConversionOptions = ToFlowBlocksOptions & {
   listCounterStreams: ListCounterStreams;
   numberedRefResults?: ReadonlyMap<PMNode, string>;
+  textBoxAnchorBlockIds: Map<string, ParagraphBlock["id"]>;
 };
 
 const DEFAULT_FONT = "Calibri";
+const TEXT_BOX_ANCHOR_BLOCK_ID = Symbol.for("stll.textBoxAnchorBlockId");
 const DEFAULT_TABLE_CELL_MARGIN_TWIPS = {
   top: 0,
   right: 108,
@@ -1961,6 +1964,13 @@ function convertParagraph(
       ...(frame.wrap !== undefined ? { wrap: frame.wrap } : {}),
     });
   }
+  node.descendants((child) => {
+    if (child.type.name !== "textBoxAnchor") {
+      return true;
+    }
+    options.textBoxAnchorBlockIds.set(expectTextBoxAnchorAttrs(child).anchorId, block.id);
+    return false;
+  });
   return block;
 }
 
@@ -2644,6 +2654,12 @@ function convertTextBoxNode(
   if (attrs._docxGroupId !== undefined) {
     setTextBoxGroupId(textBox, attrs._docxGroupId);
   }
+  const anchorBlockId = attrs._docxAnchorId
+    ? opts.textBoxAnchorBlockIds.get(attrs._docxAnchorId)
+    : undefined;
+  if (anchorBlockId !== undefined) {
+    Reflect.set(textBox, TEXT_BOX_ANCHOR_BLOCK_ID, anchorBlockId);
+  }
   return textBox;
 }
 
@@ -2699,6 +2715,7 @@ export function toFlowBlocks(doc: PMNode, options: ToFlowBlocksOptions = {}): Fl
       final: listCounterState,
       original: originalListCounterState,
     },
+    textBoxAnchorBlockIds: new Map(),
     numberedRefResults: resolveNumberedRefFields(doc, {
       listCounterState: cloneListCounterState(listCounterState),
       originalListCounterState: cloneListCounterState(originalListCounterState),

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -1596,6 +1596,11 @@ type LayoutTextBoxOptions = {
   sectionMarginBottom: number;
 };
 
+const TEXT_BOX_ANCHOR_BLOCK_ID = Symbol.for("stll.textBoxAnchorBlockId");
+
+const readTextBoxAnchorBlockId = (block: TextBoxBlock): unknown =>
+  Reflect.get(block, TEXT_BOX_ANCHOR_BLOCK_ID);
+
 /**
  * Layout a text box block onto pages.
  */
@@ -1667,6 +1672,13 @@ function layoutTextBox(
         })
       : paginator.getColumnX(state.columnIndex);
     const vertical = block.position.vertical;
+    const anchorBlockId = readTextBoxAnchorBlockId(block);
+    const anchorParagraph =
+      vertical?.relativeTo === "paragraph" && typeof anchorBlockId === "string"
+        ? state.page.fragments.find(
+            (fragment) => fragment.kind === "paragraph" && fragment.blockId === anchorBlockId,
+          )
+        : undefined;
     const y = isPageFrameRelativeAnchor(vertical?.relativeTo)
       ? state.topMargin +
         bandTopContentY(vertical, {
@@ -1675,7 +1687,7 @@ function layoutTextBox(
           marginBottom: sectionMarginBottom,
           boxHeight: measure.height,
         })
-      : state.cursorY + emuToPixels(vertical?.posOffset ?? 0);
+      : (anchorParagraph?.y ?? state.cursorY) + emuToPixels(vertical?.posOffset ?? 0);
     const fragment: TextBoxFragment = {
       kind: "textBox",
       blockId: block.id,

--- a/packages/core/src/layout-engine/textbox-band.test.ts
+++ b/packages/core/src/layout-engine/textbox-band.test.ts
@@ -201,6 +201,27 @@ describe("topAndBottom band text box layout", () => {
     expect(paragraph?.y).toBe(MARGINS.top);
   });
 
+  test("paragraph-owned text box positions from its host paragraph", () => {
+    const host = para("host");
+    const anchored = verticalBanner({ relativeTo: "paragraph", posOffset: EMU_PER_INCH });
+    Reflect.set(anchored, Symbol.for("stll.textBoxAnchorBlockId"), host.id);
+    const frags = textBoxFragments([host, anchored], [paraMeasure, boxMeasure]);
+    const box = frags.find((fragment) => fragment.kind === "textBox");
+    const paragraph = frags.find((fragment) => fragment.kind === "paragraph");
+
+    expect(box?.y).toBe((paragraph?.y ?? 0) + 96);
+  });
+
+  test("does not reuse paragraph ownership for a line-relative text box", () => {
+    const host = para("host");
+    const anchored = verticalBanner({ relativeTo: "line", posOffset: EMU_PER_INCH });
+    Reflect.set(anchored, Symbol.for("stll.textBoxAnchorBlockId"), host.id);
+    const frags = textBoxFragments([host, anchored], [paraMeasure, boxMeasure]);
+    const box = frags.find((fragment) => fragment.kind === "textBox");
+
+    expect(box?.y).toBe(MARGINS.top + paraMeasure.totalHeight + 96);
+  });
+
   test("band uses the section top margin, not a page's first-page margin", () => {
     // On a title page the first-page top margin can differ from the section
     // margin. The measure pass reserves the band using the section margin, so

--- a/packages/core/src/layout-painter/renderPage.test.ts
+++ b/packages/core/src/layout-painter/renderPage.test.ts
@@ -724,6 +724,90 @@ describe("header and footer rendering", () => {
     expect(textBox?.dataset["hfRid"]).toBe("rIdFooter");
   });
 
+  test("positions a paragraph-owned header text box from its host paragraph", () => {
+    const emusPerPixel = 9_525;
+    const hostBlock: ParagraphBlock = {
+      kind: "paragraph",
+      id: "text-box-host",
+      runs: [{ kind: "text", text: "Host" }],
+    };
+    const textBoxBlock: TextBoxBlock = {
+      kind: "textBox",
+      id: "owned-header-box",
+      width: 80,
+      height: 20,
+      content: [],
+      wrapType: "inFront",
+      position: {
+        vertical: {
+          relativeTo: "paragraph",
+          posOffset: 8 * emusPerPixel,
+        },
+      },
+    };
+    Reflect.set(textBoxBlock, Symbol.for("stll.textBoxAnchorBlockId"), hostBlock.id);
+
+    const pageElement = renderPage(
+      { ...page, fragments: [] },
+      { pageNumber: 1, totalPages: 1, section: "body" },
+      {
+        document: fakeDocument,
+        headerContent: {
+          blocks: [hostBlock, textBoxBlock],
+          measures: [
+            { kind: "paragraph", lines: [], totalHeight: 12 },
+            textBoxMeasure(textBoxBlock.width, textBoxBlock.height),
+          ],
+          height: 12,
+        },
+      },
+    ) as unknown as FakeElement;
+
+    expect(findByClass(pageElement, "layout-textbox")?.style.top).toBe("8px");
+  });
+
+  test("keeps line-relative header text boxes anchored to the current flow cursor", () => {
+    const emusPerPixel = 9_525;
+    const hostBlock: ParagraphBlock = {
+      kind: "paragraph",
+      id: "line-anchor-host",
+      runs: [{ kind: "text", text: "Host" }],
+    };
+    const textBoxBlock: TextBoxBlock = {
+      kind: "textBox",
+      id: "line-relative-header-box",
+      width: 80,
+      height: 20,
+      content: [],
+      wrapType: "inFront",
+      position: {
+        vertical: {
+          relativeTo: "line",
+          posOffset: 8 * emusPerPixel,
+        },
+      },
+    };
+    Reflect.set(textBoxBlock, Symbol.for("stll.textBoxAnchorBlockId"), hostBlock.id);
+
+    const pageElement = renderPage(
+      { ...page, fragments: [] },
+      { pageNumber: 1, totalPages: 1, section: "body" },
+      {
+        document: fakeDocument,
+        headerContent: {
+          blocks: [hostBlock, textBoxBlock],
+          measures: [
+            { kind: "paragraph", lines: [], totalHeight: 12 },
+            textBoxMeasure(textBoxBlock.width, textBoxBlock.height),
+          ],
+          height: 12,
+        },
+      },
+    ) as unknown as FakeElement;
+
+    expect(findByClass(pageElement, "layout-textbox")?.style.top).toBe("20px");
+  });
+
   test("interactive header/footer box tracks the flow band, not a floating shape's extent (#869)", () => {
     const para = (id: string): ParagraphBlock => ({
       kind: "paragraph",

--- a/packages/core/src/layout-painter/renderPage.ts
+++ b/packages/core/src/layout-painter/renderPage.ts
@@ -70,6 +70,8 @@ import { emuToPixels, isFloatingImageRun, isTextWrappingFloatingImageRun } from 
 import type { RenderContext } from "./renderUtils";
 import { renderWatermarkLayer } from "./renderWatermark";
 
+const TEXT_BOX_ANCHOR_BLOCK_ID = Symbol.for("stll.textBoxAnchorBlockId");
+
 /**
  * Page-level floating image that has been extracted from paragraphs.
  * These are positioned absolutely within the page's content area.
@@ -1065,6 +1067,7 @@ function renderHeaderFooterContent(
   // RenderContext) know the HF caller is supplying its own top/left, rather
   // than the body case where the layout engine assigns fragment coordinates.
   const hfContext: RenderContext = { ...context, positioning: "absolute" };
+  const paragraphStartYByBlockId = new Map<ParagraphBlock["id"], number>();
 
   for (let i = 0; i < content.blocks.length; i++) {
     const block = content.blocks[i];
@@ -1079,6 +1082,7 @@ function renderHeaderFooterContent(
 
       // Track the Y position where this paragraph starts
       const paragraphStartY = cursorY;
+      paragraphStartYByBlockId.set(paragraphBlock.id, paragraphStartY);
 
       // Extract floating images and filter them from runs. Match the
       // body's classification (`isFloatingImageRun`) so images that are
@@ -1236,11 +1240,16 @@ function renderHeaderFooterContent(
         document: doc,
         renderTable: renderNestedTable,
       });
+      const anchorBlockId = Reflect.get(block, TEXT_BOX_ANCHOR_BLOCK_ID);
+      const paragraphY =
+        block.position?.vertical?.relativeTo === "paragraph" && typeof anchorBlockId === "string"
+          ? (paragraphStartYByBlockId.get(anchorBlockId) ?? cursorY)
+          : cursorY;
       const textBoxTop = block.position
         ? resolveHeaderFooterFloatTop(
             {
               height: measure.height,
-              paragraphY: cursorY,
+              paragraphY,
               position: block.position,
             },
             layout,


### PR DESCRIPTION
## Summary

- preserve the owning paragraph when extracted text boxes enter layout
- resolve paragraph-relative vertical placement from that paragraph
- keep line- and page-relative placement behavior unchanged

## Validation

- focused flow-conversion and text-box layout tests
- dependency audit