### PR TITLE
fix(core): preserve run property revision boundaries

### DIFF
--- a/.changeset/fresh-run-boundaries.md
+++ b/.changeset/fresh-run-boundaries.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve run property revision boundaries when parsing DOCX content.

--- a/packages/core/src/docx/runConsolidator.test.ts
+++ b/packages/core/src/docx/runConsolidator.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import type { Run } from "../types/document";
+import { consolidateRuns } from "./runConsolidator";
+
+const changedRun = (text: string): Run => ({
+  type: "run",
+  formatting: { fontSizeCs: 22 },
+  propertyChanges: [
+    {
+      type: "runPropertyChange",
+      info: {
+        id: 1,
+        author: "Reviewer",
+        date: "2026-09-08T08:00:00Z",
+      },
+      previousFormatting: { bold: true, fontSizeCs: 22 },
+      currentFormatting: { fontSizeCs: 22 },
+    },
+  ],
+  content: [{ type: "text", text }],
+});
+
+describe("run consolidation boundaries", () => {
+  test("preserves both boundaries of a run-property revision", () => {
+    const unchanged = (text: string): Run => ({
+      type: "run",
+      formatting: { fontSizeCs: 22 },
+      content: [{ type: "text", text }],
+    });
+
+    const result = consolidateRuns([
+      unchanged("before"),
+      changedRun("changed"),
+      unchanged("after"),
+    ]);
+
+    expect(result).toHaveLength(3);
+    expect(result.at(1)).toEqual(changedRun("changed"));
+    expect(result.map((run) => run.content.at(0))).toEqual([
+      { type: "text", text: "before" },
+      { type: "text", text: "changed" },
+      { type: "text", text: "after" },
+    ]);
+  });
+});

--- a/packages/core/src/docx/runConsolidator.test.ts
+++ b/packages/core/src/docx/runConsolidator.test.ts
@@ -1,15 +1,25 @@
 import { describe, expect, test } from "bun:test";
-import type { Run } from "../types/document";
-import { consolidateRuns } from "./runConsolidator";
+import { panic } from "better-result";
 
