### PR TITLE
chore(core): accept template-conditions across 0.x minors

### DIFF
--- a/.changeset/wide-template-conditions-range.md
+++ b/.changeset/wide-template-conditions-range.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Widen the `@stll/template-conditions` dependency to `>=0.4.0 <1.0.0`. folio-core consumes only the scanner surface, so a host monorepo that already provides template-conditions as a workspace package satisfies the range across 0.x minors instead of installing a second registry copy beside its own.

--- a/bun.lock
+++ b/bun.lock
@@ -59,7 +59,7 @@
       "dependencies": {
         "@stll/docx-core": "workspace:^",
         "@stll/docx-utils": "^0.1.0",
-        "@stll/template-conditions": "^0.4.0",
+        "@stll/template-conditions": ">=0.4.0 <1.0.0",
         "better-result": "3.0.1",
         "csstype": "^3.1.3",
         "dompurify": "^3.4.13",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@stll/docx-core": "workspace:^",
     "@stll/docx-utils": "^0.1.0",
-    "@stll/template-conditions": "^0.4.0",
+    "@stll/template-conditions": ">=0.4.0 <1.0.0",
     "better-result": "3.0.1",
     "csstype": "^3.1.3",
     "dompurify": "^3.4.13",


### PR DESCRIPTION
`packages/core` declared `"@stll/template-conditions": "^0.4.0"`. A caret on a 0.x version pins the minor, so every template-conditions minor forces a folio release just to move the range, and until that release lands a consumer that already provides template-conditions as a workspace package installs a second registry copy of the grammar beside its own.

folio-core consumes only the scanner surface (`scanMarkers`, `isBlockDirectiveKind`, `assertNever`, and the `MarkerMeta` / `DirectiveKind` types), which is the stable part of the package, so `>=0.4.0 <1.0.0` matches what it actually depends on.

- `packages/core/package.json`: range widened to `>=0.4.0 <1.0.0`.
- `bun.lock`: regenerated in place by `bun install`; the resolved version is unchanged at 0.4.0 (0.4.0 is the newest published release).
- Patch changeset for `@stll/folio-core`.

No other package is touched. `check:dependencies`, `check:lockfile-versions`, `check:quarantine-excludes`, `check:dedupe`, and `format:check` pass locally; none of them constrain external dependency range syntax.
