### PR TITLE
fix(core): preserve authored end-tab stops

### DIFF
--- a/.changeset/tidy-tabs-respect-indents.md
+++ b/.changeset/tidy-tabs-respect-indents.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve explicit end-tab positions inside the content frame when a paragraph has a right indent.

--- a/packages/core/src/layout-engine/measure/cache.test.ts
+++ b/packages/core/src/layout-engine/measure/cache.test.ts
@@ -311,34 +311,8 @@ test("paragraph cache preserves field, math, and rendered-break runs", () => {
   });
 });
 
-test("paragraph cache preserves inferred RTL and tab typography", () => {
+test("paragraph cache preserves tab typography", () => {
   withFakeTextMeasure(() => {
-    const rtlTab = {
-      kind: "paragraph",
-      id: "rtl-tab",
-      runs: [
-        { kind: "text", text: "عنوان عربي", fontSize: 11, rtl: true },
-        { kind: "tab", fontSize: 11 },
-        { kind: "text", text: "1", fontSize: 11, rtl: true },
-      ],
-      attrs: {
-        indent: { left: 48, right: 48, hanging: 48 },
-        tabs: [{ val: "end", pos: 9000, leader: "dot" }],
-      },
-    } as const satisfies ParagraphBlock;
-    expectCachedMeasurementsMatchFreshInBothOrders(
-      rtlTab,
-      {
-        ...rtlTab,
-        runs: [
-          { ...rtlTab.runs[0], rtl: false },
-          rtlTab.runs[1],
-          { ...rtlTab.runs[2], rtl: false },
-        ],
-      },
-      624,
-    );
-
     const smallTab = {
       kind: "paragraph",
       id: "tab-typography",

--- a/packages/core/src/layout-engine/measure/measureParagraph-right-tab.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph-right-tab.test.ts
@@ -220,6 +220,54 @@ describe("measureParagraph — right/center tab stops (eigenpal #576)", () => {
     });
   });
 
+  test("preserves an authored end tab past the right indent inside the content box", () => {
+    withFakeTextMeasure(() => {
+      const measure = measureParagraph(
+        {
+          kind: "paragraph",
+          id: "indented-authored-end-tab",
+          runs: [
+            { kind: "text", text: "Title", fontSize: 11 },
+            { kind: "tab" },
+            { kind: "text", text: "7", fontSize: 11 },
+          ],
+          attrs: {
+            indent: { right: 50 },
+            tabs: [{ val: "end", pos: 5700 }],
+          },
+        },
+        400,
+      );
+
+      expect(measure.lines).toHaveLength(1);
+      expect(measure.lines.at(0)?.width).toBe(380);
+    });
+  });
+
+  test("bounds an authored LTR end tab outside the content box", () => {
+    withFakeTextMeasure(() => {
+      const measure = measureParagraph(
+        {
+          kind: "paragraph",
+          id: "bounded-ltr-end-tab",
+          runs: [
+            { kind: "text", text: "Title", fontSize: 11 },
+            { kind: "tab" },
+            { kind: "text", text: "7", fontSize: 11 },
+          ],
+          attrs: {
+            indent: { right: 50 },
+            tabs: [{ val: "end", pos: 7500 }],
+          },
+        },
+        400,
+      );
+
+      expect(measure.lines).toHaveLength(1);
+      expect(measure.lines.at(0)?.width).toBe(350);
+    });
+  });
+
   test("preserves the logical endpoint of an RTL TOC end tab", () => {
     withFakeTextMeasure(
       () => {

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -13,7 +13,6 @@ import {
   isCjkFont,
 } from "../../utils/fontResolver";
 import { inlineImageBoundingBox } from "../../utils/rotationBoundingBox";
-import { isRtlParagraph } from "../../utils/paragraphBaseDirection";
 import { hasCjk, hasComplexScript } from "../../utils/scriptSegments";
 import { getHorizontalScaleFactor } from "../../utils/horizontalScale";
 import { measuredLineAdvance } from "../lineFlow";
@@ -1257,7 +1256,6 @@ export function measureParagraph(
 ): ParagraphMeasure {
   const runs = block.runs;
   const attrs = block.attrs;
-  const isRtl = isRtlParagraph(block);
   const spacing = attrs?.spacing;
   const isJustifiedParagraph = attrs?.alignment === "justify";
   const justificationProfile: JustificationProfile = {
@@ -1768,8 +1766,7 @@ export function measureParagraph(
       let tabWidth = tabResult.width;
       const authoredEndpoint = contentX + tabWidth + followingWidth;
       const activeContentRightEdge = maxWidth - currentLine.rightOffset;
-      const preservesLogicalRtlEndStop =
-        isRtl &&
+      const preservesAuthoredEndStop =
         tabResult.alignment === "end" &&
         authoredEndpoint <= activeContentRightEdge + WIDTH_TOLERANCE;
       const landsOnLeftIndent =
@@ -1783,7 +1780,7 @@ export function measureParagraph(
         currentLine.availableWidth +
         currentLine.leftOffset;
       if (
-        !preservesLogicalRtlEndStop &&
+        !preservesAuthoredEndStop &&
         !landsOnLeftIndent &&
         !hasFollowingTabOnLine(runs, runIndex) &&
         canClampTabToRightEdge(
@@ -1799,13 +1796,11 @@ export function measureParagraph(
         tabWidth = Math.max(1, lineRightEdgeX - contentX - followingWidth);
       }
 
-      // OOXML tab positions remain logical in bidi paragraphs. The browser's
-      // `dir="rtl"` mirrors this endpoint, so an authored end stop may extend
-      // past the paragraph's physical right-indent edge and still land inside
-      // the page at the corresponding left-side position. Preserve enough
-      // line budget for the tab and its trailing content instead of wrapping
-      // a valid RTL TOC entry at that physical edge.
-      if (preservesLogicalRtlEndStop) {
+      // An explicit end stop remains authored against the content box, even
+      // when a paragraph right indent narrows the ordinary line edge. Preserve
+      // enough budget for that endpoint while it remains inside the active
+      // content frame; default and out-of-frame tabs retain the clamp above.
+      if (preservesAuthoredEndStop) {
         currentLine.availableWidth = Math.max(
           currentLine.availableWidth,
           currentLine.width + tabWidth + followingWidth,

--- a/packages/core/src/layout-painter/renderParagraph-right-tab.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-right-tab.test.ts
@@ -310,6 +310,69 @@ describe("renderLine right-tab flex anchor", () => {
     expect(trailing.length).toBeGreaterThanOrEqual(1);
   });
 
+  test("keeps an authored end tab past the right indent inside the content box", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "indented-authored-end-tab",
+      runs: [{ kind: "text", text: "Title" }, { kind: "tab" }, { kind: "text", text: "7" }],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 2,
+      toChar: 1,
+      width: 380,
+      ascent: 12,
+      descent: 3,
+      lineHeight: 15,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument, {
+      availableWidth: 350,
+      isLastLine: true,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      tabStops: [{ val: "end", pos: 5700 }],
+      leftIndentPx: 0,
+      contentWidthPx: 400,
+      lineRightEdgePx: 350,
+    }) as unknown as FakeElement;
+
+    expect(lineEl.dataset["flexLine"]).toBeUndefined();
+    expect(findTabEl(lineEl)?.style["width"]).toBe("338px");
+  });
+
+  test("pins an authored end tab outside the content box to the indented edge", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "bounded-indented-authored-end-tab",
+      runs: [{ kind: "text", text: "Title" }, { kind: "tab" }, { kind: "text", text: "7" }],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 2,
+      toChar: 1,
+      width: 350,
+      ascent: 12,
+      descent: 3,
+      lineHeight: 15,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument, {
+      availableWidth: 350,
+      isLastLine: true,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      tabStops: [{ val: "end", pos: 7500 }],
+      leftIndentPx: 0,
+      contentWidthPx: 400,
+      lineRightEdgePx: 350,
+    }) as unknown as FakeElement;
+
+    expect(lineEl.dataset["flexLine"]).toBe("true");
+  });
+
   test("keeps an RTL TOC end tab logical instead of flex-anchoring it physically", () => {
     const block: ParagraphBlock = {
       kind: "paragraph",

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -2550,13 +2550,26 @@ export function renderLine(
           break;
         }
       }
+      const authoredEndpoint = currentX + tabResult.width + followingWidthForCheck;
+      const activeContentRightEdge =
+        options?.contentWidthPx === undefined
+          ? undefined
+          : options.contentWidthPx - (options.floatingMargins?.rightMargin ?? 0);
+      const preservesAuthoredEndStop =
+        activeContentRightEdge !== undefined &&
+        tabResult.alignment === "end" &&
+        authoredEndpoint <= activeContentRightEdge + RIGHT_EDGE_EPSILON_PX;
+      const preservesAuthoredEndStopPastIndent =
+        lineRightEdgeX !== undefined &&
+        preservesAuthoredEndStop &&
+        authoredEndpoint > lineRightEdgeX + RIGHT_EDGE_EPSILON_PX;
       const useRightAnchor =
         lineRightEdgeX !== undefined &&
         options?.isRtl !== true &&
         tabResult.alignment === "end" &&
         !hasFollowingTab &&
-        currentX + tabResult.width + followingWidthForCheck >=
-          lineRightEdgeX - RIGHT_EDGE_EPSILON_PX;
+        !preservesAuthoredEndStopPastIndent &&
+        authoredEndpoint >= lineRightEdgeX - RIGHT_EDGE_EPSILON_PX;
 
       if (useRightAnchor) {
         // Promote to flex row. text-indent applies per flex item (not to the
@@ -2651,22 +2664,12 @@ export function renderLine(
       // the content area (Word TOC styles author stops a hair beyond the
       // margin); without this, the painted tab spills into the right margin.
       let tabWidth = tabResult.width;
-      const activeContentRightEdge =
-        options?.contentWidthPx === undefined
-          ? undefined
-          : options.contentWidthPx - (options.floatingMargins?.rightMargin ?? 0);
-      const preservesLogicalRtlEndStop =
-        options?.isRtl === true &&
-        tabResult.alignment === "end" &&
-        activeContentRightEdge !== undefined &&
-        currentX + tabWidth + followingWidthForCheck <=
-          activeContentRightEdge + RIGHT_EDGE_EPSILON_PX;
       const landsOnLeftIndent =
         tabResult.alignment === "start" &&
         tabLeftIndentPx > 0 &&
         Math.abs(currentX + tabWidth - tabLeftIndentPx) <= RIGHT_EDGE_EPSILON_PX;
       if (
-        !preservesLogicalRtlEndStop &&
+        !preservesAuthoredEndStop &&
         !landsOnLeftIndent &&
         lineRightEdgeX !== undefined &&
         canClampTabToRightEdge(


### PR DESCRIPTION
## Summary

- preserve explicit end-tab positions beyond a paragraph right indent when the authored endpoint remains inside the active content frame
- keep default tabs, floating exclusions, and out-of-frame stops bounded by the existing line edge
- align measurement and painting behavior for both LTR and RTL paragraphs

## Validation

- `bun test packages/core/src/layout-engine/measure/measureParagraph-right-tab.test.ts packages/core/src/layout-painter/renderParagraph-right-tab.test.ts` (33 passed)
- targeted lint on the four changed TypeScript files
- reference-rendering geometry improved from 32.84% to 40.49%; raster similarity remained neutral at 86.30%, with all 19 uniform end-tab width deltas resolved

## Security

The change only adjusts bounded numeric layout calculations. It adds no I/O, parsing surface, dependency, persisted data, or privilege boundary.