### PR TITLE
feat: template directives follow the docxtpl Jinja dialect

### DIFF
--- a/.changeset/template-jinja-dialect.md
+++ b/.changeset/template-jinja-dialect.md
@@ -20,5 +20,5 @@ the new optional `alias` field.
 The React and Vue overlays rename the kind-derived class suffixes to match:
 `--each` → `--for`, `--endeach` → `--endfor`, `--elseif` → `--elif` on
 `.folio-template-directive`, `--each` → `--for` on `.folio-template-band-rail`,
-plus a new `.folio-template-directive--loop`. Closer hover hints read `endif` /
-`endfor`.
+plus a new `.folio-template-directive--loop`. Closer hover hints read
+`endif · <opener expression>` / `endfor · <opener expression>`.

--- a/.changeset/template-jinja-dialect.md
+++ b/.changeset/template-jinja-dialect.md
@@ -1,0 +1,24 @@
+---
+"@stll/folio-core": minor
+"@stll/folio-react": minor
+"@stll/folio-vue": minor
+---
+
+Template directives follow the docxtpl dialect of Jinja.
+
+`@stll/folio-core` now scans markers with `@stll/template-conditions` 0.4:
+`{{ path | filter(...) }}`, `{% if %}` / `{% elif %}` / `{% else %}` /
+`{% endif %}`, `{% for alias in path %}` / `{% endfor %}`,
+`{{ clause("Name") }}`, `{{ num("key") }}`, `{{ ref("key") }}`, and the
+`{{ loop.* }}` counters.
+
+`DirectiveKind` renames accordingly (`each` → `for`, `endeach` → `endfor`,
+`elseif` → `elif`, `index`/`count` → the single `loop` kind). A `for`
+`DirectiveRange` carries the iterated array path in `expr` and the loop alias in
+the new optional `alias` field.
+
+The React and Vue overlays rename the kind-derived class suffixes to match:
+`--each` → `--for`, `--endeach` → `--endfor`, `--elseif` → `--elif` on
+`.folio-template-directive`, `--each` → `--for` on `.folio-template-band-rail`,
+plus a new `.folio-template-directive--loop`. Closer hover hints read `endif` /
+`endfor`.

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -554,6 +554,7 @@ export type DirectiveRange = {
     kind: DirectiveKind;
     expr: string;
     clauseVersion?: string;
+    alias?: string;
     block: boolean;
 };
 

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -554,6 +554,7 @@ export type DirectiveRange = {
     kind: DirectiveKind;
     expr: string;
     clauseVersion?: string;
+    alias?: string;
     block: boolean;
 };
 

--- a/bun.lock
+++ b/bun.lock
@@ -59,7 +59,7 @@
       "dependencies": {
         "@stll/docx-core": "workspace:^",
         "@stll/docx-utils": "^0.1.0",
-        "@stll/template-conditions": "^0.1.0",
+        "@stll/template-conditions": "^0.4.0",
         "better-result": "3.0.1",
         "csstype": "^3.1.3",
         "dompurify": "^3.4.13",
@@ -813,7 +813,7 @@
 
     "@speed-highlight/core": ["@speed-highlight/core@1.2.17", "", {}, "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg=="],
 
-    "@stll/conditions": ["@stll/conditions@0.1.0", "", { "dependencies": { "valibot": "1.4.1" } }, "sha512-38y+hAAQsOfniDr9xt03mbW4ShYKL9dUE50p9eo8ExXlRen08VAaeVt8Z2tDl9qPM45052XHJT8VoABp//MJ0w=="],
+    "@stll/conditions": ["@stll/conditions@0.3.1", "", { "dependencies": { "better-result": "3.0.0", "valibot": "1.4.2" } }, "sha512-zAAi0wo78t74HkrrGEUPUHGvB4Rp6PM0y4DB2De/UExdqLn4RIvT94fHvq6FnRZPhQBvcN1bjjQJEmTFp9y2jQ=="],
 
     "@stll/docx-core": ["@stll/docx-core@workspace:packages/docx-core"],
 
@@ -835,7 +835,7 @@
 
     "@stll/playground-vue": ["@stll/playground-vue@workspace:packages/playground-vue"],
 
-    "@stll/template-conditions": ["@stll/template-conditions@0.1.0", "", { "dependencies": { "@stll/conditions": "^0.1.0", "better-result": "2.9.2" } }, "sha512-GkgzEDiSqpzG3GexlOfVXHgYiQSME8osQIZ645F9ooQbvDcsTVX5YVpfvmPwe3EOhRol6WjEyO2t/39+hNvQsg=="],
+    "@stll/template-conditions": ["@stll/template-conditions@0.4.0", "", { "dependencies": { "@stll/conditions": "^0.3.1", "better-result": "3.0.1" } }, "sha512-OV09iYBikYj+YQ+yrFnC2Z8siCEgalUElzfwqsTEdPyKjLfoV2A/H1Q5KsU7WGKQEYQBCpZu4E7eblosjnIxtw=="],
 
     "@tailwindcss/cli": ["@tailwindcss/cli@4.3.3", "", { "dependencies": { "@parcel/watcher": "2.5.1", "@tailwindcss/node": "4.3.3", "@tailwindcss/oxide": "4.3.3", "enhanced-resolve": "^5.24.1", "mri": "^1.2.0", "picocolors": "^1.1.1", "tailwindcss": "4.3.3" }, "bin": { "tailwindcss": "./dist/index.mjs" } }, "sha512-ZvS/n1ZHOBKcVlhkt8l5NNr1EDXk1NboYO5CYDOs6NUmvT9z6bzkwsosaJftY57T/3gWNzWMJzIXLodZC8ssdw=="],
 
@@ -2243,7 +2243,7 @@
 
     "@rushstack/node-core-library/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
-    "@stll/template-conditions/better-result": ["better-result@2.9.2", "", {}, "sha512-WIFoBPCdnTOdk9inkE1ZRvCZ4P0CpSkAiLlchC65N7n9DcjZ3NhqkBOlafzpOVnO8ixyi37kicmSJ3ENhPZl7Q=="],
+    "@stll/conditions/better-result": ["better-result@3.0.0", "", {}, "sha512-6aAtXzewlQYw6BrlKL164xDAsVJ+z2Au3Bwik27tXQBNs3OP3MDVDHznb8ovbqA3jtYxTWbchBikb/K3MjevZA=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" }, "bundled": true }, "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@stll/docx-core": "workspace:^",
     "@stll/docx-utils": "^0.1.0",
-    "@stll/template-conditions": "^0.1.0",
+    "@stll/template-conditions": "^0.4.0",
     "better-result": "3.0.1",
     "csstype": "^3.1.3",
     "dompurify": "^3.4.13",

