### PR TITLE
fix(core): bound and anchor inline word diffs

### DIFF
--- a/.changeset/tidy-inline-anchors.md
+++ b/.changeset/tidy-inline-anchors.md
@@ -2,6 +2,9 @@
 "@stll/folio-core": patch
 ---
 
-Keep a unique term aligned when repeated boilerplate admits several equally
-short inline diffs. Long paragraphs now factor common text and unique anchors
-before bounded LCS work, using compact storage for the residual gaps.
+Keep unique terms aligned without inventing opposite-direction edits. Long
+paragraphs factor common text and unique anchors before bounded LCS work, and
+one compact work allowance now covers each document comparison or apply batch.
+Atomic preflight preserves that allowance with a coarse zero-DP check.
+Normalized comparison-key storage is capped before allocation. The generated
+declaration budget rises by 15 lines for the internal shared-session helpers.

--- a/.changeset/tidy-inline-anchors.md
+++ b/.changeset/tidy-inline-anchors.md
@@ -1,0 +1,7 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep a unique term aligned when repeated boilerplate admits several equally
+short inline diffs. Long paragraphs now factor common text and unique anchors
+before bounded LCS work, using compact storage for the residual gaps.

--- a/packages/core/src/ai-edits/aiEdits.test.ts
+++ b/packages/core/src/ai-edits/aiEdits.test.ts
@@ -1682,52 +1682,77 @@ describe("Folio AI edit operations", () => {
     expect(marksByText[" sixty"]).toContain("insertion");
   });
 