-const changedRun = (text: string): Run => ({
+import type { Hyperlink, Run } from "../types/document";
+import { parseDocumentBody } from "./documentParser";
+import { consolidateParagraphContent, consolidateRuns } from "./runConsolidator";
+import { serializeParagraph } from "./serializer/paragraphSerializer";
+
+const plainRun = (text: string): Run => ({
+  type: "run",
+  formatting: { fontSizeCs: 22 },
+  content: [{ type: "text", text }],
+});
+
+const changedRun = (text: string, id = 1): Run => ({
   type: "run",
   formatting: { fontSizeCs: 22 },
   propertyChanges: [
     {
       type: "runPropertyChange",
       info: {
-        id: 1,
+        id,
         author: "Reviewer",
         date: "2026-09-08T08:00:00Z",
       },
@@ -20,26 +30,111 @@ const changedRun = (text: string): Run => ({
   content: [{ type: "text", text }],
 });
 
+const runText = (run: Run): string =>
+  run.content.map((content) => (content.type === "text" ? content.text : "")).join("");
+
 describe("run consolidation boundaries", () => {
-  test("preserves both boundaries of a run-property revision", () => {
-    const unchanged = (text: string): Run => ({
-      type: "run",
-      formatting: { fontSizeCs: 22 },
-      content: [{ type: "text", text }],
-    });
+  test.each([
+    {
+      name: "at the start",
+      runs: [changedRun("changed"), plainRun("after"), plainRun("end")],
+      expectedText: ["changed", "afterend"],
+      expectedChangedIndex: 0,
+    },
+    {
+      name: "in the middle",
+      runs: [plainRun("before"), changedRun("changed"), plainRun("after")],
+      expectedText: ["before", "changed", "after"],
+      expectedChangedIndex: 1,
+    },
+    {
+      name: "at the end",
+      runs: [plainRun("before"), plainRun("middle"), changedRun("changed")],
+      expectedText: ["beforemiddle", "changed"],
+      expectedChangedIndex: 1,
+    },
+  ])(
+    "keeps a run-property revision range $name",
+    ({ runs, expectedText, expectedChangedIndex }) => {
+      const result = consolidateRuns(runs);
 
+      expect(result.map(runText)).toEqual(expectedText);
+      expect(result.at(expectedChangedIndex)).toEqual(changedRun("changed"));
+      expect(result.filter((run) => run.propertyChanges?.length).map(runText)).toEqual(["changed"]);
+    },
+  );
+
+  test("keeps adjacent run-property revisions separate", () => {
     const result = consolidateRuns([
-      unchanged("before"),
-      changedRun("changed"),
-      unchanged("after"),
+      plainRun("before"),
+      changedRun("first", 1),
+      changedRun("second", 2),
+      plainRun("after"),
     ]);
 
-    expect(result).toHaveLength(3);
-    expect(result.at(1)).toEqual(changedRun("changed"));
-    expect(result.map((run) => run.content.at(0))).toEqual([
-      { type: "text", text: "before" },
-      { type: "text", text: "changed" },
-      { type: "text", text: "after" },
+    expect(result.map(runText)).toEqual(["before", "first", "second", "after"]);
+    expect(result.map((run) => run.propertyChanges?.at(0)?.info.id)).toEqual([
+      undefined,
+      1,
+      2,
+      undefined,
     ]);
+  });
+
+  test("keeps a run-property revision range inside a hyperlink", () => {
+    const hyperlink: Hyperlink = {
+      type: "hyperlink",
+      href: "https://example.test",
+      children: [plainRun("before"), changedRun("changed"), plainRun("after")],
+    };
+
+    const result = consolidateParagraphContent([hyperlink]);
+
+    expect(result).toHaveLength(1);
+    expect(result.at(0)).toEqual({
+      ...hyperlink,
+      children: [plainRun("before"), changedRun("changed"), plainRun("after")],
+    });
+  });
+
+  test("merges runs when their property-change collection is empty", () => {
+    const result = consolidateRuns([
+      { ...plainRun("before"), propertyChanges: [] },
+      { ...plainRun("after"), propertyChanges: [] },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result.map(runText)).toEqual(["beforeafter"]);
+  });
+
+  test("keeps the changed text in its own serialized run after parsing", () => {
+    const body = parseDocumentBody(`
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>
+          <w:p>
+            <w:r><w:rPr><w:szCs w:val="22"/></w:rPr><w:t>before</w:t></w:r>
+            <w:r><w:rPr><w:szCs w:val="22"/><w:rPrChange w:id="1" w:author="Reviewer" w:date="2026-09-08T08:00:00Z"><w:rPr><w:b/><w:szCs w:val="22"/></w:rPr></w:rPrChange></w:rPr><w:t>changed</w:t></w:r>
+            <w:r><w:rPr><w:szCs w:val="22"/></w:rPr><w:t>after</w:t></w:r>
+          </w:p>
+        </w:body>
+      </w:document>
+    `);
+    const paragraph = body.content.at(0);
+
+    expect(paragraph?.type).toBe("paragraph");
+    if (paragraph?.type !== "paragraph") {
+      panic("Expected parsed paragraph");
+    }
+
+    expect(paragraph.content.filter((content) => content.type === "run").map(runText)).toEqual([
+      "before",
+      "changed",
+      "after",
+    ]);
+
+    const xml = serializeParagraph(paragraph);
+    expect(xml).toMatch(
+      /<w:r>[^]*?<w:t>before<\/w:t><\/w:r><w:r><w:rPr>[^]*?<w:rPrChange\b[^]*?<\/w:rPrChange><\/w:rPr><w:t>changed<\/w:t><\/w:r><w:r>[^]*?<w:t>after<\/w:t><\/w:r>/u,
+    );
   });
 });

--- a/packages/core/src/docx/runConsolidator.ts
+++ b/packages/core/src/docx/runConsolidator.ts
@@ -266,6 +266,13 @@ function isMergeableContent(content: RunContent): boolean {
  * Runs with breaks, tabs, images, fields, etc. act as merge boundaries
  */
 export function canMergeRun(run: Run): boolean {
+  // A run-property revision owns an exact text range. Merging either boundary
+  // would discard that range because a consolidated run can carry only one
+  // property-change collection.
+  if (run.propertyChanges && run.propertyChanges.length > 0) {
+    return false;
+  }
+
   // Empty runs can be merged
   if (run.content.length === 0) {
     return true;


### PR DESCRIPTION
## Summary

- Keep runs carrying `w:rPrChange` separate during parser consolidation.
- Preserve the exact text range owned by each run-property revision, including adjacent revisions and revisions inside hyperlinks.
- Leave empty property-change collections mergeable.

## Validation

- 7 focused consolidation and parse-to-serialize tests pass.
- `@stll/folio-core` typecheck passes.
- `@stll/folio-core` build passes.
- Tests cover revision boundaries at the start, middle, and end; adjacent revisions; hyperlinks; empty collections; and serialized OOXML.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the exact text ranges of run-property revisions when parsing and serialising DOCX files.
  * Prevented revised text from being incorrectly merged with adjacent content.
  * Maintained revision boundaries within hyperlinks and across adjacent runs.

* **Tests**
  * Added coverage for revision boundaries, empty property changes, hyperlinks, and full parse-and-serialise round trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->