### PR TITLE
fix(core): report only referenced numbering changes

### DIFF
--- a/.changeset/numbering-reference-census.md
+++ b/.changeset/numbering-reference-census.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Report numbering changes only for levels referenced by a paragraph in either document.

--- a/packages/core/src/ai-edits/snapshot.ts
+++ b/packages/core/src/ai-edits/snapshot.ts
@@ -1,3 +1,4 @@
+import { panic } from "better-result";
 import type { Mark, Node as PMNode } from "prosemirror-model";
 import { TableMap } from "prosemirror-tables";
 
@@ -14,6 +15,13 @@ import type {
   FolioAIInlineFormatting,
   FolioAITextRangeHandle,
 } from "./types";
+
+const numberingReferenceKeysBySnapshot = new WeakMap<FolioAIEditSnapshot, readonly string[]>();
+
+/** @internal Numbering references collected during the snapshot's document walk. */
+export const numberingReferenceKeysOf = (snapshot: FolioAIEditSnapshot): readonly string[] =>
+  numberingReferenceKeysBySnapshot.get(snapshot) ??
+  panic("A numbering census was requested for a snapshot that did not record one");
 
 export const normalizeFolioAIBlockText = (text: string): string =>
   text.replace(/\s+/gu, " ").trim();
@@ -229,6 +237,7 @@ export const createFolioAIEditSnapshot = (doc: PMNode): FolioAIEditSnapshot => {
   }[] = [];
   const hashCounts = new Map<string, number>();
   const usedBlockIds = new Set<string>();
+  const numberingReferenceKeys = new Set<string>();
   const tableIndexByStart = new Map(
     folioStoryTables(doc).map(({ start, index }) => [start, index] as const),
   );
@@ -297,6 +306,10 @@ export const createFolioAIEditSnapshot = (doc: PMNode): FolioAIEditSnapshot => {
     const displayLabel = getDisplayLabel(node);
     const styleId = getStyleId(node);
     const listLevel = getListLevel(node);
+    const numberingReferenceKey = getNumberingReferenceKey(node);
+    if (numberingReferenceKey) {
+      numberingReferenceKeys.add(numberingReferenceKey);
+    }
     const previewRuns = getPreviewRuns(node);
     const table = getTableLocation({ path, blockIndex: index, tableIndexByStart });
 
@@ -334,7 +347,9 @@ export const createFolioAIEditSnapshot = (doc: PMNode): FolioAIEditSnapshot => {
     };
   }
 
