### PR TITLE
fix(core): resize shape-fitted text boxes to content

### DIFF
--- a/.changeset/clean-shapes-fit.md
+++ b/.changeset/clean-shapes-fit.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Resize shape-fitted text boxes to their measured content height.

--- a/packages/core/src/layout-engine/measure/measureBlocks.test.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.test.ts
@@ -113,7 +113,7 @@ describe("text box fitting", () => {
     }, fakeMeasure);
   });
 
-  test("shape fitting expands past the authored height without shrinking a larger box", () => {
+  test("shape fitting resizes the authored height to its content", () => {
     withFakeTextMeasure(() => {
       const fixed: TextBoxBlock = {
         kind: "textBox",
@@ -143,7 +143,7 @@ describe("text box fitting", () => {
 
       expect(fittedMeasure.height).toBeGreaterThan(fixedMeasure.height);
       expect(fixedMeasure.height).toBe(1);
-      expect(largeMeasure.height).toBe(1_000);
+      expect(largeMeasure.height).toBe(fittedMeasure.height);
     }, fakeMeasure);
   });
 

--- a/packages/core/src/layout-engine/measure/measureBlocks.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.ts
@@ -1081,10 +1081,7 @@ export function measureTextBoxBlock(
     tb.autoFit === "shape" && tb.textWrap === "none" ? Math.max(tb.width, fittedWidth) : tb.width;
   const contentHeight = layoutTextBoxContent(tb.content, innerMeasures).totalHeight;
   const contentBoxHeight = contentHeight + margins.top + margins.bottom;
-  const totalHeight =
-    tb.autoFit === "shape"
-      ? Math.max(tb.height ?? 0, contentBoxHeight)
-      : (tb.height ?? contentBoxHeight);
+  const totalHeight = tb.autoFit === "shape" ? contentBoxHeight : (tb.height ?? contentBoxHeight);
   return {
     kind: "textBox",
     width: totalWidth,


### PR DESCRIPTION
## Summary

- size shape-fitted text boxes from measured content height
- allow fitting to shrink as well as expand an authored shape extent
- preserve authored height for fixed and normal fitting modes

## Validation

- focused text-box fitting tests
- dependency audit