### PR TITLE
fix(core): preserve watermark host conversion edges

### DIFF
--- a/.changeset/tidy-watermark-hosts.md
+++ b/.changeset/tidy-watermark-hosts.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve watermark host clearance across incremental and text box layout paths.

--- a/packages/core/src/layout-bridge/convert/headerFooterLayout.test.ts
+++ b/packages/core/src/layout-bridge/convert/headerFooterLayout.test.ts
@@ -1082,6 +1082,45 @@ describe("convertHeaderFooterPmDocToContent", () => {
     expect(fromContent?.marginPushBottom).toBe(12);
     expect(fromPmDoc?.marginPushBottom).toBe(12);
     expect(bare?.marginPushBottom).toBe(0);
+    expect(fromPmDoc?.textSig).not.toBe(bare?.textSig);
+  });
+
+  test("keeps detached watermark host clearance after a terminal table", () => {
+    const result = convertHeaderFooterToContent(
+      {
+        type: "header",
+        hdrFtrType: "default",
+        content: [
+          {
+            type: "table",
+            rows: [
+              {
+                type: "tableRow",
+                cells: [
+                  {
+                    type: "tableCell",
+                    content: [{ type: "paragraph", content: [] }],
+                  },
+                ],
+              },
+            ],
+          },
+          { type: "paragraph", content: [] },
+        ],
+        watermark: { kind: "text", text: "DRAFT" },
+        watermarkBlockIndex: 1,
+      },
+      456,
+      pmMetrics,
+      { measureBlocks },
+    );
+    const host = result?.blocks.at(-1);
+
+    expect(host?.kind).toBe("paragraph");
+    if (host?.kind !== "paragraph") {
+      return;
+    }
+    expect(host.attrs?.suppressEmptyParagraphHeight).toBe(false);
   });
 
   test("marks the indexed watermark host when another paragraph precedes it", () => {
@@ -1097,6 +1136,42 @@ describe("convertHeaderFooterPmDocToContent", () => {
 
     expect(pmDoc.child(0).attrs["_detachedWatermarkHost"]).toBeNull();
     expect(pmDoc.child(1).attrs["_detachedWatermarkHost"]).toBe(true);
+  });
+
+  test("retains a detached watermark host that only contains a text box", () => {
+    const pmDoc = headerFooterToProseDocWithDetachedWatermarkHost({
+      type: "header",
+      hdrFtrType: "default",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "run",
+              content: [
+                {
+                  type: "shape",
+                  shape: {
+                    type: "shape",
+                    shapeType: "textBox",
+                    size: { width: 914_400, height: 457_200 },
+                    textBody: {
+                      content: [{ type: "paragraph", content: [] }],
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      watermarkBlockIndex: 0,
+    });
+
+    expect(pmDoc.childCount).toBe(2);
+    expect(pmDoc.child(0).type.name).toBe("paragraph");
+    expect(pmDoc.child(0).attrs["_detachedWatermarkHost"]).toBe(true);
+    expect(pmDoc.child(1).type.name).toBe("textBox");
   });
 
   test("rejects malformed detached watermark host metadata with its attr path", () => {

--- a/packages/core/src/layout-bridge/convert/headerFooterLayout.ts
+++ b/packages/core/src/layout-bridge/convert/headerFooterLayout.ts
@@ -1022,6 +1022,7 @@ function serializeParagraphAttrs(attrs: Record<string, unknown> | undefined): st
   const keys = [
     "alignment",
     "bidi",
+    "suppressEmptyParagraphHeight",
     "indent",
     "spacing",
     "styleId",

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -2026,6 +2026,9 @@ function isPaintlessTerminalParagraph(block: FlowBlock | undefined): block is Pa
   }
 
   const attrs = block.attrs;
+  if (attrs?.suppressEmptyParagraphHeight === false) {
+    return false;
+  }
   return !(
     (attrs?.listMarker !== undefined && !attrs.listMarkerHidden) ||
     attrs?.borders?.top ||

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -3656,6 +3656,7 @@ type ConvertParagraphWithTextBoxesOptions = {
   textBoxGroupId: string;
   context: TableConversionContext;
   extraRunFormatting?: TextFormatting;
+  preserveEmptyWrapper?: boolean;
   tableParagraphOverlay?: TableCellParagraphSpacingOverlay;
 };
 
@@ -3666,6 +3667,7 @@ function convertParagraphWithTextBoxes(
     textBoxGroupId,
     context,
     extraRunFormatting,
+    preserveEmptyWrapper,
     tableParagraphOverlay,
   }: ConvertParagraphWithTextBoxesOptions,
 ): PMNode[] {
@@ -3684,7 +3686,8 @@ function convertParagraphWithTextBoxes(
   const isEmptyAfterExtraction =
     textBoxes.length > 0 && !hasContentBesidesTextBoxAnchors(pmParagraph);
   const keepWrapperParagraph =
-    isEmptyAfterExtraction && hasParagraphBoundaryPayload(block, pmParagraph);
+    isEmptyAfterExtraction &&
+    (preserveEmptyWrapper === true || hasParagraphBoundaryPayload(block, pmParagraph));
   if (!isEmptyAfterExtraction || keepWrapperParagraph) {
     nodes.push(pmParagraph);
   }
@@ -4133,11 +4136,13 @@ export function headerFooterToProseDoc(
     const out: PMNode[] = [];
     for (const block of blocks) {
       if (block.type === "paragraph") {
+        const isDetachedWatermarkHost = Reflect.get(block, DETACHED_WATERMARK_HOST) === true;
         const paragraphNodes = convertParagraphWithTextBoxes(block, styleResolver, {
           textBoxGroupId: nextTextBoxGroupId(),
           context: conversionContext,
+          preserveEmptyWrapper: isDetachedWatermarkHost,
         });
-        if (Reflect.get(block, DETACHED_WATERMARK_HOST) === true) {
+        if (isDetachedWatermarkHost) {
           const paragraphNodeIndex = paragraphNodes.findIndex(
             ({ type }) => type.name === "paragraph",
           );


### PR DESCRIPTION
## Summary

- include empty-host suppression state in the header/footer paint signature
- protect detached watermark hosts from terminal paragraph suppression
- retain the marked wrapper when a watermark host contains only an extracted text box

## Validation

- `bun test packages/core/src/layout-bridge/convert/headerFooterLayout.test.ts` (45 pass)
- fresh remote CI is authoritative for the transplanted follow-up branch

Follow-up to #745 after automated review identified the three edge cases.