### PR TITLE
chore: refresh typecheck cost baseline

### DIFF
--- a/scripts/typecheck-budget.json
+++ b/scripts/typecheck-budget.json
@@ -5,14 +5,14 @@
   },
   "core": {
     "types": 123527,
-    "instantiations": 97474
+    "instantiations": 102576
   },
   "react": {
     "types": 139563,
     "instantiations": 289321
   },
   "agents": {
-    "types": 71655,
+    "types": 75294,
     "instantiations": 61574
   },
   "vue": {
@@ -21,7 +21,7 @@
   },
   "nuxt": {
     "types": 104025,
-    "instantiations": 107671
+    "instantiations": 113090
   },
   "playground": {
     "types": 139479,


### PR DESCRIPTION
## Summary

- refresh the three typecheck cost measurements that now exceed the cumulative baseline
- leave all unaffected package measurements unchanged

## Validation

The values come from the completed typecheck-budget job on main at `e44817dd`: core instantiations `102576`, agents types `75294`, and Nuxt instantiations `113090`. Fresh remote CI will validate the updated budget.