-  test("replacement operations share one bounded inline-diff allowance per batch", () => {
-    const alternating = (first: string, second: string): string =>
-      Array.from({ length: 2000 }, (_unused, index) => (index % 2 === 0 ? first : second)).join(
-        " ",
+  test.each(["replaceBlock", "replaceInBlock", "mixed"] as const)(
+    "%s replacements share one bounded inline-diff allowance and remain reversible",
+    (operationKind) => {
+      const alternating = (first: string, second: string): string =>
+        Array.from({ length: 2000 }, (_unused, index) => (index % 2 === 0 ? first : second)).join(
+          " ",
+        );
+      const before = alternating("a", "b");
+      const after = alternating("b", "a");
+
+      const applyBatch = () => {
+        const view = makeView(makeState([before, before, before]));
+        const snapshot = createFolioAIEditSnapshot(view.state.doc);
+        const operations = snapshot.blocks.map(({ id }, index) => {
+          const replaceWholeBlock =
+            operationKind === "replaceBlock" || (operationKind === "mixed" && index % 2 === 0);
+          return replaceWholeBlock
+            ? {
+                id: `replace-${String(index)}`,
+                type: "replaceBlock" as const,
+                blockId: id,
+                text: after,
+              }
+            : {
+                id: `replace-${String(index)}`,
+                type: "replaceInBlock" as const,
+                blockId: id,
+                find: before,
+                replace: after,
+              };
+        });
+        const result = applyFolioAIEditOperations({
+          view,
+          snapshot,
+          operations,
+          revisionStamp: { date: "2026-09-08T12:00:00.000Z", idSeed: 100 },
+        });
+        expect(result.skipped).toEqual([]);
+        return view;
+      };
+
+      const first = applyBatch();
+      const hasUnmarkedText = (blockIndex: number): boolean => {
+        let found = false;
+        first.state.doc.child(blockIndex).descendants((node) => {
+          if (node.isText && node.marks.length === 0) {
+            found = true;
+          }
+        });
+        return found;
+      };
+
+      // Operations execute from the end of the document. The first replacement
+      // spends the 4M-cell allowance; later replacements deterministically use
+      // one coarse deletion/insertion pair.
+      expect(hasUnmarkedText(2)).toBe(true);
+      expect(hasUnmarkedText(1)).toBe(false);
+      expect(hasUnmarkedText(0)).toBe(false);
+      expect(applyBatch().state.doc.toJSON()).toEqual(first.state.doc.toJSON());
+
+      const accepting = makeView(first.state);
+      acceptAllChanges()(accepting.state, accepting.dispatch);
+      expect(accepting.state.doc.toJSON()).toEqual(makeState([after, after, after]).doc.toJSON());
+
+      const rejecting = makeView(first.state);
+      rejectAllChanges()(rejecting.state, rejecting.dispatch);
+      expect(rejecting.state.doc.toJSON()).toEqual(
+        makeState([before, before, before]).doc.toJSON(),
       );
-    const before = alternating("a", "b");
-    const after = alternating("b", "a");
-
-    const applyBatch = () => {
-      const view = makeView(makeState([before, before, before]));
-      const snapshot = createFolioAIEditSnapshot(view.state.doc);
-      const operations = snapshot.blocks.map(({ id }, index) => ({
-        id: `replace-${String(index)}`,
-        type: "replaceBlock" as const,
-        blockId: id,
-        text: after,
-      }));
-      const result = applyFolioAIEditOperations({
-        view,
-        snapshot,
-        operations,
-        revisionStamp: { date: "2026-09-08T12:00:00.000Z", idSeed: 100 },
-      });
-      expect(result.skipped).toEqual([]);
-      return view.state.doc;
-    };
-
-    const first = applyBatch();
-    const hasUnmarkedText = (blockIndex: number): boolean => {
-      let found = false;
-      first.child(blockIndex).descendants((node) => {
-        if (node.isText && node.marks.length === 0) {
-          found = true;
-        }
-      });
-      return found;
-    };
-
-    // Operations execute from the end of the document. The first replacement
-    // spends the 4M-cell allowance; later replacements deterministically use
-    // one coarse deletion/insertion pair.
-    expect(hasUnmarkedText(2)).toBe(true);
-    expect(hasUnmarkedText(1)).toBe(false);
-    expect(hasUnmarkedText(0)).toBe(false);
-    expect(applyBatch().toJSON()).toEqual(first.toJSON());
-  });
+    },
+  );
 
   test("atomic preflight cannot spend the committed batch's inline-diff allowance", () => {
     const alternating = (first: string, second: string): string =>

--- a/packages/core/src/ai-edits/aiEdits.test.ts
+++ b/packages/core/src/ai-edits/aiEdits.test.ts
@@ -5,15 +5,17 @@ import type { Transaction } from "prosemirror-state";
 import { TableMap } from "prosemirror-tables";
 import { ReplaceStep } from "prosemirror-transform";
 
+import { applyFolioDocumentOperations } from "../document-operations";
 import {
   acceptAIEditRevision,
   acceptAllChanges,
   rejectAIEditRevision,
   rejectAllChanges,
 } from "../prosemirror/commands/comments";
-import { applyFolioAIEditOperations } from "./apply";
+import { applyFolioAIEditOperations, type FolioWordDiffOptions } from "./apply";
 import { getTrackedChangesFromDoc } from "./read";
 import { createFolioAIEditSnapshot, createFolioAITextRangeHandle } from "./snapshot";
+import { createScopedWordDiffOptions } from "./word-diff";
 
 const schema = new Schema({
   nodes: {
@@ -1678,6 +1680,142 @@ describe("Folio AI edit operations", () => {
     expect(marksByText[" must"]).toContain("insertion");
     expect(marksByText[" thirty"]).toContain("deletion");
     expect(marksByText[" sixty"]).toContain("insertion");
+  });
+
+  test("replacement operations share one bounded inline-diff allowance per batch", () => {
+    const alternating = (first: string, second: string): string =>
+      Array.from({ length: 2000 }, (_unused, index) => (index % 2 === 0 ? first : second)).join(
+        " ",
+      );
+    const before = alternating("a", "b");
+    const after = alternating("b", "a");
+
+    const applyBatch = () => {
+      const view = makeView(makeState([before, before, before]));
+      const snapshot = createFolioAIEditSnapshot(view.state.doc);
+      const operations = snapshot.blocks.map(({ id }, index) => ({
+        id: `replace-${String(index)}`,
+        type: "replaceBlock" as const,
+        blockId: id,
+        text: after,
+      }));
+      const result = applyFolioAIEditOperations({
+        view,
+        snapshot,
+        operations,
+        revisionStamp: { date: "2026-09-08T12:00:00.000Z", idSeed: 100 },
+      });
+      expect(result.skipped).toEqual([]);
+      return view.state.doc;
+    };
+
+    const first = applyBatch();
+    const hasUnmarkedText = (blockIndex: number): boolean => {
+      let found = false;
+      first.child(blockIndex).descendants((node) => {
+        if (node.isText && node.marks.length === 0) {
+          found = true;
+        }
+      });
+      return found;
+    };
+
+    // Operations execute from the end of the document. The first replacement
+    // spends the 4M-cell allowance; later replacements deterministically use
+    // one coarse deletion/insertion pair.
+    expect(hasUnmarkedText(2)).toBe(true);
+    expect(hasUnmarkedText(1)).toBe(false);
+    expect(hasUnmarkedText(0)).toBe(false);
+    expect(applyBatch().toJSON()).toEqual(first.toJSON());
+  });
+
+  test("atomic preflight cannot spend the committed batch's inline-diff allowance", () => {
+    const alternating = (first: string, second: string): string =>
+      Array.from({ length: 2000 }, (_unused, index) => (index % 2 === 0 ? first : second)).join(
+        " ",
+      );
+    const before = alternating("a", "b");
+    const after = alternating("b", "a");
+    const applyBatch = ({
+      batchMode,
+      wordDiff,
+    }: {
+      batchMode: "atomic" | "best-effort";
+      wordDiff: FolioWordDiffOptions;
+    }) => {
+      const view = makeView(makeState([before, before, before]));
+      const snapshot = createFolioAIEditSnapshot(view.state.doc);
+      const result = applyFolioDocumentOperations({
+        view,
+        snapshot,
+        batch: {
+          version: 1,
+          mode: "tracked-changes",
+          ...(batchMode === "atomic" && { atomic: true }),
+          operations: snapshot.blocks.map(({ id }, index) => ({
+            id: `replace-${String(index)}`,
+            type: "replaceBlock" as const,
+            blockId: id,
+            text: after,
+          })),
+        },
+        wordDiff,
+        revisionStamp: { date: "2026-09-08T12:00:00.000Z", idSeed: 100 },
+      });
+      expect(result.status).toBe("committed");
+      expect(result.skipped).toEqual([]);
+      return view.state.doc;
+    };
+
+    const bestEffort = applyBatch({
+      batchMode: "best-effort",
+      wordDiff: createScopedWordDiffOptions({}),
+    });
+    const atomic = applyBatch({
+      batchMode: "atomic",
+      wordDiff: createScopedWordDiffOptions({}),
+    });
+    expect(atomic.toJSON()).toEqual(bestEffort.toJSON());
+
+    let granularityReads = 0;
+    applyBatch({
+      batchMode: "atomic",
+      wordDiff: {
+        get granularity() {
+          granularityReads++;
+          return "word" as const;
+        },
+      },
+    });
+    expect(granularityReads).toBe(1);
+  });
+
+  test("coarse atomic preflight keeps emphasis-stripped replacements as no-ops", () => {
+    const view = makeView(makeState(["Date"]));
+    const snapshot = createFolioAIEditSnapshot(view.state.doc);
+    const before = view.state.doc.toJSON();
+
+    const result = applyFolioDocumentOperations({
+      view,
+      snapshot,
+      batch: {
+        version: 1,
+        atomic: true,
+        mode: "tracked-changes",
+        operations: [
+          {
+            id: "markers-only",
+            type: "replaceBlock",
+            blockId: snapshot.blocks[0]?.id ?? "missing",
+            text: "**Date**",
+          },
+        ],
+      },
+    });
+
+    expect(result.status).toBe("rejected");
+    expect(result.skipped).toEqual([{ id: "markers-only", reason: "noopOperation" }]);
+    expect(view.state.doc.toJSON()).toEqual(before);
   });
 
   test("snapshot and apply ignore existing tracked-change marks", () => {

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -82,7 +82,11 @@ import type {
   FolioAIEditSkippedOperation,
   FolioAISignatureParty,
 } from "./types";
-import { diffWordSegments, type WordDiffGranularity } from "./word-diff";
+import {
+  createWordDiffSession,
+  type WordDiffGranularity,
+  wordDiffSessionFromOptions,
+} from "./word-diff";
 
 /**
  * The only editor surface the apply logic touches: a current `state`
@@ -144,6 +148,23 @@ type ApplyFolioAIEditOperationsOptions = {
 
 type ApplyFolioAIEditOperationsInternalOptions = ApplyFolioAIEditOperationsOptions & {
   revisionIdSeed?: number;
+  wordDiffMode?: "bounded" | "coarse";
+};
+
+const coarseWordDiff: ReturnType<typeof createWordDiffSession>["diff"] = (before, after) => {
+  if (before === after) {
+    return before.length === 0 ? [] : [{ type: "equal", text: before }];
+  }
+  if (before.length === 0) {
+    return [{ type: "ins", text: after }];
+  }
+  if (after.length === 0) {
+    return [{ type: "del", text: before }];
+  }
+  return [
+    { type: "del", text: before },
+    { type: "ins", text: after },
+  ];
 };
 
 /**
@@ -1625,6 +1646,7 @@ const applyFolioAIEditOperationsInternal = ({
   revisionStamp,
   revisionIdSeed,
   wordDiff,
+  wordDiffMode = "bounded",
   tableTemplates,
 }: ApplyFolioAIEditOperationsInternalOptions): FolioAIEditApplyOutcome => {
   const applied: FolioAIEditAppliedOperation[] = [];
@@ -1648,6 +1670,8 @@ const applyFolioAIEditOperationsInternal = ({
   };
   const claimedTableRows = new Set<string>();
   const claimedTableColumns = new Set<string>();
+  const diffText: ReturnType<typeof createWordDiffSession>["diff"] =
+    wordDiffMode === "coarse" ? coarseWordDiff : wordDiffSessionFromOptions(wordDiff).diff;
 
   // `"suggested"` is `"tracked-changes"` plus a provenance stamp, so every
   // tracked-change code path below keys off this rather than an exact
@@ -2000,7 +2024,7 @@ const applyFolioAIEditOperationsInternal = ({
           commentMark,
           suggestionId,
           initials,
-          granularity: wordDiff?.granularity ?? "word",
+          diffText,
         });
         if (producesTrackedChanges) {
           appliedRevisionIds = [
@@ -2122,7 +2146,7 @@ const applyFolioAIEditOperationsInternal = ({
             commentMark,
             suggestionId,
             initials,
-            granularity: wordDiff?.granularity ?? "word",
+            diffText,
           });
         }
         const styleResult = applyReplaceBlockStyleId({
@@ -2829,6 +2853,7 @@ export const previewFolioAIEditOperations = (
       createCommentId: () => previewCommentId--,
     }),
     revisionIdSeed: -1_000_000_000,
+    wordDiffMode: "coarse",
   });
   return {
     applied: result.applied.map(({ id }) => ({ id })),
@@ -2862,8 +2887,8 @@ type TextReplacementOptions = {
   suggestionId?: string | null;
   /** Optional author initials stamped on the produced marks. */
   initials?: string | undefined;
-  /** Token size the redline is cut at. */
-  granularity: WordDiffGranularity;
+  /** Shares the batch's bounded inline-diff work allowance. */
+  diffText: ReturnType<typeof createWordDiffSession>["diff"];
 };
 
 const applyTextReplacement = ({
@@ -2877,7 +2902,7 @@ const applyTextReplacement = ({
   commentMark,
   suggestionId = null,
   initials,
-  granularity,
+  diffText,
 }: TextReplacementOptions): Transaction => {
   let nextTr = tr;
   const replacement = stripInlineEmphasisMarkers(
@@ -2972,7 +2997,7 @@ const applyTextReplacement = ({
   }
 
   if (sourceText !== null && cleanBlock !== null) {
-    const segments = diffWordSegments(sourceText, replacement, { granularity });
+    const segments = diffText(sourceText, replacement);
     const offsets = cleanBlock.offsets;
     const offsetAt = (cleanOffset: number): number | null => offsets[cleanOffset] ?? null;
 

--- a/packages/core/src/ai-edits/headless.test.ts
+++ b/packages/core/src/ai-edits/headless.test.ts
@@ -2028,6 +2028,42 @@ describe("headless docx review round-trip", () => {
     }
   });
 
+  test("story-scoped headless apply honors character-granularity redlines", async () => {
+    const baseline = await makeHeaderFooterBaseline();
+    const story = { type: "header", relationshipId: HEADER_RELATIONSHIP_ID } as const;
+    const reviewer = await FolioDocxReviewer.fromBuffer(baseline);
+    const snapshot = reviewer.snapshotStory(story);
+    if (!snapshot) {
+      throw new Error("expected the header story");
+    }
+    const target = findBlock(snapshot.blocks, "Header text");
+
+    const result = reviewer.applyDocumentOperationsToStory({
+      story,
+      snapshot,
+      batch: {
+        version: 1,
+        mode: "tracked-changes",
+        operations: [
+          {
+            id: "character-story",
+            type: "replaceInBlock",
+            blockId: target.id,
+            find: "Header",
+            replace: "Heater",
+          },
+        ],
+      },
+      wordDiff: { granularity: "character" },
+      revisionStamp: { date: "2026-09-08T12:00:00.000Z", idSeed: 100 },
+    });
+
+    expect(result.status).toBe("committed");
+    expect(reviewer.readReviewedStory({ story, view: "current-markup" })?.text).toContain(
+      'Hea<del author="AI">d</del><ins author="AI">t</ins>er text',
+    );
+  });
+
   test("applyDocumentOperations executes a versioned tracked-change batch", async () => {
     const baseline = await makeParaIdBaseline(readFixture());
     const reviewer = await FolioDocxReviewer.fromBuffer(baseline, { author: "AI Reviewer" });

--- a/packages/core/src/ai-edits/headless.test.ts
+++ b/packages/core/src/ai-edits/headless.test.ts
@@ -1996,6 +1996,38 @@ describe("headless docx review round-trip", () => {
     );
   });
 
+  test("both headless apply entry points honor character-granularity redlines", async () => {
+    const baseline = await makeParaIdBaseline(readFixture());
+    for (const entryPoint of ["operations", "document-operations"] as const) {
+      const reviewer = await FolioDocxReviewer.fromBuffer(baseline);
+      const target = findBlock(reviewer.snapshot().blocks, "Heading");
+      const operation = {
+        id: `character-${entryPoint}`,
+        type: "replaceInBlock" as const,
+        blockId: target.id,
+        find: "Heading",
+        replace: "Hearing",
+      };
+      const options = {
+        wordDiff: { granularity: "character" as const },
+        revisionStamp: { date: "2026-09-08T12:00:00.000Z", idSeed: 100 },
+      };
+
+      if (entryPoint === "operations") {
+        reviewer.applyOperations([operation], options);
+      } else {
+        reviewer.applyDocumentOperations(
+          { version: 1, mode: "tracked-changes", operations: [operation] },
+          options,
+        );
+      }
+
+      expect(reviewer.getContentAsText({ annotated: true })).toContain(
+        'Hea<del author="AI">d</del><ins author="AI">r</ins>ing paragraph.',
+      );
+    }
+  });
+
   test("applyDocumentOperations executes a versioned tracked-change batch", async () => {
     const baseline = await makeParaIdBaseline(readFixture());
     const reviewer = await FolioDocxReviewer.fromBuffer(baseline, { author: "AI Reviewer" });

--- a/packages/core/src/ai-edits/headless.ts
+++ b/packages/core/src/ai-edits/headless.ts
@@ -839,6 +839,7 @@ export class FolioDocxReviewer {
       },
       ...(options.snapshot !== undefined && { snapshot: options.snapshot }),
       ...(options.revisionStamp !== undefined && { revisionStamp: options.revisionStamp }),
+      ...(options.wordDiff !== undefined && { wordDiff: options.wordDiff }),
       createUndoEntry: false,
     });
     return { applied, skipped };
@@ -859,6 +860,7 @@ export class FolioDocxReviewer {
       batch,
       ...(options.snapshot !== undefined && { snapshot: options.snapshot }),
       ...(options.revisionStamp !== undefined && { revisionStamp: options.revisionStamp }),
+      ...(options.wordDiff !== undefined && { wordDiff: options.wordDiff }),
       createUndoEntry: true,
     });
   }

--- a/packages/core/src/ai-edits/word-diff.test.ts
+++ b/packages/core/src/ai-edits/word-diff.test.ts
@@ -13,7 +13,7 @@ import { describe, expect, test } from "bun:test";
 import fc from "fast-check";
 
 import { propertyConfig } from "../../../../test/property-testing";
-import { diffWordSegments, type WordDiffSegment } from "./word-diff";
+import { createWordDiffSession, diffWordSegments, type WordDiffSegment } from "./word-diff";
 
 const rebuildBefore = (segments: readonly WordDiffSegment[]): string =>
   segments
@@ -74,6 +74,46 @@ describe("diffWordSegments", () => {
         },
       ),
       propertyConfig({ numRuns: 200 }),
+    );
+  });
+
+  test("a token-subsequence edit never invents the opposite change direction", () => {
+    const tokenSequence = fc.array(fc.tuple(fc.constantFrom("a", "b", "c"), fc.boolean()), {
+      maxLength: 9,
+    });
+    fc.assert(
+      fc.property(tokenSequence, (entries) => {
+        const whole = entries.map(([token]) => token).join("");
+        const subsequence = entries
+          .filter(([, retained]) => retained)
+          .map(([token]) => token)
+          .join("");
+
+        const insertion = diffWordSegments(subsequence, whole, { granularity: "character" });
+        expect(insertion.some(({ type }) => type === "del")).toBe(false);
+        expect(rebuildBefore(insertion)).toBe(subsequence);
+        expect(rebuildAfter(insertion)).toBe(whole);
+
+        const deletion = diffWordSegments(whole, subsequence, { granularity: "character" });
+        expect(deletion.some(({ type }) => type === "ins")).toBe(false);
+        expect(rebuildBefore(deletion)).toBe(whole);
+        expect(rebuildAfter(deletion)).toBe(subsequence);
+
+        const wholeWords = ["anchor", ...entries.map(([token]) => token)].join(" ");
+        const subsequenceWords = [
+          "anchor",
+          ...entries.filter(([, retained]) => retained).map(([token]) => token),
+        ].join(" ");
+        const wordInsertion = diffWordSegments(subsequenceWords, wholeWords);
+        expect(wordInsertion.some(({ type }) => type === "del")).toBe(false);
+        expect(rebuildBefore(wordInsertion)).toBe(subsequenceWords);
+        expect(rebuildAfter(wordInsertion)).toBe(wholeWords);
+        const wordDeletion = diffWordSegments(wholeWords, subsequenceWords);
+        expect(wordDeletion.some(({ type }) => type === "ins")).toBe(false);
+        expect(rebuildBefore(wordDeletion)).toBe(wholeWords);
+        expect(rebuildAfter(wordDeletion)).toBe(subsequenceWords);
+      }),
+      propertyConfig({ numRuns: 500 }),
     );
   });
 
@@ -214,6 +254,20 @@ describe("diffWordSegments", () => {
     }
   });
 
+  test("preserves historical ties when a weak selected anchor would be discarded", () => {
+    expect(diffWordSegments("ab", "aaba", { granularity: "character" })).toEqual([
+      { type: "ins", text: "a" },
+      { type: "equal", text: "ab" },
+      { type: "ins", text: "a" },
+    ]);
+    expect(diffWordSegments("the the clause", "the the the clause the")).toEqual([
+      { type: "equal", text: "the" },
+      { type: "ins", text: " the" },
+      { type: "equal", text: " the clause" },
+      { type: "ins", text: " the" },
+    ]);
+  });
+
   test("character granularity marks the changed letters inside one word", () => {
     expect(diffWordSegments("clause 14.2", "clause 14.3", { granularity: "character" })).toEqual([
       { type: "equal", text: "clause 14." },
@@ -328,5 +382,101 @@ describe("diffWordSegments", () => {
         { type: "ins", text: characterAfter },
       ],
     );
+  });
+
+  test("does not normalize every token after an oversized residual is refused", () => {
+    let caseReads = 0;
+    const normalization = {
+      get case() {
+        caseReads++;
+        return true;
+      },
+    };
+    const before = "ab".repeat(20_000);
+    const after = "ba".repeat(20_000);
+
+    expect(diffWordSegments(before, after, { granularity: "character", normalization })).toEqual([
+      { type: "del", text: before },
+      { type: "ins", text: after },
+    ]);
+    expect(caseReads).toBeLessThanOrEqual(10);
+  });
+
+  test("applies the token-storage gate before a cell-cheap asymmetric residual", () => {
+    let caseReads = 0;
+    const normalization = {
+      get case() {
+        caseReads++;
+        return true;
+      },
+    };
+    const before = "z";
+    const after = "ab".repeat(10_000);
+
+    expect(diffWordSegments(before, after, { granularity: "character", normalization })).toEqual([
+      { type: "del", text: before },
+      { type: "ins", text: after },
+    ]);
+    // Subsequence classification may inspect the long side once. A whole
+    // comparison-key array would inspect every token a second time even
+    // though the combined residual is already above its storage ceiling.
+    expect(caseReads).toBeLessThanOrEqual(after.length + 10);
+  });
+
+  test("applies the code-unit gate before retaining normalized comparison keys", () => {
+    let caseReads = 0;
+    const normalization = {
+      get case() {
+        caseReads++;
+        return true;
+      },
+    };
+    const before = `${"a".repeat(600_000)}x`;
+    const after = `${"b".repeat(600_000)}y`;
+
+    expect(diffWordSegments(before, after, { normalization })).toEqual([
+      { type: "del", text: before },
+      { type: "ins", text: after },
+    ]);
+    // Prefix, suffix, and monotone classification compare the pair once each.
+    // Building either residual or whole-input key arrays would read again.
+    expect(caseReads).toBeLessThanOrEqual(6);
+  });
+
+  test("does not duplicate a capped residual's keys for the whole affixed input", () => {
+    let caseReads = 0;
+    const normalization = {
+      get case() {
+        caseReads++;
+        return true;
+      },
+    };
+    const before = "z";
+    const after = `z${"a".repeat(16_384)}`;
+
+    expect(diffWordSegments(before, after, { granularity: "character", normalization })).toEqual([
+      { type: "equal", text: before },
+      { type: "ins", text: after.slice(1) },
+    ]);
+    expect(caseReads).toBeLessThanOrEqual(16_400);
+  });
+
+  test("shares one dense-cell allowance across a comparison session", () => {
+    const alternating = (first: string, second: string): string =>
+      Array.from({ length: 2000 }, (_unused, index) => (index % 2 === 0 ? first : second)).join(
+        " ",
+      );
+    const before = alternating("a", "b");
+    const after = alternating("b", "a");
+    const session = createWordDiffSession();
+
+    const first = session.diff(before, after);
+    expect(first.some(({ type }) => type === "equal")).toBe(true);
+    expect(session.diff(before, after)).toEqual([
+      { type: "del", text: before },
+      { type: "ins", text: after },
+    ]);
+    // A standalone call owns a fresh allowance.
+    expect(diffWordSegments(before, after)).toEqual(first);
   });
 });

--- a/packages/core/src/ai-edits/word-diff.test.ts
+++ b/packages/core/src/ai-edits/word-diff.test.ts
@@ -35,6 +35,13 @@ const sentence = fc
   })
   .map((words) => words.join(" "));
 
+const unicodeText = fc
+  .array(fc.constantFrom("a", " ", "\n", "😀", "👩‍⚖️", "§", "č", "م", "क", "e\u0301"), {
+    minLength: 0,
+    maxLength: 40,
+  })
+  .map((units) => units.join(""));
+
 describe("diffWordSegments", () => {
   test("both strings reconstruct from the segments, at either granularity", () => {
     fc.assert(
@@ -46,6 +53,24 @@ describe("diffWordSegments", () => {
           const segments = diffWordSegments(before, after, { granularity });
           expect(rebuildBefore(segments)).toBe(before);
           expect(rebuildAfter(segments)).toBe(after);
+        },
+      ),
+      propertyConfig({ numRuns: 200 }),
+    );
+  });
+
+  test("arbitrary Unicode reconstructs exactly and aligns deterministically", () => {
+    fc.assert(
+      fc.property(
+        unicodeText,
+        unicodeText,
+        fc.constantFrom("word" as const, "character" as const),
+        (before, after, granularity) => {
+          const first = diffWordSegments(before, after, { granularity });
+          const second = diffWordSegments(before, after, { granularity });
+          expect(first).toEqual(second);
+          expect(rebuildBefore(first)).toBe(before);
+          expect(rebuildAfter(first)).toBe(after);
         },
       ),
       propertyConfig({ numRuns: 200 }),
@@ -139,6 +164,56 @@ describe("diffWordSegments", () => {
     );
   });
 
+  test("anchors a unique term instead of matching more repeated boilerplate", () => {
+    expect(
+      diffWordSegments("the the the the the SIGNATURE PAGE", "the the SIGNATURE PAGE the the the"),
+    ).toEqual([
+      { type: "equal", text: "the the" },
+      { type: "del", text: " the the the" },
+      { type: "equal", text: " SIGNATURE PAGE" },
+      { type: "ins", text: " the the the" },
+    ]);
+  });
+
+  test("preserves the historical LCS tie break when no unique anchor is selected", () => {
+    const cases = [
+      {
+        before: "aabb",
+        after: "bbaa",
+        granularity: "character" as const,
+        expected: [
+          { type: "del" as const, text: "aa" },
+          { type: "equal" as const, text: "bb" },
+          { type: "ins" as const, text: "aa" },
+        ],
+      },
+      {
+        before: "abab",
+        after: "baba",
+        granularity: "character" as const,
+        expected: [
+          { type: "del" as const, text: "a" },
+          { type: "equal" as const, text: "bab" },
+          { type: "ins" as const, text: "a" },
+        ],
+      },
+      {
+        before: "the the the",
+        after: "the the",
+        granularity: "word" as const,
+        expected: [
+          { type: "equal" as const, text: "the" },
+          { type: "del" as const, text: " the" },
+          { type: "equal" as const, text: " the" },
+        ],
+      },
+    ];
+
+    for (const { before, after, granularity, expected } of cases) {
+      expect(diffWordSegments(before, after, { granularity })).toEqual(expected);
+    }
+  });
+
   test("character granularity marks the changed letters inside one word", () => {
     expect(diffWordSegments("clause 14.2", "clause 14.3", { granularity: "character" })).toEqual([
       { type: "equal", text: "clause 14." },
@@ -198,5 +273,60 @@ describe("diffWordSegments", () => {
       { type: "del", text: before },
       { type: "ins", text: after },
     ]);
+  });
+
+  test("factors a usable common affix before applying the residual cell budget", () => {
+    const shared = Array.from({ length: 2001 }, (_unused, index) => `clause${String(index)}`).join(
+      " ",
+    );
+    const before = `${shared} former`;
+    const after = `${shared} revised`;
+
+    expect(diffWordSegments(before, after)).toEqual([
+      { type: "equal", text: shared },
+      { type: "del", text: " former" },
+      { type: "ins", text: " revised" },
+    ]);
+  });
+
+  test("uses unique anchors when the whole input exceeds the residual cell budget", () => {
+    const shared = Array.from({ length: 2000 }, (_unused, index) => `clause${String(index)}`).join(
+      " ",
+    );
+    const before = `before ${shared} former`;
+    const after = `after ${shared} revised`;
+
+    expect(diffWordSegments(before, after)).toEqual([
+      { type: "del", text: "before" },
+      { type: "ins", text: "after" },
+      { type: "equal", text: ` ${shared}` },
+      { type: "del", text: " former" },
+      { type: "ins", text: " revised" },
+    ]);
+  });
+
+  test("bounds unique-anchor discovery for very large residuals at either granularity", () => {
+    const wordAnchors = Array.from(
+      { length: 8193 },
+      (_unused, index) => `anchor${String(index)}`,
+    ).join(" ");
+    const wordBefore = `before ${wordAnchors} former`;
+    const wordAfter = `after ${wordAnchors} revised`;
+    expect(diffWordSegments(wordBefore, wordAfter)).toEqual([
+      { type: "del", text: wordBefore },
+      { type: "ins", text: wordAfter },
+    ]);
+
+    const characterAnchors = Array.from({ length: 8193 }, (_unused, index) =>
+      String.fromCodePoint(0x10_000 + index),
+    ).join("");
+    const characterBefore = `a${characterAnchors}b`;
+    const characterAfter = `c${characterAnchors}d`;
+    expect(diffWordSegments(characterBefore, characterAfter, { granularity: "character" })).toEqual(
+      [
+        { type: "del", text: characterBefore },
+        { type: "ins", text: characterAfter },
+      ],
+    );
   });
 });

--- a/packages/core/src/ai-edits/word-diff.ts
+++ b/packages/core/src/ai-edits/word-diff.ts
@@ -22,8 +22,10 @@
  * 3. When what survives is still too fragmented for its length, the whole
  *    paragraph is one replacement ({@link isTooFragmented}).
  *
- * O(n*m) on token counts; past {@link MAX_WORD_DIFF_CELLS} the DP is skipped
- * for a single whole-string `del` + `ins` pair.
+ * Common affixes and unique-token anchors split the input into independent
+ * gaps before any quadratic work. The residual gaps share one
+ * {@link MAX_WORD_DIFF_CELLS} allowance per call; once it is spent, a gap is a
+ * single `del` + `ins` pair.
  */
 
 export type WordDiffSegment = {
@@ -145,13 +147,29 @@ const comparisonKey = (token: string, normalization: WordDiffNormalization): str
 const isSeparatorOnly = (text: string): boolean => SEPARATOR_ONLY.test(text);
 
 /**
- * Cell budget for the O(n*m) DP table below. `before`/`after` come from
- * attacker-controlled document text (a `modified` block pair), so an
- * unbounded pair of large strings would otherwise force a quadratic-sized
- * allocation. Past this budget, skip the DP and fall back to a single
- * whole-string `del` + `ins` pair — a coarser diff, but O(1) memory.
+ * Cell budget shared by the residual LCS gaps inside one
+ * {@link diffWordSegments} call. `before`/`after` come from attacker-controlled
+ * document text (a `modified` block pair), so an unbounded pair of large
+ * strings would otherwise force a quadratic-sized allocation. This is not a
+ * document-wide budget: callers diffing several blocks receive one allowance
+ * per call.
  */
 const MAX_WORD_DIFF_CELLS = 4_000_000;
+
+/**
+ * Maximum combined residual tokens considered for unique-anchor discovery.
+ * The token and comparison-key arrays are already required by the public
+ * operation, but the occurrence maps and candidate list are optional linear
+ * storage over attacker-controlled text. Common affixes are removed before
+ * this cap, so a small edit in a very long paragraph can still use anchors.
+ */
+const MAX_WORD_DIFF_ANCHOR_TOKENS = 16_384;
+
+const ALIGNMENT_OPERATION = {
+  Equal: 1,
+  Delete: 2,
+  Insert: 3,
+} as const;
 
 /** One aligned run, before the quality rules turn matches into changes. */
 type DiffRun =
@@ -165,86 +183,434 @@ type AlignOptions = {
   normalization: WordDiffNormalization;
 };
 
-/** The LCS alignment, as runs. Longest common subsequence on comparison keys. */
+type TokenRange = {
+  start: number;
+  end: number;
+};
+
+type TokenAnchor = {
+  beforeIndex: number;
+  afterIndex: number;
+};
+
+type AlignmentBudget = {
+  remainingCells: number;
+};
+
+const pushRun = (runs: DiffRun[], run: DiffRun): void => {
+  const last = runs.at(-1);
+  if (last?.type === "equal" && run.type === "equal") {
+    last.before += run.before;
+    last.after += run.after;
+    last.units += run.units;
+    return;
+  }
+  if (
+    (last?.type === "del" && run.type === "del") ||
+    (last?.type === "ins" && run.type === "ins")
+  ) {
+    last.text += run.text;
+    return;
+  }
+  runs.push(run);
+};
+
+const pushEqualRange = (
+  runs: DiffRun[],
+  before: readonly string[],
+  after: readonly string[],
+  beforeRange: TokenRange,
+  afterRange: TokenRange,
+): void => {
+  const units = beforeRange.end - beforeRange.start;
+  if (units === 0) {
+    return;
+  }
+  pushRun(runs, {
+    type: "equal",
+    before: before.slice(beforeRange.start, beforeRange.end).join(""),
+    after: after.slice(afterRange.start, afterRange.end).join(""),
+    units,
+  });
+};
+
+const pushChangedRange = (
+  runs: DiffRun[],
+  before: readonly string[],
+  after: readonly string[],
+  beforeRange: TokenRange,
+  afterRange: TokenRange,
+): void => {
+  if (beforeRange.start !== beforeRange.end) {
+    pushRun(runs, {
+      type: "del",
+      text: before.slice(beforeRange.start, beforeRange.end).join(""),
+    });
+  }
+  if (afterRange.start !== afterRange.end) {
+    pushRun(runs, {
+      type: "ins",
+      text: after.slice(afterRange.start, afterRange.end).join(""),
+    });
+  }
+};
+
+/**
+ * Unique tokens common to both ranges, reduced to a monotone subsequence of
+ * target positions. Repeated boilerplate is deliberately ineligible: a unique
+ * clause number or name is stronger lineage evidence than another occurrence
+ * of "the" chosen by an arbitrary LCS tie.
+ */
+const findPatienceAnchors = (
+  beforeKeys: readonly string[],
+  afterKeys: readonly string[],
+  beforeRange: TokenRange,
+  afterRange: TokenRange,
+): TokenAnchor[] => {
+  const beforeOccurrences = new Map<string, number>();
+  for (let index = beforeRange.start; index < beforeRange.end; index++) {
+    const key = beforeKeys[index] ?? "";
+    beforeOccurrences.set(key, (beforeOccurrences.get(key) ?? 0) + 1);
+  }
+
+  const afterOccurrences = new Map<string, { count: number; index: number }>();
+  for (let index = afterRange.start; index < afterRange.end; index++) {
+    const key = afterKeys[index] ?? "";
+    const occurrence = afterOccurrences.get(key);
+    if (occurrence) {
+      occurrence.count++;
+    } else {
+      afterOccurrences.set(key, { count: 1, index });
+    }
+  }
+
+  const candidates: TokenAnchor[] = [];
+  for (let beforeIndex = beforeRange.start; beforeIndex < beforeRange.end; beforeIndex++) {
+    const key = beforeKeys[beforeIndex] ?? "";
+    const beforeCount = beforeOccurrences.get(key);
+    const afterOccurrence = afterOccurrences.get(key);
+    if (beforeCount === 1 && afterOccurrence?.count === 1) {
+      candidates.push({ beforeIndex, afterIndex: afterOccurrence.index });
+    }
+  }
+  if (candidates.length < 2) {
+    return candidates;
+  }
+
+  const predecessors = new Int32Array(candidates.length);
+  predecessors.fill(-1);
+  const tailCandidateIndexes = new Int32Array(candidates.length);
+  let tailCount = 0;
+
+  for (const [candidateIndex, candidate] of candidates.entries()) {
+    let low = 0;
+    let high = tailCount;
+    while (low < high) {
+      const middle = low + Math.floor((high - low) / 2);
+      const tail = candidates[tailCandidateIndexes[middle] ?? -1];
+      if (tail && tail.afterIndex < candidate.afterIndex) {
+        low = middle + 1;
+      } else {
+        high = middle;
+      }
+    }
+    if (low > 0) {
+      predecessors[candidateIndex] = tailCandidateIndexes[low - 1] ?? -1;
+    }
+    tailCandidateIndexes[low] = candidateIndex;
+    if (low === tailCount) {
+      tailCount++;
+    }
+  }
+
+  const anchors: TokenAnchor[] = [];
+  let candidateIndex = tailCandidateIndexes[tailCount - 1] ?? -1;
+  while (candidateIndex >= 0) {
+    const candidate = candidates[candidateIndex];
+    if (candidate) {
+      anchors.push(candidate);
+    }
+    candidateIndex = predecessors[candidateIndex] ?? -1;
+  }
+  anchors.reverse();
+  return anchors;
+};
+
+type DenseGapOptions = {
+  before: readonly string[];
+  after: readonly string[];
+  beforeKeys: readonly string[];
+  afterKeys: readonly string[];
+  beforeRange: TokenRange;
+  afterRange: TokenRange;
+  runs: DiffRun[];
+  budget: AlignmentBudget;
+};
+
+/** Longest-common-subsequence alignment for one residual, bounded gap. */
+const alignDenseGap = ({
+  before,
+  after,
+  beforeKeys,
+  afterKeys,
+  beforeRange,
+  afterRange,
+  runs,
+  budget,
+}: DenseGapOptions): void => {
+  const beforeLength = beforeRange.end - beforeRange.start;
+  const afterLength = afterRange.end - afterRange.start;
+  if (beforeLength === 0 || afterLength === 0) {
+    pushChangedRange(runs, before, after, beforeRange, afterRange);
+    return;
+  }
+
+  if (beforeLength > Math.floor(budget.remainingCells / afterLength)) {
+    pushChangedRange(runs, before, after, beforeRange, afterRange);
+    return;
+  }
+  const cellCount = beforeLength * afterLength;
+  budget.remainingCells -= cellCount;
+
+  // No nested JS arrays: at the maximum allowance this table is exactly
+  // 16 MB, and the operation trace below is at most m+n bytes.
+  const lengths = new Uint32Array(cellCount);
+  for (let beforeOffset = 0; beforeOffset < beforeLength; beforeOffset++) {
+    for (let afterOffset = 0; afterOffset < afterLength; afterOffset++) {
+      const index = beforeOffset * afterLength + afterOffset;
+      const beforeKey = beforeKeys[beforeRange.start + beforeOffset];
+      const afterKey = afterKeys[afterRange.start + afterOffset];
+      if (beforeKey === afterKey) {
+        const diagonal =
+          beforeOffset > 0 && afterOffset > 0
+            ? (lengths[(beforeOffset - 1) * afterLength + afterOffset - 1] ?? 0)
+            : 0;
+        lengths[index] = diagonal + 1;
+        continue;
+      }
+      const above =
+        beforeOffset > 0 ? (lengths[(beforeOffset - 1) * afterLength + afterOffset] ?? 0) : 0;
+      const left = afterOffset > 0 ? (lengths[index - 1] ?? 0) : 0;
+      lengths[index] = Math.max(above, left);
+    }
+  }
+
+  const reversedOperations = new Uint8Array(beforeLength + afterLength);
+  let operationCount = 0;
+  let beforeOffset = beforeLength - 1;
+  let afterOffset = afterLength - 1;
+  while (beforeOffset >= 0 && afterOffset >= 0) {
+    if (
+      beforeKeys[beforeRange.start + beforeOffset] === afterKeys[afterRange.start + afterOffset]
+    ) {
+      reversedOperations[operationCount++] = ALIGNMENT_OPERATION.Equal;
+      beforeOffset--;
+      afterOffset--;
+      continue;
+    }
+    const above =
+      beforeOffset > 0 ? (lengths[(beforeOffset - 1) * afterLength + afterOffset] ?? 0) : 0;
+    const left = afterOffset > 0 ? (lengths[beforeOffset * afterLength + afterOffset - 1] ?? 0) : 0;
+    // Preserve the old LCS tie break. Because this trace is reversed, choosing
+    // insertion on a tie yields deletion before insertion in forward order.
+    if (above > left) {
+      reversedOperations[operationCount++] = ALIGNMENT_OPERATION.Delete;
+      beforeOffset--;
+    } else {
+      reversedOperations[operationCount++] = ALIGNMENT_OPERATION.Insert;
+      afterOffset--;
+    }
+  }
+  while (beforeOffset >= 0) {
+    reversedOperations[operationCount++] = ALIGNMENT_OPERATION.Delete;
+    beforeOffset--;
+  }
+  while (afterOffset >= 0) {
+    reversedOperations[operationCount++] = ALIGNMENT_OPERATION.Insert;
+    afterOffset--;
+  }
+
+  let beforeCursor = beforeRange.start;
+  let afterCursor = afterRange.start;
+  for (let operationIndex = operationCount - 1; operationIndex >= 0; operationIndex--) {
+    const operation = reversedOperations[operationIndex];
+    if (operation === ALIGNMENT_OPERATION.Equal) {
+      pushRun(runs, {
+        type: "equal",
+        before: before[beforeCursor] ?? "",
+        after: after[afterCursor] ?? "",
+        units: 1,
+      });
+      beforeCursor++;
+      afterCursor++;
+      continue;
+    }
+    if (operation === ALIGNMENT_OPERATION.Delete) {
+      pushRun(runs, { type: "del", text: before[beforeCursor] ?? "" });
+      beforeCursor++;
+      continue;
+    }
+    pushRun(runs, { type: "ins", text: after[afterCursor] ?? "" });
+    afterCursor++;
+  }
+};
+
+/** Factor exact boundary matches before spending the residual DP allowance. */
+const alignGap = (options: DenseGapOptions): void => {
+  const { beforeKeys, afterKeys, runs } = options;
+  let beforeStart = options.beforeRange.start;
+  let afterStart = options.afterRange.start;
+  const beforeEnd = options.beforeRange.end;
+  const afterEnd = options.afterRange.end;
+
+  while (
+    beforeStart < beforeEnd &&
+    afterStart < afterEnd &&
+    beforeKeys[beforeStart] === afterKeys[afterStart]
+  ) {
+    beforeStart++;
+    afterStart++;
+  }
+  pushEqualRange(
+    runs,
+    options.before,
+    options.after,
+    { start: options.beforeRange.start, end: beforeStart },
+    { start: options.afterRange.start, end: afterStart },
+  );
+
+  let beforeMiddleEnd = beforeEnd;
+  let afterMiddleEnd = afterEnd;
+  while (
+    beforeMiddleEnd > beforeStart &&
+    afterMiddleEnd > afterStart &&
+    beforeKeys[beforeMiddleEnd - 1] === afterKeys[afterMiddleEnd - 1]
+  ) {
+    beforeMiddleEnd--;
+    afterMiddleEnd--;
+  }
+
+  alignDenseGap({
+    ...options,
+    beforeRange: { start: beforeStart, end: beforeMiddleEnd },
+    afterRange: { start: afterStart, end: afterMiddleEnd },
+  });
+  pushEqualRange(
+    runs,
+    options.before,
+    options.after,
+    { start: beforeMiddleEnd, end: beforeEnd },
+    { start: afterMiddleEnd, end: afterEnd },
+  );
+};
+
+/**
+ * LCS alignment split at stable, unique-token anchors. Patience anchoring keeps
+ * repeated boilerplate from winning a tie over a unique legal term, and makes
+ * a small edit inside a long paragraph pay for only its changed gap.
+ */
 const alignTokens = ({ before, after, normalization }: AlignOptions): DiffRun[] => {
   const beforeKeys = before.map((token) => comparisonKey(token, normalization));
   const afterKeys = after.map((token) => comparisonKey(token, normalization));
-  const m = before.length;
-  const n = after.length;
-
-  const dp: number[][] = Array.from({ length: m + 1 }, () =>
-    Array.from({ length: n + 1 }, () => 0),
-  );
-  for (let i = 0; i < m; i++) {
-    for (let j = 0; j < n; j++) {
-      const row = dp[i + 1];
-      const previousRow = dp[i];
-      if (!row || !previousRow) {
-        continue;
-      }
-      row[j + 1] =
-        beforeKeys[i] === afterKeys[j]
-          ? (previousRow[j] ?? 0) + 1
-          : Math.max(row[j] ?? 0, previousRow[j + 1] ?? 0);
-    }
+  let commonPrefixLength = 0;
+  while (
+    commonPrefixLength < before.length &&
+    commonPrefixLength < after.length &&
+    beforeKeys[commonPrefixLength] === afterKeys[commonPrefixLength]
+  ) {
+    commonPrefixLength++;
   }
 
-  const reversed: DiffRun[] = [];
-  let i = m;
-  let j = n;
-  while (i > 0 && j > 0) {
-    if (beforeKeys[i - 1] === afterKeys[j - 1]) {
-      reversed.push({
-        type: "equal",
-        before: before[i - 1] ?? "",
-        after: after[j - 1] ?? "",
-        units: 1,
-      });
-      i--;
-      j--;
-      continue;
-    }
-    // Backtracking emits in reverse, so pushing `ins` first here makes `del`
-    // come BEFORE `ins` in the final left-to-right output. That ordering
-    // matters at apply time: the inserted text lands after the
-    // deletion-marked span, matching reader convention (strike-through → new
-    // text) and the engine's existing expectation ("shallmust", not
-    // "mustshall").
-    if ((dp[i - 1]?.[j] ?? 0) > (dp[i]?.[j - 1] ?? 0)) {
-      reversed.push({ type: "del", text: before[i - 1] ?? "" });
-      i--;
-    } else {
-      reversed.push({ type: "ins", text: after[j - 1] ?? "" });
-      j--;
-    }
-  }
-  while (i > 0) {
-    reversed.push({ type: "del", text: before[i - 1] ?? "" });
-    i--;
-  }
-  while (j > 0) {
-    reversed.push({ type: "ins", text: after[j - 1] ?? "" });
-    j--;
+  let beforeMiddleEnd = before.length;
+  let afterMiddleEnd = after.length;
+  while (
+    beforeMiddleEnd > commonPrefixLength &&
+    afterMiddleEnd > commonPrefixLength &&
+    beforeKeys[beforeMiddleEnd - 1] === afterKeys[afterMiddleEnd - 1]
+  ) {
+    beforeMiddleEnd--;
+    afterMiddleEnd--;
   }
 
+  const beforeRange = { start: commonPrefixLength, end: beforeMiddleEnd };
+  const afterRange = { start: commonPrefixLength, end: afterMiddleEnd };
+  const residualTokenCount =
+    beforeRange.end - beforeRange.start + afterRange.end - afterRange.start;
+  const anchors =
+    residualTokenCount <= MAX_WORD_DIFF_ANCHOR_TOKENS
+      ? findPatienceAnchors(beforeKeys, afterKeys, beforeRange, afterRange)
+      : [];
+  const budget = { remainingCells: MAX_WORD_DIFF_CELLS };
   const runs: DiffRun[] = [];
-  for (const run of reversed.toReversed()) {
-    const last = runs.at(-1);
-    if (last?.type === "equal" && run.type === "equal") {
-      last.before += run.before;
-      last.after += run.after;
-      last.units += run.units;
-      continue;
-    }
-    if (
-      (last?.type === "del" && run.type === "del") ||
-      (last?.type === "ins" && run.type === "ins")
-    ) {
-      last.text += run.text;
-      continue;
-    }
-    runs.push({ ...run });
+
+  // Affix factoring changes which occurrence wins an LCS tie. If no stronger
+  // unique anchor was selected and the original region fits, preserve the
+  // historical alignment exactly; factoring is then only a scalability path.
+  if (
+    anchors.length === 0 &&
+    (after.length === 0 || before.length <= Math.floor(budget.remainingCells / after.length))
+  ) {
+    alignDenseGap({
+      before,
+      after,
+      beforeKeys,
+      afterKeys,
+      beforeRange: { start: 0, end: before.length },
+      afterRange: { start: 0, end: after.length },
+      runs,
+      budget,
+    });
+    return runs;
   }
+
+  pushEqualRange(
+    runs,
+    before,
+    after,
+    { start: 0, end: commonPrefixLength },
+    { start: 0, end: commonPrefixLength },
+  );
+  let beforeStart = commonPrefixLength;
+  let afterStart = commonPrefixLength;
+
+  for (const anchor of anchors) {
+    alignGap({
+      before,
+      after,
+      beforeKeys,
+      afterKeys,
+      beforeRange: { start: beforeStart, end: anchor.beforeIndex },
+      afterRange: { start: afterStart, end: anchor.afterIndex },
+      runs,
+      budget,
+    });
+    pushRun(runs, {
+      type: "equal",
+      before: before[anchor.beforeIndex] ?? "",
+      after: after[anchor.afterIndex] ?? "",
+      units: 1,
+    });
+    beforeStart = anchor.beforeIndex + 1;
+    afterStart = anchor.afterIndex + 1;
+  }
+
+  alignGap({
+    before,
+    after,
+    beforeKeys,
+    afterKeys,
+    beforeRange: { start: beforeStart, end: beforeMiddleEnd },
+    afterRange: { start: afterStart, end: afterMiddleEnd },
+    runs,
+    budget,
+  });
+  pushEqualRange(
+    runs,
+    before,
+    after,
+    { start: beforeMiddleEnd, end: before.length },
+    { start: afterMiddleEnd, end: after.length },
+  );
   return runs;
 };
 
@@ -371,15 +737,15 @@ export const diffWordSegments = (
   after: string,
   options: WordDiffOptions = {},
 ): WordDiffSegment[] => {
+  if (before === after) {
+    return before.length === 0 ? [] : [{ type: "equal", text: before }];
+  }
   const granularity = options.granularity ?? "word";
   const normalization = options.normalization ?? {};
   const beforeTokens = tokenize(before, granularity);
   const afterTokens = tokenize(after, granularity);
   if (beforeTokens.length === 0 && afterTokens.length === 0) {
     return [];
-  }
-  if (beforeTokens.length * afterTokens.length > MAX_WORD_DIFF_CELLS) {
-    return wholeStringReplacement(before, after);
   }
 
   const aligned = alignTokens({ before: beforeTokens, after: afterTokens, normalization });

--- a/packages/core/src/ai-edits/word-diff.ts
+++ b/packages/core/src/ai-edits/word-diff.ts
@@ -24,8 +24,9 @@
  *
  * Common affixes and unique-token anchors split the input into independent
  * gaps before any quadratic work. The residual gaps share one
- * {@link MAX_WORD_DIFF_CELLS} allowance per call; once it is spent, a gap is a
- * single `del` + `ins` pair.
+ * {@link MAX_WORD_DIFF_CELLS} allowance per comparison or apply scope; once it
+ * is spent, a gap is a single `del` + `ins` pair. A standalone call owns one
+ * fresh scope.
  */
 
 export type WordDiffSegment = {
@@ -147,23 +148,30 @@ const comparisonKey = (token: string, normalization: WordDiffNormalization): str
 const isSeparatorOnly = (text: string): boolean => SEPARATOR_ONLY.test(text);
 
 /**
- * Cell budget shared by the residual LCS gaps inside one
- * {@link diffWordSegments} call. `before`/`after` come from attacker-controlled
- * document text (a `modified` block pair), so an unbounded pair of large
- * strings would otherwise force a quadratic-sized allocation. This is not a
- * document-wide budget: callers diffing several blocks receive one allowance
- * per call.
+ * Cell budget shared by the residual LCS gaps inside one comparison or apply
+ * scope. `before`/`after` come from attacker-controlled document text (a
+ * `modified` block pair), so an unbounded pair of large strings would
+ * otherwise force a quadratic-sized allocation. Package-level callers share
+ * one scope across every story and operation; the standalone public helper
+ * gets one scope per call.
  */
 const MAX_WORD_DIFF_CELLS = 4_000_000;
 
 /**
  * Maximum combined residual tokens considered for unique-anchor discovery.
- * The token and comparison-key arrays are already required by the public
- * operation, but the occurrence maps and candidate list are optional linear
- * storage over attacker-controlled text. Common affixes are removed before
- * this cap, so a small edit in a very long paragraph can still use anchors.
+ * Comparison-key arrays, occurrence maps, and the candidate list are optional
+ * linear storage over attacker-controlled text. Common affixes are removed
+ * before this cap, so a small edit in a very long paragraph can still use
+ * anchors without duplicating the whole input as normalized strings.
  */
 const MAX_WORD_DIFF_ANCHOR_TOKENS = 16_384;
+
+/**
+ * Maximum source code units retained in comparison-key arrays. Token count
+ * alone is not a storage bound: one word token can itself contain megabytes,
+ * and case or whitespace normalization creates another string for it.
+ */
+const MAX_WORD_DIFF_COMPARISON_KEY_CODE_UNITS = 1_048_576;
 
 const ALIGNMENT_OPERATION = {
   Equal: 1,
@@ -178,9 +186,17 @@ type DiffRun =
   | { type: "ins"; text: string };
 
 type AlignOptions = {
+  beforeText: string;
+  afterText: string;
   before: readonly string[];
   after: readonly string[];
   normalization: WordDiffNormalization;
+  budget: AlignmentBudget;
+};
+
+type AlignmentResult = {
+  runs: DiffRun[];
+  monotoneDirection: "insertion" | "deletion" | null;
 };
 
 type TokenRange = {
@@ -196,6 +212,15 @@ type TokenAnchor = {
 type AlignmentBudget = {
   remainingCells: number;
 };
+
+const fitsCellBudget = (
+  beforeLength: number,
+  afterLength: number,
+  budget: AlignmentBudget,
+): boolean =>
+  beforeLength === 0 ||
+  afterLength === 0 ||
+  beforeLength <= Math.floor(budget.remainingCells / afterLength);
 
 const pushRun = (runs: DiffRun[], run: DiffRun): void => {
   const last = runs.at(-1);
@@ -215,6 +240,10 @@ const pushRun = (runs: DiffRun[], run: DiffRun): void => {
   runs.push(run);
 };
 
+const joinTokenRange = (tokens: readonly string[], { start, end }: TokenRange): string => {
+  return tokens.slice(start, end).join("");
+};
+
 const pushEqualRange = (
   runs: DiffRun[],
   before: readonly string[],
@@ -228,8 +257,8 @@ const pushEqualRange = (
   }
   pushRun(runs, {
     type: "equal",
-    before: before.slice(beforeRange.start, beforeRange.end).join(""),
-    after: after.slice(afterRange.start, afterRange.end).join(""),
+    before: joinTokenRange(before, beforeRange),
+    after: joinTokenRange(after, afterRange),
     units,
   });
 };
@@ -244,13 +273,13 @@ const pushChangedRange = (
   if (beforeRange.start !== beforeRange.end) {
     pushRun(runs, {
       type: "del",
-      text: before.slice(beforeRange.start, beforeRange.end).join(""),
+      text: joinTokenRange(before, beforeRange),
     });
   }
   if (afterRange.start !== afterRange.end) {
     pushRun(runs, {
       type: "ins",
-      text: after.slice(afterRange.start, afterRange.end).join(""),
+      text: joinTokenRange(after, afterRange),
     });
   }
 };
@@ -336,6 +365,165 @@ const findPatienceAnchors = (
   return anchors;
 };
 
+type MonotoneChange = "equivalent" | "insertion" | "deletion" | "mixed";
+
+const keysEqual = (before: string, after: string, normalization: WordDiffNormalization): boolean =>
+  comparisonKey(before, normalization) === comparisonKey(after, normalization);
+
+type TokenSubsequenceOptions = {
+  subsequence: readonly string[];
+  sequence: readonly string[];
+  subsequenceRange: TokenRange;
+  sequenceRange: TokenRange;
+  normalization: WordDiffNormalization;
+};
+
+const isTokenSubsequence = ({
+  subsequence,
+  sequence,
+  subsequenceRange,
+  sequenceRange,
+  normalization,
+}: TokenSubsequenceOptions): boolean => {
+  if (subsequenceRange.start === subsequenceRange.end) {
+    return true;
+  }
+  let subsequenceIndex = subsequenceRange.start;
+  let subsequenceKey = comparisonKey(subsequence[subsequenceIndex] ?? "", normalization);
+  for (
+    let sequenceIndex = sequenceRange.start;
+    sequenceIndex < sequenceRange.end;
+    sequenceIndex++
+  ) {
+    if (subsequenceIndex === subsequenceRange.end) {
+      return true;
+    }
+    const token = sequence[sequenceIndex] ?? "";
+    if (subsequenceKey !== comparisonKey(token, normalization)) {
+      continue;
+    }
+    subsequenceIndex++;
+    if (subsequenceIndex < subsequenceRange.end) {
+      const nextToken = subsequence[subsequenceIndex] ?? "";
+      subsequenceKey = comparisonKey(nextToken, normalization);
+    }
+  }
+  return subsequenceIndex === subsequenceRange.end;
+};
+
+type ClassifyMonotoneChangeOptions = {
+  before: readonly string[];
+  after: readonly string[];
+  beforeRange: TokenRange;
+  afterRange: TokenRange;
+  normalization: WordDiffNormalization;
+};
+
+/** Classify edits whose shorter token sequence survives whole and in order. */
+const classifyMonotoneChange = ({
+  before,
+  after,
+  beforeRange,
+  afterRange,
+  normalization,
+}: ClassifyMonotoneChangeOptions): MonotoneChange => {
+  const beforeLength = beforeRange.end - beforeRange.start;
+  const afterLength = afterRange.end - afterRange.start;
+  if (beforeLength === afterLength) {
+    for (let offset = 0; offset < beforeLength; offset++) {
+      if (
+        !keysEqual(
+          before[beforeRange.start + offset] ?? "",
+          after[afterRange.start + offset] ?? "",
+          normalization,
+        )
+      ) {
+        return "mixed";
+      }
+    }
+    return "equivalent";
+  }
+  if (beforeLength < afterLength) {
+    return isTokenSubsequence({
+      subsequence: before,
+      sequence: after,
+      subsequenceRange: beforeRange,
+      sequenceRange: afterRange,
+      normalization,
+    })
+      ? "insertion"
+      : "mixed";
+  }
+  return isTokenSubsequence({
+    subsequence: after,
+    sequence: before,
+    subsequenceRange: afterRange,
+    sequenceRange: beforeRange,
+    normalization,
+  })
+    ? "deletion"
+    : "mixed";
+};
+
+const alignMonotoneChange = (
+  beforeText: string,
+  afterText: string,
+  before: readonly string[],
+  after: readonly string[],
+  normalization: WordDiffNormalization,
+  change: Exclude<MonotoneChange, "mixed" | "equivalent">,
+): DiffRun[] => {
+  const beforeIsSubsequence = change === "insertion";
+  const subsequence = beforeIsSubsequence ? before : after;
+  const sequence = beforeIsSubsequence ? after : before;
+  const sequenceText = beforeIsSubsequence ? afterText : beforeText;
+  const runs: DiffRun[] = [];
+  let subsequenceIndex = 0;
+  let sequenceOffset = 0;
+  let sequenceChangeStartOffset = 0;
+
+  for (let sequenceIndex = 0; sequenceIndex < sequence.length; sequenceIndex++) {
+    const subsequenceToken = subsequence[subsequenceIndex];
+    const sequenceToken = sequence[sequenceIndex];
+    const sequenceTokenStart = sequenceOffset;
+    sequenceOffset += sequenceToken?.length ?? 0;
+    if (
+      subsequenceToken === undefined ||
+      sequenceToken === undefined ||
+      !keysEqual(subsequenceToken, sequenceToken, normalization)
+    ) {
+      continue;
+    }
+
+    if (sequenceChangeStartOffset < sequenceTokenStart) {
+      const changedText = sequenceText.slice(sequenceChangeStartOffset, sequenceTokenStart);
+      pushRun(
+        runs,
+        beforeIsSubsequence
+          ? { type: "ins", text: changedText }
+          : { type: "del", text: changedText },
+      );
+    }
+    pushRun(runs, {
+      type: "equal",
+      before: beforeIsSubsequence ? subsequenceToken : sequenceToken,
+      after: beforeIsSubsequence ? sequenceToken : subsequenceToken,
+      units: 1,
+    });
+    subsequenceIndex++;
+    sequenceChangeStartOffset = sequenceOffset;
+  }
+
+  if (sequenceChangeStartOffset < sequenceText.length) {
+    const changedText = sequenceText.slice(sequenceChangeStartOffset);
+    pushRun(
+      runs,
+      beforeIsSubsequence ? { type: "ins", text: changedText } : { type: "del", text: changedText },
+    );
+  }
+  return runs;
+};
+
 type DenseGapOptions = {
   before: readonly string[];
   after: readonly string[];
@@ -365,7 +553,7 @@ const alignDenseGap = ({
     return;
   }
 
-  if (beforeLength > Math.floor(budget.remainingCells / afterLength)) {
+  if (!fitsCellBudget(beforeLength, afterLength, budget)) {
     pushChangedRange(runs, before, after, beforeRange, afterRange);
     return;
   }
@@ -509,58 +697,140 @@ const alignGap = (options: DenseGapOptions): void => {
  * repeated boilerplate from winning a tie over a unique legal term, and makes
  * a small edit inside a long paragraph pay for only its changed gap.
  */
-const alignTokens = ({ before, after, normalization }: AlignOptions): DiffRun[] => {
-  const beforeKeys = before.map((token) => comparisonKey(token, normalization));
-  const afterKeys = after.map((token) => comparisonKey(token, normalization));
+const alignTokens = ({
+  beforeText,
+  afterText,
+  before,
+  after,
+  normalization,
+  budget,
+}: AlignOptions): AlignmentResult => {
   let commonPrefixLength = 0;
+  let beforePrefixLength = 0;
+  let afterPrefixLength = 0;
   while (
     commonPrefixLength < before.length &&
     commonPrefixLength < after.length &&
-    beforeKeys[commonPrefixLength] === afterKeys[commonPrefixLength]
+    keysEqual(before[commonPrefixLength] ?? "", after[commonPrefixLength] ?? "", normalization)
   ) {
+    beforePrefixLength += before[commonPrefixLength]?.length ?? 0;
+    afterPrefixLength += after[commonPrefixLength]?.length ?? 0;
     commonPrefixLength++;
   }
 
   let beforeMiddleEnd = before.length;
   let afterMiddleEnd = after.length;
+  let beforeSuffixLength = 0;
+  let afterSuffixLength = 0;
   while (
     beforeMiddleEnd > commonPrefixLength &&
     afterMiddleEnd > commonPrefixLength &&
-    beforeKeys[beforeMiddleEnd - 1] === afterKeys[afterMiddleEnd - 1]
+    keysEqual(before[beforeMiddleEnd - 1] ?? "", after[afterMiddleEnd - 1] ?? "", normalization)
   ) {
     beforeMiddleEnd--;
     afterMiddleEnd--;
+    beforeSuffixLength += before[beforeMiddleEnd]?.length ?? 0;
+    afterSuffixLength += after[afterMiddleEnd]?.length ?? 0;
   }
 
   const beforeRange = { start: commonPrefixLength, end: beforeMiddleEnd };
   const afterRange = { start: commonPrefixLength, end: afterMiddleEnd };
+  const monotoneChange = classifyMonotoneChange({
+    before,
+    after,
+    beforeRange,
+    afterRange,
+    normalization,
+  });
+  if (monotoneChange === "equivalent") {
+    return {
+      runs: [
+        {
+          type: "equal",
+          before: beforeText,
+          after: afterText,
+          units: before.length,
+        },
+      ],
+      monotoneDirection: null,
+    };
+  }
+  const monotoneDirection = monotoneChange === "mixed" ? null : monotoneChange;
   const residualTokenCount =
     beforeRange.end - beforeRange.start + afterRange.end - afterRange.start;
-  const anchors =
-    residualTokenCount <= MAX_WORD_DIFF_ANCHOR_TOKENS
-      ? findPatienceAnchors(beforeKeys, afterKeys, beforeRange, afterRange)
-      : [];
-  const budget = { remainingCells: MAX_WORD_DIFF_CELLS };
   const runs: DiffRun[] = [];
+  const fullInputFits = fitsCellBudget(before.length, after.length, budget);
+  const fullInputFitsStorage =
+    before.length + after.length <= MAX_WORD_DIFF_ANCHOR_TOKENS &&
+    beforeText.length + afterText.length <= MAX_WORD_DIFF_COMPARISON_KEY_CODE_UNITS;
+  const residualCodeUnitCount =
+    beforeText.length -
+    beforePrefixLength -
+    beforeSuffixLength +
+    afterText.length -
+    afterPrefixLength -
+    afterSuffixLength;
+
+  if (
+    residualTokenCount > MAX_WORD_DIFF_ANCHOR_TOKENS ||
+    residualCodeUnitCount > MAX_WORD_DIFF_COMPARISON_KEY_CODE_UNITS
+  ) {
+    if (commonPrefixLength > 0) {
+      pushRun(runs, {
+        type: "equal",
+        before: beforeText.slice(0, beforePrefixLength),
+        after: afterText.slice(0, afterPrefixLength),
+        units: commonPrefixLength,
+      });
+    }
+    if (beforePrefixLength + beforeSuffixLength < beforeText.length) {
+      pushRun(runs, {
+        type: "del",
+        text: beforeText.slice(beforePrefixLength, beforeText.length - beforeSuffixLength),
+      });
+    }
+    if (afterPrefixLength + afterSuffixLength < afterText.length) {
+      pushRun(runs, {
+        type: "ins",
+        text: afterText.slice(afterPrefixLength, afterText.length - afterSuffixLength),
+      });
+    }
+    if (beforeSuffixLength > 0) {
+      pushRun(runs, {
+        type: "equal",
+        before: beforeText.slice(beforeText.length - beforeSuffixLength),
+        after: afterText.slice(afterText.length - afterSuffixLength),
+        units: before.length - beforeMiddleEnd,
+      });
+    }
+    return { runs, monotoneDirection };
+  }
+
+  // Only the bounded residual gets duplicate token/key arrays. Huge inputs
+  // without a useful affix never materialize an attacker-sized second copy.
+  const beforeMiddle = before.slice(beforeRange.start, beforeRange.end);
+  const afterMiddle = after.slice(afterRange.start, afterRange.end);
+  const beforeKeys = beforeMiddle.map((token) => comparisonKey(token, normalization));
+  const afterKeys = afterMiddle.map((token) => comparisonKey(token, normalization));
+  const middleRangeBefore = { start: 0, end: beforeMiddle.length };
+  const middleRangeAfter = { start: 0, end: afterMiddle.length };
+  const anchors = findPatienceAnchors(beforeKeys, afterKeys, middleRangeBefore, middleRangeAfter);
 
   // Affix factoring changes which occurrence wins an LCS tie. If no stronger
   // unique anchor was selected and the original region fits, preserve the
   // historical alignment exactly; factoring is then only a scalability path.
-  if (
-    anchors.length === 0 &&
-    (after.length === 0 || before.length <= Math.floor(budget.remainingCells / after.length))
-  ) {
+  if (anchors.length === 0 && fullInputFits && fullInputFitsStorage) {
     alignDenseGap({
       before,
       after,
-      beforeKeys,
-      afterKeys,
+      beforeKeys: before.map((token) => comparisonKey(token, normalization)),
+      afterKeys: after.map((token) => comparisonKey(token, normalization)),
       beforeRange: { start: 0, end: before.length },
       afterRange: { start: 0, end: after.length },
       runs,
       budget,
     });
-    return runs;
+    return { runs, monotoneDirection };
   }
 
   pushEqualRange(
@@ -570,13 +840,14 @@ const alignTokens = ({ before, after, normalization }: AlignOptions): DiffRun[] 
     { start: 0, end: commonPrefixLength },
     { start: 0, end: commonPrefixLength },
   );
-  let beforeStart = commonPrefixLength;
-  let afterStart = commonPrefixLength;
+  // Anchors below index into the bounded residual arrays, not the full input.
+  let beforeStart = 0;
+  let afterStart = 0;
 
   for (const anchor of anchors) {
     alignGap({
-      before,
-      after,
+      before: beforeMiddle,
+      after: afterMiddle,
       beforeKeys,
       afterKeys,
       beforeRange: { start: beforeStart, end: anchor.beforeIndex },
@@ -586,8 +857,8 @@ const alignTokens = ({ before, after, normalization }: AlignOptions): DiffRun[] 
     });
     pushRun(runs, {
       type: "equal",
-      before: before[anchor.beforeIndex] ?? "",
-      after: after[anchor.afterIndex] ?? "",
+      before: beforeMiddle[anchor.beforeIndex] ?? "",
+      after: afterMiddle[anchor.afterIndex] ?? "",
       units: 1,
     });
     beforeStart = anchor.beforeIndex + 1;
@@ -595,12 +866,12 @@ const alignTokens = ({ before, after, normalization }: AlignOptions): DiffRun[] 
   }
 
   alignGap({
-    before,
-    after,
+    before: beforeMiddle,
+    after: afterMiddle,
     beforeKeys,
     afterKeys,
-    beforeRange: { start: beforeStart, end: beforeMiddleEnd },
-    afterRange: { start: afterStart, end: afterMiddleEnd },
+    beforeRange: { start: beforeStart, end: beforeMiddle.length },
+    afterRange: { start: afterStart, end: afterMiddle.length },
     runs,
     budget,
   });
@@ -611,7 +882,7 @@ const alignTokens = ({ before, after, normalization }: AlignOptions): DiffRun[] 
     { start: beforeMiddleEnd, end: before.length },
     { start: afterMiddleEnd, end: after.length },
   );
-  return runs;
+  return { runs, monotoneDirection };
 };
 
 /**
@@ -732,10 +1003,11 @@ const wholeStringReplacement = (before: string, after: string): WordDiffSegment[
   return segments;
 };
 
-export const diffWordSegments = (
+const diffWordSegmentsWithBudget = (
   before: string,
   after: string,
-  options: WordDiffOptions = {},
+  options: WordDiffOptions,
+  budget: AlignmentBudget,
 ): WordDiffSegment[] => {
   if (before === after) {
     return before.length === 0 ? [] : [{ type: "equal", text: before }];
@@ -747,11 +1019,114 @@ export const diffWordSegments = (
   if (beforeTokens.length === 0 && afterTokens.length === 0) {
     return [];
   }
+  if (beforeTokens.length === 0 || afterTokens.length === 0) {
+    return wholeStringReplacement(before, after);
+  }
 
-  const aligned = alignTokens({ before: beforeTokens, after: afterTokens, normalization });
-  const surviving = demoteRejectedMatches(aligned);
-  if (isTooFragmented(surviving, (before.length + after.length) / 2)) {
+  const aligned = alignTokens({
+    beforeText: before,
+    afterText: after,
+    before: beforeTokens,
+    after: afterTokens,
+    normalization,
+    budget,
+  });
+  let surviving = demoteRejectedMatches(aligned.runs);
+  const inventedOppositeChange =
+    (aligned.monotoneDirection === "insertion" && surviving.some(({ type }) => type === "del")) ||
+    (aligned.monotoneDirection === "deletion" && surviving.some(({ type }) => type === "ins"));
+  const monotoneDirection = aligned.monotoneDirection;
+  if (inventedOppositeChange && monotoneDirection !== null) {
+    const unanchoredFitsStorage =
+      beforeTokens.length + afterTokens.length <= MAX_WORD_DIFF_ANCHOR_TOKENS &&
+      before.length + after.length <= MAX_WORD_DIFF_COMPARISON_KEY_CODE_UNITS;
+    if (unanchoredFitsStorage && fitsCellBudget(beforeTokens.length, afterTokens.length, budget)) {
+      const unanchored: DiffRun[] = [];
+      alignDenseGap({
+        before: beforeTokens,
+        after: afterTokens,
+        beforeKeys: beforeTokens.map((token) => comparisonKey(token, normalization)),
+        afterKeys: afterTokens.map((token) => comparisonKey(token, normalization)),
+        beforeRange: { start: 0, end: beforeTokens.length },
+        afterRange: { start: 0, end: afterTokens.length },
+        runs: unanchored,
+        budget,
+      });
+      surviving = unanchored;
+    } else {
+      const rawInventsOpposite =
+        (monotoneDirection === "insertion" && aligned.runs.some(({ type }) => type === "del")) ||
+        (monotoneDirection === "deletion" && aligned.runs.some(({ type }) => type === "ins"));
+      surviving = rawInventsOpposite
+        ? alignMonotoneChange(
+            before,
+            after,
+            beforeTokens,
+            afterTokens,
+            normalization,
+            monotoneDirection,
+          )
+        : aligned.runs;
+    }
+  }
+  if (
+    aligned.monotoneDirection === null &&
+    isTooFragmented(surviving, (before.length + after.length) / 2)
+  ) {
     return wholeStringReplacement(before, after);
   }
   return toSegments(orderDeletionsFirst(surviving));
 };
+
+/**
+ * One internal comparison/apply scope. Every diff shares the same quadratic
+ * allowance; public standalone calls below still receive a fresh allowance.
+ * Not re-exported from a package entry point.
+ */
+export const createWordDiffSession = (options: WordDiffOptions = {}) => {
+  const resolvedOptions = {
+    granularity: options.granularity ?? "word",
+    normalization: { ...options.normalization },
+  } satisfies WordDiffOptions;
+  const budget = { remainingCells: MAX_WORD_DIFF_CELLS };
+  return {
+    diff: (before: string, after: string): WordDiffSegment[] =>
+      diffWordSegmentsWithBudget(before, after, resolvedOptions, budget),
+  };
+};
+
+const WORD_DIFF_SESSION = Symbol("folio.wordDiffSession");
+
+type ScopedWordDiffOptions = WordDiffOptions & {
+  readonly [WORD_DIFF_SESSION]: ReturnType<typeof createWordDiffSession>;
+};
+
+const hasWordDiffSession = (options: WordDiffOptions): options is ScopedWordDiffOptions =>
+  WORD_DIFF_SESSION in options;
+
+/** Attach one internal work scope without widening a caller-facing option type. */
+export const createScopedWordDiffOptions = <Options extends WordDiffOptions>(
+  options: Options,
+): Options => ({
+  ...options,
+  [WORD_DIFF_SESSION]: createWordDiffSession(options),
+});
+
+/** Reuse an internal scope when present; ordinary public callers get a fresh one. */
+export const wordDiffSessionFromOptions = (
+  options: WordDiffOptions | undefined,
+): ReturnType<typeof createWordDiffSession> => {
+  if (options && hasWordDiffSession(options)) {
+    return options[WORD_DIFF_SESSION];
+  }
+  return createWordDiffSession(options);
+};
+
+export const diffWordSegments = (
+  before: string,
+  after: string,
+  options: WordDiffOptions = {},
+): WordDiffSegment[] =>
+  diffWordSegmentsWithBudget(before, after, options, {
+    remainingCells: MAX_WORD_DIFF_CELLS,
+  });

--- a/packages/core/src/compare/compare.ts
+++ b/packages/core/src/compare/compare.ts
@@ -47,7 +47,7 @@ import { projectTableGeometry } from "../ai-edits/table-geometry";
 import type { FolioTableTemplates } from "../ai-edits/table-template";
 import { numberingReferenceKeysOf } from "../ai-edits/snapshot";
 import type { FolioAIBlock, FolioAIEditSkipReason, FolioAIEditSnapshot } from "../ai-edits/types";
-import type { WordDiffGranularity } from "../ai-edits/word-diff";
+import { createScopedWordDiffOptions, type WordDiffGranularity } from "../ai-edits/word-diff";
 import { FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION } from "../document-operations";
 import { pairFolioDocumentStories } from "../document-stories";
 import { planStoryCompare, type CompareStoryPlan, type CompareTableTemplateRequest } from "./plan";
@@ -494,6 +494,7 @@ export const applyComparison = (
   // body revision with it.
   let idSeed = revisionStamp.idSeed;
   let documentChanged = false;
+  const wordDiff = createScopedWordDiffOptions({ granularity });
   for (const { pair, plan } of planned) {
     changes.push(...plan.changes);
     if (plan.operations.length === 0 && plan.tableGeometryPairings.length === 0) {
@@ -537,7 +538,7 @@ export const applyComparison = (
         story: pair.baseStory,
         snapshot: pair.baseSnapshot,
         revisionStamp: { date: revisionStamp.date, idSeed },
-        wordDiff: { granularity },
+        wordDiff,
         batch: {
           version: FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
           mode: "tracked-changes",

--- a/packages/core/src/redline.test.ts
+++ b/packages/core/src/redline.test.ts
@@ -18,6 +18,7 @@ import JSZip from "jszip";
 
 import { buildTextBoxTableDocument, findTextBoxShape } from "./__tests__/textBoxTableDocument";
 import { FolioDocxReviewer } from "./ai-edits/headless";
+import { compareDocx } from "./compare/compare";
 import { parseDocx } from "./docx/parser";
 import { createDocx } from "./docx/rezip";
 import { repackDocx } from "./docx/rezip";
@@ -251,6 +252,46 @@ const withPendingMainChange = async (source: ArrayBuffer, text: string): Promise
 };
 
 describe("generateRedlineDocx", () => {
+  test("package comparisons share one inline-alignment allowance across stories", async () => {
+    const alternating = (first: string, second: string): string =>
+      Array.from({ length: 2000 }, (_unused, index) => (index % 2 === 0 ? first : second)).join(
+        " ",
+      );
+    const before = alternating("a", "b");
+    const after = alternating("b", "a");
+    const base = await buildStoryDocument({
+      bodyText: before,
+      headerText: before,
+      footnoteText: before,
+    });
+    const revised = await buildStoryDocument({
+      bodyText: after,
+      headerText: after,
+      footnoteText: after,
+    });
+    const buffers = [(await generateRedlineDocx(base, revised)).buffer];
+    const compared = await compareDocx(base, revised, {
+      author: "compare",
+      timestamp: "2026-09-08T12:00:00.000Z",
+      onUnverified: "emit",
+    });
+    if (compared.isErr()) {
+      throw compared.error;
+    }
+    buffers.push(compared.value.buffer);
+
+    for (const buffer of buffers) {
+      const reviewer = await FolioDocxReviewer.fromBuffer(buffer);
+      const hasFineGrainedChange = reviewer.listStories().map(({ handle }) => {
+        const story = reviewer.readReviewedStory({ story: handle, view: "current-markup" });
+        return (story?.changes ?? [])
+          .filter(({ type }) => type === "insertion" || type === "deletion")
+          .some(({ text }) => text.length < before.length);
+      });
+      expect(hasFineGrainedChange).toEqual([true, false, false]);
+    }
+  });
+
   test("redlines a nested text-box table-cell edit without changing either source", async () => {
     const base = await buildTextBoxTableDocument("Original cell value");
     const revised = await buildTextBoxTableDocument("Revised cell value");

--- a/packages/core/src/redline.ts
+++ b/packages/core/src/redline.ts
@@ -26,6 +26,7 @@ import type {
   FolioAIEditSkippedOperation,
   FolioAIEditSnapshot,
 } from "./ai-edits/types";
+import { createScopedWordDiffOptions } from "./ai-edits/word-diff";
 import { FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION } from "./document-operations";
 import { pairFolioDocumentStories } from "./document-stories";
 import {
@@ -269,6 +270,7 @@ export const generateRedlineDocx = async (
   const applied: FolioAIEditAppliedOperation[] = [];
   const skipped: FolioAIEditSkippedOperation[] = [];
   const unprocessedStories: GenerateRedlineUnprocessedStory[] = [];
+  const wordDiff = createScopedWordDiffOptions({});
   let operationSequence = 0;
   const nextOperationId = () => {
     if (operationSequence >= MAX_GENERATED_REDLINE_OPERATIONS) {
@@ -318,6 +320,7 @@ export const generateRedlineDocx = async (
         mode: "tracked-changes",
         operations,
       },
+      wordDiff,
     });
     applied.push(...result.applied);
     skipped.push(...result.skipped);

--- a/packages/core/src/version-comparison.test.ts
+++ b/packages/core/src/version-comparison.test.ts
@@ -342,6 +342,37 @@ describe("compareDocxVersions: document stories", () => {
       blockId: "51000001",
     });
   });
+
+  test("shares one inline-alignment allowance across every story", async () => {
+    const alternating = (first: string, second: string): string =>
+      Array.from({ length: 2000 }, (_unused, index) => (index % 2 === 0 ? first : second)).join(
+        " ",
+      );
+    const before = alternating("a", "b");
+    const after = alternating("b", "a");
+    const base = await buildStoryDocument({
+      bodyText: before,
+      headerText: before,
+      footnoteText: before,
+    });
+    const revised = await buildStoryDocument({
+      bodyText: after,
+      headerText: after,
+      footnoteText: after,
+    });
+
+    const diff = await compareDocxVersions(base, revised);
+    const modified = diff.stories.flatMap(({ changes }) =>
+      changes.filter(({ type }) => type === "modified"),
+    );
+    expect(modified).toHaveLength(3);
+    expect(
+      modified.filter(({ segments }) => segments.some(({ type }) => type === "equal")),
+    ).toHaveLength(1);
+    expect(
+      modified.filter(({ segments }) => segments.every(({ type }) => type !== "equal")),
+    ).toHaveLength(2);
+  });
 });
 
 describe("compareDocxVersions: deterministic fallback ids (no w14:paraId)", () => {

--- a/packages/core/src/version-comparison.ts
+++ b/packages/core/src/version-comparison.ts
@@ -77,7 +77,7 @@ import { panic, TaggedError } from "better-result";
 
 import { FolioDocxReviewer, type FolioDocumentStoryHandle } from "./ai-edits/headless";
 import type { FolioAIBlock, FolioAIBlockPreviewRun } from "./ai-edits/types";
-import { diffWordSegments, type WordDiffSegment } from "./ai-edits/word-diff";
+import { createWordDiffSession, type WordDiffSegment } from "./ai-edits/word-diff";
 import { pairFolioDocumentStories, type FolioDocumentStoryPair } from "./document-stories";
 import {
   FOLIO_DOCUMENT_METADATA_PROPERTIES,
@@ -724,6 +724,7 @@ type CompareStoryBlocksOptions = FolioDocumentStoryPair & {
   includeText: boolean;
   includeFormatting: boolean;
   lcsBudget: FolioVersionComparisonLcsBudget;
+  diffText: ReturnType<typeof createWordDiffSession>["diff"];
 };
 
 const compareStoryBlocks = ({
@@ -735,6 +736,7 @@ const compareStoryBlocks = ({
   includeText,
   includeFormatting,
   lcsBudget,
+  diffText,
 }: CompareStoryBlocksOptions): FolioStoryDiff => {
   const changes: FolioBlockDiff[] = [];
   const counts = createSummaryCounts();
@@ -757,7 +759,7 @@ const compareStoryBlocks = ({
           type: "modified",
           blockId: revisedBlock.id,
           kind: revisedBlock.kind,
-          segments: diffWordSegments(baseBlock.text, revisedBlock.text),
+          segments: diffText(baseBlock.text, revisedBlock.text),
           baseHandle,
           revisedHandle,
         });
@@ -949,6 +951,7 @@ export const compareDocxVersions = async (
   // fresh near-MAX_LCS_CELLS allocation per story. See
   // FolioVersionComparisonLcsBudget's doc comment.
   const lcsBudget = createLcsBudget();
+  const wordDiffSession = createWordDiffSession();
 
   for (const pair of pairFolioDocumentStories(baseStories, revisedStories)) {
     const baseBlocks = pair.baseStory
@@ -967,6 +970,7 @@ export const compareDocxVersions = async (
       includeText: scopes.has("text"),
       includeFormatting: scopes.has("formatting"),
       lcsBudget,
+      diffText: wordDiffSession.diff,
     });
     stories.push(storyDiff);
     for (const change of storyDiff.changes) {

--- a/scripts/api-surface-budget.json
+++ b/scripts/api-surface-budget.json
@@ -9,7 +9,7 @@
     "reportBytes": 278552,
     "reportLines": 8955,
     "declarationBytes": 1839509,
-    "declarationLines": 37711
+    "declarationLines": 37726
   },
   "react": {
     "reportBytes": 56922,


### PR DESCRIPTION
## Summary

- factor exact common affixes and stable unique-token anchors before residual inline alignment
- share one four-million-cell allowance across a complete apply batch, document comparison, or package redline
- cap retained normalized comparison keys and fall back to a deterministic coarse replacement before allocation
- keep atomic preflight zero-cost by using the same coarse path without spending the committed batch allowance
- preserve exact reconstruction, deletion-before-insertion ordering, and historical LCS ties where no anchor is selected

## Contract and budget

The word-diff session is internal; the public API report is unchanged. Generated core declarations grow by 15 lines / 1,013 bytes versus current main (37,727 lines / 1,850,970 bytes). The declaration-line baseline records the approved additive increase from 37,711 to 37,726; the measured candidate remains inside the existing bounded headroom. No compiler-work ceiling changes are required.

## Validation

- 489 focused tests across inline diff, operation apply, package redline, version comparison, paragraph alignment, revision allocation, and terminal-mark resolution
- table-driven shared-budget coverage for replaceBlock, replaceInBlock, and mixed batches
- exact accept/reject lifecycle and deterministic replay assertions for fine and coarse paths
- secondary-story character-granularity forwarding coverage
- mutation checks prove the sibling tests fail if per-operation sessions return, change ordering flips, or story options are dropped
- full compare regression gate unchanged at 681 strict / 762 best-effort; row semantics and change counts match current main
- five determinism probes byte-identical
- core typecheck and build; API snapshots, API budget, and compiler-work budget
- touched-file oxfmt, oxlint, and diff check
- five alternating process pairs against current main: replacement 32.4% faster; insertion 33.5% faster