--- a/packages/core/src/prosemirror/plugins/templateDirectives.test.ts
+++ b/packages/core/src/prosemirror/plugins/templateDirectives.test.ts
@@ -12,22 +12,23 @@ const docOf = (...paragraphs: string[]) =>
   );
 
 describe("scanDirectives", () => {
-  test("recognizes @num and @ref numbering markers as their own kinds", () => {
+  test("recognizes num() and ref() numbering markers as their own kinds", () => {
     const doc = docOf(
-      "Clause {{@num:scope}}. Scope of authority.",
-      "As set out in Clause {{@ref:scope}}, signed on {{signing_date}}.",
+      'Clause {{ num("scope") }}. Scope of authority.',
+      'As set out in Clause {{ ref("scope") }}, signed on {{ signing_date }}.',
     );
     const tokens = scanDirectives(doc).map((r) => `${r.kind}:${r.expr}`);
 
     expect(tokens).toContain("num:scope");
     expect(tokens).toContain("ref:scope");
-    expect(tokens).toContain("placeholder:signing_date");
-    // The numbering markers must not also be claimed as plain placeholders.
-    expect(tokens.filter((token) => token === "placeholder:@num:scope")).toEqual([]);
+    // The numbering calls must not also be claimed as plain placeholders.
+    expect(tokens.filter((token) => token.startsWith("placeholder:"))).toEqual([
+      "placeholder:signing_date",
+    ]);
   });
 
   test("still recognizes clause slots and plain fields alongside them", () => {
-    const doc = docOf("Party {{tenant.name}} acts under {{@clause:Indemnity}}.");
+    const doc = docOf('Party {{ tenant.name }} acts under {{ clause("Indemnity") }}.');
     const tokens = scanDirectives(doc)
       .map((r) => `${r.kind}:${r.expr}`)
       .sort();
@@ -37,7 +38,7 @@ describe("scanDirectives", () => {
 
   test("emits mid-line conditional markers as inline (block:false) ranges", () => {
     const doc = docOf(
-      "the Buyer{{#if hasSpouse}} and their spouse{{#else}} alone{{/if}} hereby agrees.",
+      "the Buyer{% if hasSpouse %} and their spouse{% else %} alone{% endif %} hereby agrees.",
     );
     const tokens = scanDirectives(doc).map((r) => `${r.kind}:${r.expr}:${String(r.block)}`);
 
@@ -45,19 +46,19 @@ describe("scanDirectives", () => {
   });
 
   test("inline range positions cover the markers in document order", () => {
-    const doc = docOf("A{{#if x}}B{{/if}}C");
+    const doc = docOf("A{% if x %}B{% endif %}C");
     const ranges = scanDirectives(doc);
 
     expect(ranges).toHaveLength(2);
     const [opener, closer] = ranges;
     expect(opener?.kind).toBe("if");
     expect(closer?.kind).toBe("endif");
-    expect(doc.textBetween(opener?.from ?? 0, opener?.to ?? 0)).toBe("{{#if x}}");
-    expect(doc.textBetween(closer?.from ?? 0, closer?.to ?? 0)).toBe("{{/if}}");
+    expect(doc.textBetween(opener?.from ?? 0, opener?.to ?? 0)).toBe("{% if x %}");
+    expect(doc.textBetween(closer?.from ?? 0, closer?.to ?? 0)).toBe("{% endif %}");
   });
 
   test("whole-paragraph directives keep block:true", () => {
-    const doc = docOf("{{#if hasSpouse}}", "Spouse paragraph.", "{{/if}}");
+    const doc = docOf("{% if hasSpouse %}", "Spouse paragraph.", "{% endif %}");
     const blockKinds = scanDirectives(doc)
       .filter((r) => r.block)
       .map((r) => r.kind);
@@ -69,7 +70,7 @@ describe("scanDirectives", () => {
     const field = schema.node("field", {
       fieldType: "UNKNOWN",
       instruction: " QUOTE ",
-      displayText: "{{#if hasSpouse}}",
+      displayText: "{% if hasSpouse %}",
       fieldKind: "simple",
     });
     const doc = schema.node("doc", null, [schema.node("paragraph", null, [field])]);
@@ -79,17 +80,34 @@ describe("scanDirectives", () => {
     expect(range?.block).toBe(true);
     expect(range?.from).toBe(1);
     expect(range?.to).toBe(1 + field.nodeSize);
-    expect(doc.textBetween(range?.from ?? 0, range?.to ?? 0)).toBe("{{#if hasSpouse}}");
+    expect(doc.textBetween(range?.from ?? 0, range?.to ?? 0)).toBe("{% if hasSpouse %}");
   });
 
-  test("emits mid-line each markers as inline (block:false) ranges", () => {
-    const doc = docOf("Items: {{#each items}}{{items.name}}{{/each}} end.");
+  test("emits mid-line for markers as inline (block:false) ranges", () => {
+    const doc = docOf("Items: {% for item in items %}{{ item.name }}{% endfor %} end.");
     const tokens = scanDirectives(doc).map((r) => `${r.kind}:${r.expr}:${String(r.block)}`);
 
-    expect(tokens).toContain("each:items:false");
-    expect(tokens).toContain("endeach::false");
+    expect(tokens).toContain("for:items:false");
+    expect(tokens).toContain("endfor::false");
     // The field inside the inline loop still gets its chip.
-    expect(tokens).toContain("placeholder:items.name:false");
+    expect(tokens).toContain("placeholder:item.name:false");
+  });
+
+  test("a for range carries the array path as expr and the loop alias", () => {
+    // Hosts read `expr` as the array the loop walks and `alias` as the name its
+    // body binds each element to; splitting them is what lets a host resolve
+    // `{{ item.name }}` back to `items`.
+    const doc = docOf("{% for item in contracts.risks %}", "Risk.", "{% endfor %}");
+
+    const opener = scanDirectives(doc).find((r) => r.kind === "for");
+
+    expect(opener).toMatchObject({ expr: "contracts.risks", alias: "item", block: true });
+  });
+
+  test("only a for range carries an alias", () => {
+    const doc = docOf("{% if premium %}", "Premium.", "{% endif %}");
+
+    expect(scanDirectives(doc).every((r) => r.alias === undefined)).toBe(true);
   });
 });
 
@@ -105,19 +123,19 @@ describe("computeBlockDepths", () => {
   });
 
   test("assigns 0-based depth by containment", () => {
-    // {{#each}} > {{#if}} > {{#if}}  (outer loop, two nested conditions)
+    // {% for %} > {% if %} > {% if %}  (outer loop, two nested conditions)
     const ranges: DirectiveRange[] = [
-      blockRange(0, "each"),
+      blockRange(0, "for"),
       blockRange(10, "if"),
       blockRange(20, "endif"),
       blockRange(30, "if"),
       blockRange(40, "endif"),
-      blockRange(50, "endeach"),
+      blockRange(50, "endfor"),
     ];
 
     const depths = computeBlockDepths(ranges);
 
-    expect(depths.get(0)).toBe(0); // each
+    expect(depths.get(0)).toBe(0); // for
     expect(depths.get(10)).toBe(1); // first nested if
     expect(depths.get(30)).toBe(1); // sibling nested if (back to depth 1)
   });
@@ -125,11 +143,11 @@ describe("computeBlockDepths", () => {
   test("deeply nested openers keep climbing (visual cap is the overlay's job)", () => {
     const ranges: DirectiveRange[] = [
       blockRange(0, "if"),
-      blockRange(1, "each"),
+      blockRange(1, "for"),
       blockRange(2, "if"),
-      blockRange(3, "each"),
+      blockRange(3, "for"),
       blockRange(4, "if"),
-      blockRange(5, "each"),
+      blockRange(5, "for"),
     ];
 
     const depths = computeBlockDepths(ranges);
@@ -140,16 +158,16 @@ describe("computeBlockDepths", () => {
   test("ignores order of input and inline (block:false) markers", () => {
     const ranges: DirectiveRange[] = [
       blockRange(30, "endif"),
-      blockRange(0, "each"),
+      blockRange(0, "for"),
       { from: 5, to: 6, kind: "if", expr: "x", block: false }, // inline: no rail
       blockRange(10, "if"),
-      blockRange(40, "endeach"),
+      blockRange(40, "endfor"),
     ];
 
     const depths = computeBlockDepths(ranges);
 
-    expect(depths.get(0)).toBe(0); // each
-    expect(depths.get(10)).toBe(1); // if nested inside each
+    expect(depths.get(0)).toBe(0); // for
+    expect(depths.get(10)).toBe(1); // if nested inside for
     expect(depths.has(5)).toBe(false); // inline if excluded
   });
 
@@ -165,31 +183,32 @@ describe("computeBlockDepths", () => {
     expect(depths.get(10)).toBe(0);
   });
 
-  test("kind-aware: a stray {{/each}} does not shrink a foreign block's depth", () => {
-    // {{#if}} {{/each}}(stray, no open each) {{#each}} {{/if}}
-    // A blind open/close counter decrements on the stray {{/each}} and pulls the
-    // nested {{#each}} back to depth 0; kind-aware matching leaves it at depth 1.
+  test("kind-aware: a stray {% endfor %} does not shrink a foreign block's depth", () => {
+    // {% if %} {% endfor %}(stray, no open for) {% for %} {% endif %}
+    // A blind open/close counter decrements on the stray {% endfor %} and pulls
+    // the nested {% for %} back to depth 0; kind-aware matching leaves it at 1.
     const ranges: DirectiveRange[] = [
       blockRange(0, "if"),
-      blockRange(10, "endeach"), // stray: no open each to close
-      blockRange(20, "each"),
+      blockRange(10, "endfor"), // stray: no open for to close
+      blockRange(20, "for"),
       blockRange(30, "endif"),
     ];
 
     const depths = computeBlockDepths(ranges);
 
     expect(depths.get(0)).toBe(0); // outer if
-    expect(depths.get(20)).toBe(1); // each is still nested inside the open if
+    expect(depths.get(20)).toBe(1); // for is still nested inside the open if
   });
 
-  test("kind-aware: interleaved if/each closers keep opener depths intact", () => {
-    // {{#if}} {{#each}} {{/if}} {{/each}} (crossed nesting): the {{/if}} closes the
-    // if and discards the improperly-nested each, but recorded depths do not shift.
+  test("kind-aware: interleaved if/for closers keep opener depths intact", () => {
+    // {% if %} {% for %} {% endif %} {% endfor %} (crossed nesting): the
+    // {% endif %} closes the if and discards the improperly-nested for, but the
+    // recorded depths do not shift.
     const ranges: DirectiveRange[] = [
       blockRange(0, "if"),
-      blockRange(10, "each"),
+      blockRange(10, "for"),
       blockRange(20, "endif"),
-      blockRange(30, "endeach"),
+      blockRange(30, "endfor"),
     ];
 
     const depths = computeBlockDepths(ranges);

--- a/packages/core/src/prosemirror/plugins/templateDirectives.ts
+++ b/packages/core/src/prosemirror/plugins/templateDirectives.ts
@@ -4,16 +4,16 @@
  * Scans the document for legal-template markers and exposes their
  * PM ranges so the paged-canvas overlay can paint rich widgets
  * (field chips, conditional/loop bands) in place of the raw
- * `{{...}}` text. Mirrors the anonymization plugin's shape via the
- * shared {@link createDocScanPlugin} factory; the document text is
- * the only input, so there is no host-pushed config.
+ * `{{ ... }}` / `{% ... %}` text. Mirrors the anonymization plugin's
+ * shape via the shared {@link createDocScanPlugin} factory; the
+ * document text is the only input, so there is no host-pushed config.
  *
- * The grammar itself is NOT defined here: the kinds and the
- * `{{...}}` parser come from `@stll/template-conditions`
- * ({@link scanMarkers}, {@link classifyMarker}), the same module the
- * fill pipeline uses. This file only maps the scanner's text offsets
- * onto ProseMirror positions, so a new directive added to the shared
- * grammar is highlighted here automatically.
+ * The grammar itself is NOT defined here: the kinds and the marker
+ * parser come from `@stll/template-conditions` ({@link scanMarkers}),
+ * the docxtpl dialect of Jinja the fill pipeline uses. This file only
+ * maps the scanner's text offsets onto ProseMirror positions, so a new
+ * directive added to the shared grammar is highlighted here
+ * automatically.
  */
 
 import type { Node as PMNode } from "prosemirror-model";
@@ -40,15 +40,22 @@ export type DirectiveRange = {
   /** Exclusive PM doc position of the marker end. */
   to: number;
   kind: DirectiveKind;
-  /** Field path, clause name, or condition/loop expression. */
+  /**
+   * Field path, clause name, key, condition, or — for a `for` marker — the
+   * array path the loop iterates (`{% for row in items %}` ⇒ `items`).
+   */
   expr: string;
   /** Clause-slot version selector, e.g. "v3" or "latest". */
   clauseVersion?: string;
+  /** Loop alias of a `for` marker (`{% for row in items %}` ⇒ `row`); unset
+   *  for every other kind. */
+  alias?: string;
   /** True for block directives that occupy their own paragraph. */
   block: boolean;
 };
 
-/** The display expression for a marker (field path, clause name, key, condition). */
+/** The display expression for a marker (field path, clause name, key,
+ *  condition, loop array path, loop property). */
 const directiveExpr = (meta: MarkerMeta): string => {
   switch (meta.kind) {
     case "placeholder":
@@ -58,39 +65,41 @@ const directiveExpr = (meta: MarkerMeta): string => {
     case "num":
     case "ref":
       return meta.key;
+    case "loop":
+      return meta.property;
     case "if":
-    case "elseif":
-    case "each":
+    case "elif":
       return meta.expr;
-    case "index":
-    case "count":
+    case "for":
+      return meta.path;
     case "else":
     case "endif":
-    case "endeach":
+    case "endfor":
       return "";
     default:
       return assertNever(meta);
   }
 };
 
-/** Block-directive openers ({{#if}}, {{#each}}) that start a gutter-rail band. */
-const BLOCK_OPENER_KINDS = new Set<DirectiveKind>(["if", "each"]);
-/** Block-directive closers ({{/if}}, {{/each}}) that end a gutter-rail band. */
-const BLOCK_CLOSER_KINDS = new Set<DirectiveKind>(["endif", "endeach"]);
+/** Block-directive openers (`{% if %}`, `{% for %}`) that start a gutter-rail band. */
+const BLOCK_OPENER_KINDS = new Set<DirectiveKind>(["if", "for"]);
+/** Block-directive closers (`{% endif %}`, `{% endfor %}`) that end a gutter-rail band. */
+const BLOCK_CLOSER_KINDS = new Set<DirectiveKind>(["endif", "endfor"]);
 
 /**
  * Nesting depth (0-based) of every block-directive opener, derived purely from
  * the scanned ranges by containment: walk the block openers/closers in document
  * order with a kind-aware stack, and record each opener's depth as the stack size
- * before it is pushed. Only `block:true` if/each pairs participate (inline markers
+ * before it is pushed. Only `block:true` if/for pairs participate (inline markers
  * resolve within a paragraph and get no rail).
  *
  * Matching is kind-aware so a mid-edit / unbalanced template stays sane: a closer
- * pops the nearest opener of the *same family* ({{/if}} ⇒ {{#if}}, {{/each}} ⇒
- * {{#each}}), dropping any still-open openers nested above it; a closer with no
- * matching opener is ignored (never decrements a foreign block's depth). A blind
- * open/close counter would mis-count here: e.g. a stray {{/each}} between {{#if}}
- * and a nested {{#each}} would wrongly pull the inner {{#each}} back to depth 0.
+ * pops the nearest opener of the *same family* (`{% endif %}` ⇒ `{% if %}`,
+ * `{% endfor %}` ⇒ `{% for %}`), dropping any still-open openers nested above it;
+ * a closer with no matching opener is ignored (never decrements a foreign block's
+ * depth). A blind open/close counter would mis-count here: e.g. a stray
+ * `{% endfor %}` between `{% if %}` and a nested `{% for %}` would wrongly pull
+ * the inner `{% for %}` back to depth 0.
  *
  * Keyed by the opener's `from` PM position, which is unique per marker, so the
  * overlay can look a band's depth up from its opener range. This is a pure
@@ -110,7 +119,7 @@ export const computeBlockDepths = (ranges: readonly DirectiveRange[]): Map<numbe
       stack.push(range.kind);
       continue;
     }
-    const wantOpener: DirectiveKind = range.kind === "endif" ? "if" : "each";
+    const wantOpener: DirectiveKind = range.kind === "endif" ? "if" : "for";
     const matchIdx = stack.lastIndexOf(wantOpener);
     if (matchIdx !== -1) {
       stack.length = matchIdx;
@@ -118,6 +127,10 @@ export const computeBlockDepths = (ranges: readonly DirectiveRange[]): Map<numbe
   }
   return depths;
 };
+
+/** The loop alias a `for` marker binds, or undefined for every other kind. */
+const directiveAlias = (meta: MarkerMeta): string | undefined =>
+  meta.kind === "for" ? meta.alias : undefined;
 
 export const scanDirectives = (doc: PMNode): DirectiveRange[] => {
   const ranges: DirectiveRange[] = [];
@@ -132,23 +145,26 @@ export const scanDirectives = (doc: PMNode): DirectiveRange[] => {
     const sole = lineMarkers.length === 1 ? lineMarkers[0] : undefined;
     if (sole && sole.raw === trimmed && isBlockDirectiveKind(sole.meta.kind)) {
       const last = chunks.at(-1);
+      const alias = directiveAlias(sole.meta);
       ranges.push({
         from: chunks[0]?.start ?? 0,
         to: last ? (last.end ?? last.start + last.text.length) : 0,
         kind: sole.meta.kind,
         expr: directiveExpr(sole.meta),
         block: true,
+        ...(alias !== undefined ? { alias } : {}),
       });
       continue;
     }
 
-    // Otherwise, inline markers. Mid-line if/elseif/else/endif and
-    // {{#each}}/{{/each}} are emitted with `block:false`: the fill engine
+    // Otherwise, inline markers. Mid-line if/elif/else/endif and
+    // `{% for %}`/`{% endfor %}` are emitted with `block:false`: the fill engine
     // resolves inline conditional spans and inline loops within a paragraph,
     // so they get the marker tint and join the outline, while the gutter-rail
     // bands stay block-only (the overlay checks `block`).
     for (const marker of scanMarkers(joined)) {
       const clauseVersion = marker.meta.kind === "clause" ? marker.meta.version : undefined;
+      const alias = directiveAlias(marker.meta);
       ranges.push({
         from: offsetToDocPos(chunks, marker.start),
         to: offsetToDocPos(chunks, marker.end, "end"),
@@ -156,6 +172,7 @@ export const scanDirectives = (doc: PMNode): DirectiveRange[] => {
         expr: directiveExpr(marker.meta),
         block: false,
         ...(clauseVersion !== undefined ? { clauseVersion } : {}),
+        ...(alias !== undefined ? { alias } : {}),
       });
     }
   }

--- a/packages/core/src/prosemirror/plugins/templatePreviewValues.test.ts
+++ b/packages/core/src/prosemirror/plugins/templatePreviewValues.test.ts
@@ -76,17 +76,17 @@ describe("templatePreviewValues: entry tracking", () => {
 
   test("skips empty values, unmatched fields, and structural directives", () => {
     const doc = docOf(
-      "Field {{tenant.name}} and clause {{@clause:Indemnity}}.",
-      "{{#if premium}}",
-      "Premium terms for {{tenant.name}}.",
-      "{{/if}}",
+      'Field {{ tenant.name }} and clause {{ clause("Indemnity") }}.',
+      "{% if premium %}",
+      "Premium terms for {{ tenant.name }}.",
+      "{% endif %}",
     );
     const state = makeState(doc, {
       values: {
         "tenant.name": "",
         "landlord.name": "Unused",
         // A clause slot keys by SLOT NAME, not the `@clause:` patch key,
-        // so this value never matches the {{@clause:Indemnity}} marker.
+        // so this value never matches the clause("Indemnity") marker.
         "@clause:Indemnity": "Not a field",
         premium: "true",
       },
@@ -97,7 +97,7 @@ describe("templatePreviewValues: entry tracking", () => {
   });
 
   test("previews a linked clause slot, keyed by slot name", () => {
-    const doc = docOf("Field {{tenant.name}} and clause {{@clause:Indemnity}}.");
+    const doc = docOf('Field {{ tenant.name }} and clause {{ clause("Indemnity") }}.');
     const state = makeState(doc, {
       values: {
         "tenant.name": "Pavel Novák",
@@ -112,11 +112,11 @@ describe("templatePreviewValues: entry tracking", () => {
       "Indemnity=The Supplier shall indemnify the Customer.",
     ]);
     const clause = entries.find((e) => e.expr === "Indemnity")!;
-    expect(sliceFromTo(state.doc, clause.from, clause.to)).toBe("{{@clause:Indemnity}}");
+    expect(sliceFromTo(state.doc, clause.from, clause.to)).toBe('{{ clause("Indemnity") }}');
   });
 
   test("renders multi-paragraph clause text as one wrapping run", () => {
-    const doc = docOf("Clause {{@clause:Terms}}.");
+    const doc = docOf('Clause {{ clause("Terms") }}.');
     const state = makeState(doc, {
       values: { Terms: "First paragraph.\nSecond paragraph." },
       mode: "highlighted",
@@ -128,7 +128,7 @@ describe("templatePreviewValues: entry tracking", () => {
   });
 
   test("skips an unlinked clause slot (no value supplied)", () => {
-    const doc = docOf("Clause {{@clause:Missing}}.");
+    const doc = docOf('Clause {{ clause("Missing") }}.');
     const state = makeState(doc, {
       values: { tenant: "Pavel Novák" },
       mode: "plain",

--- a/packages/core/src/prosemirror/plugins/templatePreviewValues.ts
+++ b/packages/core/src/prosemirror/plugins/templatePreviewValues.ts
@@ -140,8 +140,8 @@ function collectPreviewEntries(
 
   const entries: TemplatePreviewEntry[] = [];
   for (const range of scanDirectives(doc)) {
-    // Field placeholders (`{{path}}`) key the preview map by their path;
-    // clause slots (`{{@clause:Name}}`) key it by the slot name, which
+    // Field placeholders (`{{ path }}`) key the preview map by their path;
+    // clause slots (`{{ clause("Name") }}`) key it by the slot name, which
     // `scanDirectives` exposes as the clause range's `expr`. The host
     // supplies the resolved clause text under that same slot name.
     if (range.kind !== "placeholder" && range.kind !== "clause") {

--- a/packages/core/src/prosemirror/plugins/templateSlashMenu.test.ts
+++ b/packages/core/src/prosemirror/plugins/templateSlashMenu.test.ts
@@ -309,13 +309,13 @@ describe("templateSlashMenu handleTextInput", () => {
   });
 
   test('"/" inside an existing directive does not open the menu', () => {
-    // `{{#if cond}}` with the caret after "#if " (a whitespace boundary, so the
+    // `{% if cond %}` with the caret after "if " (a whitespace boundary, so the
     // generic guard would open). Opening here would nest markers
-    // (`{{#if {{field}}}}`), which the fill grammar cannot parse, so the
+    // (`{% if {{ field }} %}`), which the fill grammar cannot parse, so the
     // directive-range guard must reject it.
-    const text = "{{#if cond}}";
+    const text = "{% if cond %}";
     const doc = schema.node("doc", null, [schema.node("paragraph", null, [schema.text(text)])]);
-    const caretAfterIf = text.indexOf("#if ") + "#if ".length; // parent offset
+    const caretAfterIf = text.indexOf("if ") + "if ".length; // parent offset
     const slash = templateSlashMenuPlugin();
     const view: FakeView = {
       state: EditorState.create({

--- a/packages/core/src/prosemirror/plugins/templateSlashMenu.ts
+++ b/packages/core/src/prosemirror/plugins/templateSlashMenu.ts
@@ -94,8 +94,8 @@ const atTriggerBoundary = (state: EditorState, pos: number): boolean => {
 /** Whether `pos` falls strictly inside an existing template directive. The
  *  slash activations insert markers as raw text rather than going through
  *  `insertInline`'s overlap guard, so opening here would nest markers — e.g. a
- *  `/` typed after `#if ` inside `{{#if condition}}` could produce
- *  `{{#if {{field}}}}`, which the scanner/fill grammar cannot interpret.
+ *  `/` typed after `if ` inside `{% if condition %}` could produce
+ *  `{% if {{ field }} %}`, which the scanner/fill grammar cannot interpret.
  *  Boundaries are exclusive: a caret right before `{{` or after `}}` is fine. */
 const insideDirective = (state: EditorState, pos: number): boolean =>
   getTemplateDirectives(state).some((range) => pos > range.from && pos < range.to);

--- a/packages/react/src/components/DocxEditor.props.ts
+++ b/packages/react/src/components/DocxEditor.props.ts
@@ -295,8 +295,8 @@ export type DocxEditorProps = {
   /** Monotonic counter from the bridge store; drives the re-scroll. */
   anonymizationSelectionSeq?: number | undefined;
   /**
-   * Render legal-template markers ({{field}}, {{@clause:..}},
-   * {{#if}}/{{#each}}) as rich widgets on the page instead of raw
+   * Render legal-template markers (`{{ field }}`, `{{ clause("Name") }}`,
+   * `{% if %}`/`{% for %}`) as rich widgets on the page instead of raw
    * text. Off for ordinary documents; on for the template editor.
    */
   showTemplateDirectives?: boolean | undefined;

--- a/packages/react/src/paged-editor/TemplateDirectivesOverlay.rails.test.ts
+++ b/packages/react/src/paged-editor/TemplateDirectivesOverlay.rails.test.ts
@@ -106,19 +106,19 @@ describe("segmentBandByPages", () => {
 
 describe("pairBlockRanges", () => {
   test("pairs nested openers with their closers and carries id/kind/expr", () => {
-    // {{#each contracts.risks}} > {{#if hasVerdicts}} ... {{/if}} {{/each}}
+    // {% for r in contracts.risks %} > {% if hasVerdicts %} ... {% endif %} {% endfor %}
     const ranges = [
-      blockRange(0, "each", "contracts.risks"),
+      blockRange(0, "for", "contracts.risks"),
       blockRange(10, "if", "hasVerdicts"),
       blockRange(20, "endif"),
-      blockRange(30, "endeach"),
+      blockRange(30, "endfor"),
     ];
 
     const pairings = pairBlockRanges(ranges);
 
     expect(pairings).toHaveLength(2);
     const inner = pairings.find((p) => p.kind === "if");
-    const outer = pairings.find((p) => p.kind === "each");
+    const outer = pairings.find((p) => p.kind === "for");
     expect(inner).toMatchObject({ blockId: 10, openerFrom: 10, closerFrom: 20, closerTo: 21 });
     expect(inner?.openerExpr).toBe("hasVerdicts");
     expect(outer).toMatchObject({ blockId: 0, closerFrom: 30, openerExpr: "contracts.risks" });
@@ -139,29 +139,30 @@ describe("pairBlockRanges", () => {
   });
 
   test("carries the nesting depth from the same walk", () => {
-    // {{#each}} > {{#if}} ... {{/if}} {{/each}}: depth rides on the pairing so the
-    // rail's indentation and its opener→closer span can never diverge.
+    // {% for %} > {% if %} ... {% endif %} {% endfor %}: depth rides on the
+    // pairing so the rail's indentation and its span can never diverge.
     const pairings = pairBlockRanges([
-      blockRange(0, "each", "items"),
+      blockRange(0, "for", "items"),
       blockRange(10, "if", "cond"),
       blockRange(20, "endif"),
-      blockRange(30, "endeach"),
+      blockRange(30, "endfor"),
     ]);
 
     expect(pairings.find((p) => p.kind === "if")?.depth).toBe(1);
-    expect(pairings.find((p) => p.kind === "each")?.depth).toBe(0);
+    expect(pairings.find((p) => p.kind === "for")?.depth).toBe(0);
   });
 
-  test("kind-aware: a {{/if}} pairs with its {{#if}}, not an intervening {{#each}}", () => {
-    // {{#if}} {{#each}} {{/if}} {{/each}} (crossed nesting). Blind popping would
-    // pair the {{/if}} with the {{#each}} (an each-kind band) and the {{/each}}
-    // with the {{#if}}. Kind-aware matching closes the if correctly and drops the
-    // improperly-nested each rather than mislabelling a band.
+  test("kind-aware: an endif pairs with its if, not an intervening for", () => {
+    // {% if %} {% for %} {% endif %} {% endfor %} (crossed nesting). Blind
+    // popping would pair the {% endif %} with the {% for %} (a for-kind band) and
+    // the {% endfor %} with the {% if %}. Kind-aware matching closes the if
+    // correctly and drops the improperly-nested for rather than mislabelling a
+    // band.
     const pairings = pairBlockRanges([
       blockRange(0, "if", "A"),
-      blockRange(10, "each", "B"),
+      blockRange(10, "for", "B"),
       blockRange(20, "endif"),
-      blockRange(30, "endeach"),
+      blockRange(30, "endfor"),
     ]);
 
     expect(pairings).toHaveLength(1);
@@ -174,10 +175,11 @@ describe("pairBlockRanges", () => {
     });
   });
 
-  test("kind-aware: a {{/if}} never closes an {{#each}}", () => {
-    // {{#each}} {{/if}}: mismatched families must not pair (would be an each-kind
-    // band closed by a /if). Blind popping paired them; kind-aware drops both.
-    const pairings = pairBlockRanges([blockRange(0, "each", "B"), blockRange(10, "endif")]);
+  test("kind-aware: an endif never closes a for", () => {
+    // {% for %} {% endif %}: mismatched families must not pair (would be a
+    // for-kind band closed by an endif). Blind popping paired them; kind-aware
+    // drops both.
+    const pairings = pairBlockRanges([blockRange(0, "for", "B"), blockRange(10, "endif")]);
 
     expect(pairings).toHaveLength(0);
   });
@@ -185,22 +187,22 @@ describe("pairBlockRanges", () => {
 
 describe("closerHintLabel", () => {
   test("names what the closer closes", () => {
-    expect(closerHintLabel("if", "hasVerdicts")).toBe("/if · hasVerdicts");
-    expect(closerHintLabel("each", "contracts.risks")).toBe("/each · contracts.risks");
+    expect(closerHintLabel("if", "hasVerdicts")).toBe("endif · hasVerdicts");
+    expect(closerHintLabel("for", "contracts.risks")).toBe("endfor · contracts.risks");
   });
 
   test("falls back to the bare keyword when there is no expression", () => {
-    expect(closerHintLabel("if", "")).toBe("/if");
-    expect(closerHintLabel("each", "")).toBe("/each");
+    expect(closerHintLabel("if", "")).toBe("endif");
+    expect(closerHintLabel("for", "")).toBe("endfor");
   });
 });
 
 describe("innermostBlockAt", () => {
   const pairings = pairBlockRanges([
-    blockRange(0, "each", "items"),
+    blockRange(0, "for", "items"),
     blockRange(10, "if", "cond"),
     blockRange(20, "endif"),
-    blockRange(30, "endeach"),
+    blockRange(30, "endfor"),
   ]);
 
   test("picks the deepest block whose span contains the caret", () => {
@@ -208,7 +210,7 @@ describe("innermostBlockAt", () => {
   });
 
   test("falls back to the enclosing block when outside the inner one", () => {
-    expect(innermostBlockAt(pairings, 25)).toBe(0); // between /if and /each
+    expect(innermostBlockAt(pairings, 25)).toBe(0); // between endif and endfor
   });
 
   test("returns null outside every block or with no caret", () => {

--- a/packages/react/src/paged-editor/TemplateDirectivesOverlay.tsx
+++ b/packages/react/src/paged-editor/TemplateDirectivesOverlay.tsx
@@ -1,7 +1,7 @@
 /**
  * Template Directives Overlay
  *
- * Paints a subtle, translucent highlight over each {{...}} marker's range so a
+ * Paints a subtle, translucent highlight over each marker's range so a
  * marker reads as a token while staying fully visible and editable: the
  * highlight is faint and `pointer-events: none`, so the real text shows through
  * and the caret lands in it normally. Because it's a tint (not an opaque cover),
@@ -10,7 +10,7 @@
  *
  * Rails are quiet by default and loud on intent: every rail renders faint until
  * the block either contains the caret (innermost wins) or is hovered (via its
- * rail or one of its {{#if}}/{{/if}} chips), at which point that one block's
+ * rail or one of its `{% if %}`/`{% endif %}` chips), at which point that one block's
  * rail and both chips brighten so it can be traced end-to-end. Rails are clipped
  * per page (never across the inter-page gap, header, or footer) and confined to
  * the left margin by a depth budget derived from the margin width.
@@ -69,8 +69,8 @@ const overlayStyles: CSSProperties = {
   zIndex: 10,
 };
 
-const BLOCK_OPENERS = new Set<DirectiveKind>(["if", "each"]);
-const BLOCK_CLOSERS = new Set<DirectiveKind>(["endif", "endeach"]);
+const BLOCK_OPENERS = new Set<DirectiveKind>(["if", "for"]);
+const BLOCK_CLOSERS = new Set<DirectiveKind>(["endif", "endfor"]);
 
 const RAIL_WIDTH = 2.5;
 /** Horizontal gap between adjacent nesting depths' rails. */
@@ -82,10 +82,10 @@ const RAIL_EDGE_PAD = 2;
 /** Drop per-page segments thinner than this (sub-pixel slivers at a page seam). */
 const RAIL_SEGMENT_MIN_HEIGHT = 2;
 
-/** Opener kind of a band ("if" ⇒ condition family, "each" ⇒ loop family). */
-type BandKind = "if" | "each";
+/** Opener kind of a band ("if" ⇒ condition family, "for" ⇒ loop family). */
+type BandKind = "if" | "for";
 
-const bandKindOf = (kind: DirectiveKind): BandKind => (kind === "each" ? "each" : "if");
+const bandKindOf = (kind: DirectiveKind): BandKind => (kind === "for" ? "for" : "if");
 
 /**
  * Deepest nesting level whose rail still fits inside the left margin with a
@@ -168,9 +168,10 @@ type OpenBlock = { range: DirectiveRange; depth: number };
  * a pair share a `blockId`, the rail knows its opener→closer PM span, and each
  * pairing carries the `depth` recorded in this very walk (never a second,
  * possibly-divergent depth pass). A closer matches the nearest opener of the same
- * family ({{/if}} ⇒ {{#if}}, {{/each}} ⇒ {{#each}}) and drops any still-open
- * openers nested above it; a closer with no matching opener is ignored. This keeps
- * a mid-edit / unbalanced template from pairing a {{/if}} with an {{#each}}.
+ * family (`{% endif %}` ⇒ `{% if %}`, `{% endfor %}` ⇒ `{% for %}`) and drops any
+ * still-open openers nested above it; a closer with no matching opener is ignored.
+ * This keeps a mid-edit / unbalanced template from pairing an `{% endif %}` with a
+ * `{% for %}`.
  * Inline (block:false) markers are excluded. Pure function of the ranges.
  */
 export const pairBlockRanges = (ranges: readonly DirectiveRange[]): BlockPairing[] => {
@@ -186,7 +187,7 @@ export const pairBlockRanges = (ranges: readonly DirectiveRange[]): BlockPairing
       stack.push({ range, depth: stack.length });
       continue;
     }
-    const wantOpener: DirectiveKind = range.kind === "endif" ? "if" : "each";
+    const wantOpener: DirectiveKind = range.kind === "endif" ? "if" : "for";
     let matched: OpenBlock | undefined;
     let matchIdx = -1;
     for (let i = stack.length - 1; i >= 0; i -= 1) {
@@ -214,9 +215,9 @@ export const pairBlockRanges = (ranges: readonly DirectiveRange[]): BlockPairing
   return pairings;
 };
 
-/** Hover hint for a closer chip: what it closes, e.g. `/if · hasVerdicts`. */
+/** Hover hint for a closer chip: what it closes, e.g. `endif · hasVerdicts`. */
 export const closerHintLabel = (kind: BandKind, openerExpr: string): string => {
-  const head = kind === "each" ? "/each" : "/if";
+  const head = kind === "for" ? "endfor" : "endif";
   return openerExpr ? `${head} · ${openerExpr}` : head;
 };
 

--- a/packages/react/src/styles/editor.css
+++ b/packages/react/src/styles/editor.css
@@ -1055,18 +1055,20 @@
   background: color-mix(in srgb, #0000ff 24%, transparent);
 }
 
-/* Condition directives (if / elseif / else / endif) tint teal, matching their
+/* Condition directives (if / elif / else / endif) tint teal, matching their
    rail, so a marker's role is legible at the chip. */
 .folio-template-directive--if,
-.folio-template-directive--elseif,
+.folio-template-directive--elif,
 .folio-template-directive--else,
 .folio-template-directive--endif {
   background: color-mix(in srgb, var(--doc-tmpl-cond) 26%, transparent);
 }
 
-/* Loop directives (each / endeach) tint violet, matching their rail. */
-.folio-template-directive--each,
-.folio-template-directive--endeach {
+/* Loop directives (for / endfor) and the loop counters (`{{ loop.index }}`)
+   tint violet, matching their rail. */
+.folio-template-directive--loop,
+.folio-template-directive--for,
+.folio-template-directive--endfor {
   background: color-mix(in srgb, var(--doc-tmpl-loop) 26%, transparent);
 }
 
@@ -1081,14 +1083,14 @@
 
 /* Chip emphasis mirrors the rail: brighten the twin chips of the active pair. */
 .folio-template-directive--if.folio-template-directive--active,
-.folio-template-directive--elseif.folio-template-directive--active,
+.folio-template-directive--elif.folio-template-directive--active,
 .folio-template-directive--else.folio-template-directive--active,
 .folio-template-directive--endif.folio-template-directive--active {
   background: color-mix(in srgb, var(--doc-tmpl-cond) 44%, transparent);
 }
 
-.folio-template-directive--each.folio-template-directive--active,
-.folio-template-directive--endeach.folio-template-directive--active {
+.folio-template-directive--for.folio-template-directive--active,
+.folio-template-directive--endfor.folio-template-directive--active {
   background: color-mix(in srgb, var(--doc-tmpl-loop) 44%, transparent);
 }
 
@@ -1107,7 +1109,7 @@
     box-shadow 120ms ease;
 }
 
-.folio-template-band-rail--each {
+.folio-template-band-rail--for {
   background: color-mix(in srgb, var(--doc-tmpl-loop) 22%, transparent);
 }
 
@@ -1118,7 +1120,7 @@
 /* Loud on intent: the innermost block around the caret, or the block whose rail
    or chip is hovered, gets full strength plus a hairline glow that widens the
    rail without shifting layout — so one block is easy to trace end-to-end. */
-.folio-template-band-rail--each.folio-template-band-rail--active {
+.folio-template-band-rail--for.folio-template-band-rail--active {
   background: color-mix(in srgb, var(--doc-tmpl-loop) 90%, transparent);
   box-shadow: 0 0 0 0.75px color-mix(in srgb, var(--doc-tmpl-loop) 45%, transparent);
 }

--- a/packages/vue/src/components/DocxEditor/types.ts
+++ b/packages/vue/src/components/DocxEditor/types.ts
@@ -298,9 +298,9 @@ export type DocxEditorProps = {
   /** Monotonic counter from the bridge store; drives the re-scroll. */
   anonymizationSelectionSeq?: number | undefined;
   /**
-   * Render legal-template markers ({{field}}, {{@clause:..}}, {{#if}}/{{#each}})
-   * as rich widgets on the page instead of raw text. Off for ordinary
-   * documents; on for the template editor.
+   * Render legal-template markers (`{{ field }}`, `{{ clause("Name") }}`,
+   * `{% if %}`/`{% for %}`) as rich widgets on the page instead of raw text.
+   * Off for ordinary documents; on for the template editor.
    */
   showTemplateDirectives?: boolean | undefined;
   /**

--- a/packages/vue/src/components/TemplateDirectivesOverlay.vue
+++ b/packages/vue/src/components/TemplateDirectivesOverlay.vue
@@ -1,7 +1,7 @@
 <!--
   Template Directives Overlay (Vue)
 
-  Paints a subtle translucent highlight over each {{...}} marker's range so a
+  Paints a subtle translucent highlight over each marker's range so a
   marker reads as a token while staying visible and editable. Block directives
   additionally get a thin left-margin gutter rail spanning opener→closer, quiet
   by default and loud on caret/hover intent.
@@ -102,10 +102,10 @@ const RAIL_EDGE_PAD = 2;
 /** Drop per-page segments thinner than this (sub-pixel slivers at a page seam). */
 const RAIL_SEGMENT_MIN_HEIGHT = 2;
 
-const BLOCK_OPENERS = new Set<DirectiveKind>(["if", "each"]);
-const BLOCK_CLOSERS = new Set<DirectiveKind>(["endif", "endeach"]);
+const BLOCK_OPENERS = new Set<DirectiveKind>(["if", "for"]);
+const BLOCK_CLOSERS = new Set<DirectiveKind>(["endif", "endfor"]);
 
-type BandKind = "if" | "each";
+type BandKind = "if" | "for";
 type BandSegment = { top: number; bottom: number };
 type BlockPairing = {
   blockId: number;
@@ -125,7 +125,7 @@ type RailBand = {
 };
 type ProjectedDirectiveGroup = { range: DirectiveRange; rects: SelectionRect[] };
 
-const bandKindOf = (kind: DirectiveKind): BandKind => (kind === "each" ? "each" : "if");
+const bandKindOf = (kind: DirectiveKind): BandKind => (kind === "for" ? "for" : "if");
 
 function railBudgetDepth(marginWidth: number): number {
   const usable = marginWidth - RAIL_TEXT_CLEARANCE - RAIL_WIDTH - RAIL_EDGE_PAD;
@@ -173,7 +173,7 @@ function pairBlockRanges(ranges: readonly DirectiveRange[]): BlockPairing[] {
       stack.push({ range, depth: stack.length });
       continue;
     }
-    const wantOpener: DirectiveKind = range.kind === "endif" ? "if" : "each";
+    const wantOpener: DirectiveKind = range.kind === "endif" ? "if" : "for";
     let matched: OpenBlock | undefined;
     let matchIdx = -1;
     for (let i = stack.length - 1; i >= 0; i -= 1) {
@@ -202,7 +202,7 @@ function pairBlockRanges(ranges: readonly DirectiveRange[]): BlockPairing[] {
 }
 
 function closerHintLabel(kind: BandKind, openerExpr: string): string {
-  const head = kind === "each" ? "/each" : "/if";
+  const head = kind === "for" ? "endfor" : "endif";
   return openerExpr ? `${head} · ${openerExpr}` : head;
 }
 
@@ -432,14 +432,15 @@ onBeforeUnmount(() => {
 }
 
 .folio-template-directive--if,
-.folio-template-directive--elseif,
+.folio-template-directive--elif,
 .folio-template-directive--else,
 .folio-template-directive--endif {
   background: color-mix(in srgb, var(--doc-tmpl-cond, #0d9488) 26%, transparent);
 }
 
-.folio-template-directive--each,
-.folio-template-directive--endeach {
+.folio-template-directive--loop,
+.folio-template-directive--for,
+.folio-template-directive--endfor {
   background: color-mix(in srgb, var(--doc-tmpl-loop, #7c3aed) 26%, transparent);
 }
 
@@ -449,14 +450,14 @@ onBeforeUnmount(() => {
 }
 
 .folio-template-directive--if.folio-template-directive--active,
-.folio-template-directive--elseif.folio-template-directive--active,
+.folio-template-directive--elif.folio-template-directive--active,
 .folio-template-directive--else.folio-template-directive--active,
 .folio-template-directive--endif.folio-template-directive--active {
   background: color-mix(in srgb, var(--doc-tmpl-cond, #0d9488) 44%, transparent);
 }
 
-.folio-template-directive--each.folio-template-directive--active,
-.folio-template-directive--endeach.folio-template-directive--active {
+.folio-template-directive--for.folio-template-directive--active,
+.folio-template-directive--endfor.folio-template-directive--active {
   background: color-mix(in srgb, var(--doc-tmpl-loop, #7c3aed) 44%, transparent);
 }
 
@@ -469,7 +470,7 @@ onBeforeUnmount(() => {
     box-shadow 120ms ease;
 }
 
-.folio-template-band-rail--each {
+.folio-template-band-rail--for {
   background: color-mix(in srgb, var(--doc-tmpl-loop, #7c3aed) 22%, transparent);
 }
 
@@ -477,7 +478,7 @@ onBeforeUnmount(() => {
   background: color-mix(in srgb, var(--doc-tmpl-cond, #0d9488) 22%, transparent);
 }
 
-.folio-template-band-rail--each.folio-template-band-rail--active {
+.folio-template-band-rail--for.folio-template-band-rail--active {
   background: color-mix(in srgb, var(--doc-tmpl-loop, #7c3aed) 90%, transparent);
   box-shadow: 0 0 0 0.75px color-mix(in srgb, var(--doc-tmpl-loop, #7c3aed) 45%, transparent);
 }

--- a/scripts/api-surface-budget.json
+++ b/scripts/api-surface-budget.json
@@ -8,7 +8,7 @@
   "core": {
     "reportBytes": 278552,
     "reportLines": 8955,
-    "declarationBytes": 1752036,
+    "declarationBytes": 1839509,
     "declarationLines": 35787
   },
   "react": {

--- a/scripts/typecheck-budget.json
+++ b/scripts/typecheck-budget.json
@@ -20,7 +20,7 @@
     "instantiations": 832018
   },
   "nuxt": {
-    "types": 104025,
+    "types": 109241,
     "instantiations": 113090
   },
   "playground": {


### PR DESCRIPTION
Template markers are now the docxtpl dialect of Jinja, matching
`@stll/template-conditions` 0.4. `packages/core` scans and classifies through
that package as before, so this change is a rename of the directive kinds plus
the extra data a `for` marker carries.

## Grammar

`{{ path | filter(...) }}`, `{% if %}` / `{% elif %}` / `{% else %}` /
`{% endif %}`, `{% for alias in path %}` / `{% endfor %}`, the `{%p %}` and
`{%tr %}` placement prefixes, `{{ clause("Name") }}`, `{{ num("key") }}`,
`{{ ref("key") }}`, and the `{{ loop.index }}` family of counters.

`DirectiveKind` follows: `each` becomes `for`, `endeach` becomes `endfor`,
`elseif` becomes `elif`, and `index` / `count` collapse into one `loop` kind.

## `DirectiveRange`

A `for` range reports the **array path** in `expr` (`{% for row in items %}`
gives `items`, what hosts read as the iterated array) and the loop alias in a
new optional `alias` field:

```ts
alias?: string; // for-only
```

I kept the existing per-kind-optional-field shape (`clauseVersion` for
`clause`) rather than splitting `DirectiveRange` into a discriminated union.
Every consumer (the two overlays, the preview plugin, the depth walk, and
hosts) reads `from` / `to` / `kind` / `expr` / `block` generically and filters
by kind only where it matters; a union would force narrowing at each of those
sites and at every host that keeps ranges in one array, for no invariant the
optional field does not already express. The smaller change wins here.

## Renamed CSS classes (hosts styling the overlay must follow)

| before | after |
| --- | --- |
| `.folio-template-directive--each` | `.folio-template-directive--for` |
| `.folio-template-directive--endeach` | `.folio-template-directive--endfor` |
| `.folio-template-directive--elseif` | `.folio-template-directive--elif` |
| `.folio-template-band-rail--each` | `.folio-template-band-rail--for` |

New: `.folio-template-directive--loop`, tinted with the loop family, for the
`{{ loop.* }}` counters. Closer chip hover hints read `endif · expr` /
`endfor · expr` instead of `/if` / `/each`.

Both the React (`editor.css`) and Vue (scoped) styles carry the rename.

## Dependency

`@stll/folio-core` requires `@stll/template-conditions` `^0.4.0`.

## Budgets

Two ratchets move, both because 0.4 carries a wider type surface than 0.1 and
core re-exports the grammar's kinds:

- `nuxt.types` 104,025 to 109,241. Every package that transitively imports
  `@stll/folio-core` gains 3-5% of compiler work; nuxt was the one already
  sitting inside the 5% headroom.
- `core.declarationBytes` 1,752,036 to 1,839,509, from the new `DirectiveRange`
  field and its documentation on top of existing drift.

No other baseline is touched, so the remaining ratchets keep their current
limits.