-  return { blocks, anchors };
+  const snapshot = { blocks, anchors };
+  numberingReferenceKeysBySnapshot.set(snapshot, [...numberingReferenceKeys]);
+  return snapshot;
 };
 
 const getBlockKind = (node: PMNode, headingLevel: number | undefined): FolioAIBlockKind => {
@@ -395,6 +410,22 @@ const getListLevel = (node: PMNode): number | undefined => {
   }
   const { ilvl } = numPr;
   return typeof ilvl === "number" && Number.isInteger(ilvl) && ilvl >= 0 ? ilvl : undefined;
+};
+
+const getNumberingReferenceKey = (node: PMNode): string | null => {
+  const numPr: unknown = node.attrs["numPr"];
+  if (typeof numPr !== "object" || numPr === null || !("numId" in numPr)) {
+    return null;
+  }
+  const { numId } = numPr;
+  if (typeof numId !== "number" || !Number.isInteger(numId) || numId <= 0) {
+    return null;
+  }
+  const level = "ilvl" in numPr ? numPr.ilvl : undefined;
+  if (level !== undefined && (typeof level !== "number" || !Number.isInteger(level) || level < 0)) {
+    return null;
+  }
+  return `${String(numId)}:${String(level ?? 0)}`;
 };
 
 const getStyleId = (node: PMNode): string | undefined => {

--- a/packages/core/src/compare/README.md
+++ b/packages/core/src/compare/README.md
@@ -198,9 +198,10 @@ unrelated removal and addition.
 Renumbering that FOLLOWS from an edit needs no change of its own: labels are
 rendered from the numbering definitions rather than stored on the paragraphs,
 so inserting a list item already renumbers the ones below it as-if-accepted,
-and reporting them would bury the real edit. A definition that itself changed
-is the opposite case — every label in the list moves and no block's text does
-— and is reported as `numbering`.
+and reporting them would bury the real edit. A referenced definition that
+itself changed is the opposite case: every label using that level moves and no
+block's text does, so it is reported as `numbering`. Differences in levels no
+paragraph references on either side are omitted from the change list.
 
 A paragraph property that moved without any word moving — a list item demoted
 a level, a paragraph restyled — is a `paragraph-format` change, written as
@@ -369,8 +370,10 @@ carries the current numbers and the failing cases.
 - **A numbering definition is reported, not represented** (2026-09-06). A list
   whose format, level template or start changed is a `numbering` change, and
   the redline cannot carry it: OOXML has no tracked-change grammar for
-  `numbering.xml` at all. Accepting the result
-  therefore reproduces the target's words and keeps the base's numbering.
+  `numbering.xml` at all. Only levels referenced by a paragraph in either
+  document are reported; unused definitions are package bookkeeping, not
+  document changes. Accepting the result therefore reproduces the target's
+  words and keeps the base's numbering.
 
 ## Files
 

--- a/packages/core/src/compare/compare.ts
+++ b/packages/core/src/compare/compare.ts
@@ -45,6 +45,7 @@ import {
 } from "../ai-edits/headless";
 import { projectTableGeometry } from "../ai-edits/table-geometry";
 import type { FolioTableTemplates } from "../ai-edits/table-template";
+import { numberingReferenceKeysOf } from "../ai-edits/snapshot";
 import type { FolioAIBlock, FolioAIEditSkipReason, FolioAIEditSnapshot } from "../ai-edits/types";
 import type { WordDiffGranularity } from "../ai-edits/word-diff";
 import { FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION } from "../document-operations";
@@ -194,15 +195,15 @@ const formattingRoundTripFailure = ({
   return null;
 };
 
-const numberingKey = ({ numId, level }: FolioNumberingLevel): string =>
+const numberingKey = ({ numId, level }: Pick<FolioNumberingLevel, "numId" | "level">): string =>
   `${String(numId)}:${String(level)}`;
 
 const sameNumbering = (left: FolioNumberingLevel, right: FolioNumberingLevel): boolean =>
   left.format === right.format && left.levelText === right.levelText && left.start === right.start;
 
 /**
- * Numbering levels that differ between the two packages, in `numId` then
- * level order.
+ * Referenced numbering levels that differ between the two packages, in
+ * `numId` then level order.
  *
  * A list renumbered BY an edit needs no entry: labels come from these
  * definitions rather than from the paragraphs, so inserting an item already
@@ -216,6 +217,7 @@ type NumberingChange = Extract<CompareChange, { kind: "numbering" }>;
 const compareNumbering = (
   base: FolioDocxReviewer,
   target: FolioDocxReviewer,
+  referenced: ReadonlySet<string>,
 ): NumberingChange[] => {
   const baseLevels = new Map(
     base.readNumberingDefinitions().map((level) => [numberingKey(level), level]),
@@ -225,13 +227,16 @@ const compareNumbering = (
   );
   const changes: NumberingChange[] = [];
   for (const [key, before] of baseLevels) {
+    if (!referenced.has(key)) {
+      continue;
+    }
     const after = targetLevels.get(key) ?? null;
     if (after === null || !sameNumbering(before, after)) {
       changes.push({ kind: "numbering", numId: before.numId, level: before.level, before, after });
     }
   }
   for (const [key, after] of targetLevels) {
-    if (!baseLevels.has(key)) {
+    if (referenced.has(key) && !baseLevels.has(key)) {
       changes.push({
         kind: "numbering",
         numId: after.numId,
@@ -322,21 +327,37 @@ export const parseComparison = async (
   }
   const pairs: ComparedStoryPair[] = [];
   const unsupported: CompareUnsupportedPart[] = [];
+  const referencedNumberingLevels = new Set<string>();
+  const collectNumberingReferences = (snapshot: FolioAIEditSnapshot | null): void => {
+    if (!snapshot) {
+      return;
+    }
+    for (const referenceKey of numberingReferenceKeysOf(snapshot)) {
+      referencedNumberingLevels.add(referenceKey);
+    }
+  };
 
   for (const { baseStory, revisedStory: targetStory } of pairFolioDocumentStories(
     reviewer.listStories().map(({ handle }) => handle),
     targetReviewer.listStories().map(({ handle }) => handle),
   )) {
     if (!baseStory) {
+      if (!targetStory) {
+        panic("A story pair contained neither a base nor a target story");
+      }
+      collectNumberingReferences(targetReviewer.snapshotStory(targetStory));
       unsupported.push({ reason: "story-missing-in-base", baseStory: null, targetStory });
       continue;
     }
     if (!targetStory) {
+      collectNumberingReferences(reviewer.snapshotStory(baseStory));
       unsupported.push({ reason: "story-missing-in-target", baseStory, targetStory: null });
       continue;
     }
     const baseSnapshot = reviewer.snapshotStory(baseStory);
     const targetSnapshot = targetReviewer.snapshotStory(targetStory);
+    collectNumberingReferences(baseSnapshot);
+    collectNumberingReferences(targetSnapshot);
     if (!baseSnapshot || !targetSnapshot) {
       unsupported.push({ reason: "story-not-editable", baseStory, targetStory });
       continue;
@@ -353,7 +374,7 @@ export const parseComparison = async (
     revisionStamp: { date: options.timestamp, idSeed: existing.idSeed },
     packageDate,
     pairs,
-    numberingChanges: compareNumbering(reviewer, targetReviewer),
+    numberingChanges: compareNumbering(reviewer, targetReviewer, referencedNumberingLevels),
     unsupported,
   });
 };

--- a/packages/core/src/compare/probes.test.ts
+++ b/packages/core/src/compare/probes.test.ts
@@ -82,6 +82,35 @@ const buildColumnTableDocx = (rows: readonly (readonly ColumnCell[])[]): Promise
 const partOf = async (buffer: ArrayBuffer, name: string): Promise<string> =>
   (await (await JSZip.loadAsync(buffer)).file(name)?.async("string")) ?? "";
 
+type NumberingFormatOverride = { level: number; format: string };
+
+const withNumberingFormats = async (
+  buffer: ArrayBuffer,
+  overrides: readonly NumberingFormatOverride[],
+): Promise<ArrayBuffer> => {
+  const zip = await JSZip.loadAsync(buffer);
+  const entry = zip.file("word/numbering.xml");
+  if (!entry) {
+    throw new Error("The numbered-list fixture has no numbering part.");
+  }
+  let xml = await entry.async("string");
+  for (const { level, format } of overrides) {
+    const levelFormat = new RegExp(
+      `(<w:lvl w:ilvl="${String(level)}">[\\s\\S]*?<w:numFmt w:val=")[^"]+("/>)`,
+      "u",
+    );
+    const replaced = xml.replace(levelFormat, (_match, before: string, after: string) =>
+      [before, format, after].join(""),
+    );
+    if (replaced === xml) {
+      throw new Error(`The numbered-list fixture has no level ${String(level)} format.`);
+    }
+    xml = replaced;
+  }
+  zip.file("word/numbering.xml", xml);
+  return await zip.generateAsync({ type: "arraybuffer" });
+};
+
 const documentPartOf = async (buffer: ArrayBuffer): Promise<string> =>
   await partOf(buffer, "word/document.xml");
 
@@ -617,6 +646,48 @@ describe("single-mutation probes", () => {
     const [change] = result.value.changes;
     expect(change?.kind === "numbering" && change.before?.format).toBe("decimal");
     expect(change?.kind === "numbering" && change.after?.format).toBe("lowerRoman");
+  });
+
+  test("numbering definitions: only changed levels referenced by either document are reported", async () => {
+    const changed = await withNumberingFormats(LIST_BASE, [
+      { level: 0, format: "upperRoman" },
+      { level: 1, format: "upperLetter" },
+      { level: 2, format: "ordinal" },
+    ]);
+    const result = await compareDocx(LIST_BASE, changed, OPTIONS);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    const numberingChanges = result.value.changes.filter(({ kind }) => kind === "numbering");
+    expect(numberingChanges.map(({ level }) => level)).toEqual([0, 1]);
+  });
+
+  test("numbering definitions: a changed level newly referenced by the target is reported", async () => {
+    const items = withItemDemoted(NUMBERED_LIST_ITEMS, 1);
+    const changed = await withNumberingFormats(await buildNumberedListDocx(items), [
+      { level: 2, format: "upperRoman" },
+    ]);
+    const result = await compareDocx(LIST_BASE, changed, OPTIONS);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    const numberingChanges = result.value.changes.filter(({ kind }) => kind === "numbering");
+    expect(numberingChanges.map(({ level }) => level)).toEqual([2]);
+  });
+
+  test("numbering definitions: a changed level referenced only by the base is reported", async () => {
+    const baseItems = withItemDemoted(NUMBERED_LIST_ITEMS, 1);
+    const base = await buildNumberedListDocx(baseItems);
+    const changed = await withNumberingFormats(LIST_BASE, [{ level: 2, format: "upperRoman" }]);
+    const result = await compareDocx(base, changed, OPTIONS);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    const numberingChanges = result.value.changes.filter(({ kind }) => kind === "numbering");
+    expect(numberingChanges.map(({ level }) => level)).toEqual([2]);
   });
 
   test("change_list_level: a demoted list item is one paragraph-format change", async () => {


### PR DESCRIPTION
## Summary

- collect the numbering levels referenced across every parsed story
- omit definition-only deltas for levels unused by either document
- retain changes referenced only by the base or only by the target

## Validation

- focused generated-DOCX probes for shared, base-only, target-only, and unused levels
- mutation check: removing the reference gate made the unused changed level reappear
- core build, API extraction and budget check, focused lint and format checks
- deterministic repeated comparisons over a representative sample