### PR TITLE
fix(core): minimize resolved story error context

### DIFF
--- a/.changeset/calm-story-errors.md
+++ b/.changeset/calm-story-errors.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Limit resolved-story serialization errors to structural mismatch counts.

--- a/packages/core/src/ai-edits/headless.test.ts
+++ b/packages/core/src/ai-edits/headless.test.ts
@@ -2586,11 +2586,12 @@ describe("headless docx review discovery + resolve", () => {
       return createDocx(document);
     };
     const sensitiveText = "privileged serialization expectation";
+    const actualSensitiveText = "different serialized content";
     const expectedReviewer = await FolioDocxReviewer.fromBuffer(
       await makeBaseline(sensitiveText, "21000010"),
     );
     const mismatchedReviewer = await FolioDocxReviewer.fromBuffer(
-      await makeBaseline("different serialized content", "21000011"),
+      await makeBaseline(actualSensitiveText, "21000011"),
     );
     expect(expectedReviewer.resolveReviewedStory({ view: "final" })).toBe(true);
 
@@ -2598,9 +2599,14 @@ describe("headless docx review discovery + resolve", () => {
     try {
       reopen.mockResolvedValue(mismatchedReviewer);
       const saving = expectedReviewer.toBuffer();
-      await expect(saving).rejects.not.toHaveProperty("expectedText");
-      await expect(saving).rejects.not.toHaveProperty("actualText");
-      await expect(saving).rejects.toMatchObject({
+      const rejection = await saving.then(
+        () => null,
+        (reason: unknown) => reason,
+      );
+      const serializedRejection = JSON.stringify(rejection);
+      expect(serializedRejection).not.toContain(sensitiveText);
+      expect(serializedRejection).not.toContain(actualSensitiveText);
+      expect(rejection).toMatchObject({
         mismatches: ["text-projection", "block-projection"],
         expectedBlockCount: 1,
         actualBlockCount: 1,

--- a/packages/core/src/ai-edits/headless.test.ts
+++ b/packages/core/src/ai-edits/headless.test.ts
@@ -8,7 +8,7 @@
  * case; the copied-through package parts for the structural full-repack case).
  */
 
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import { panic } from "better-result";
 import JSZip from "jszip";
 import { EditorState } from "prosemirror-state";
@@ -2573,6 +2573,44 @@ const insertionChange = (reviewer: FolioDocxReviewer): FolioReviewChange => {
 };
 
 describe("headless docx review discovery + resolve", () => {
+  test("serialization mismatch errors never retain document text", async () => {
+    const makeBaseline = async (text: string, paraId: string) => {
+      const document = createEmptyDocument();
+      document.package.document.content = [
+        {
+          type: "paragraph",
+          paraId,
+          content: [{ type: "run", content: [{ type: "text", text }] }],
+        },
+      ];
+      return createDocx(document);
+    };
+    const sensitiveText = "privileged serialization expectation";
+    const expectedReviewer = await FolioDocxReviewer.fromBuffer(
+      await makeBaseline(sensitiveText, "21000010"),
+    );
+    const mismatchedReviewer = await FolioDocxReviewer.fromBuffer(
+      await makeBaseline("different serialized content", "21000011"),
+    );
+    expect(expectedReviewer.resolveReviewedStory({ view: "final" })).toBe(true);
+
+    const reopen = spyOn(FolioDocxReviewer, "fromBuffer");
+    try {
+      reopen.mockResolvedValue(mismatchedReviewer);
+      const saving = expectedReviewer.toBuffer();
+      await expect(saving).rejects.not.toHaveProperty("expectedText");
+      await expect(saving).rejects.not.toHaveProperty("actualText");
+      await expect(saving).rejects.toMatchObject({
+        mismatches: ["text-projection", "block-projection"],
+        expectedBlockCount: 1,
+        actualBlockCount: 1,
+        remainingChangeCount: 0,
+      });
+    } finally {
+      reopen.mockRestore();
+    }
+  });
+
   test("getContentAsText labels every block with its stable id", async () => {
     const baseline = await makeParaIdBaseline(readFixture());
     const reviewer = await FolioDocxReviewer.fromBuffer(baseline);

--- a/packages/core/src/ai-edits/headless.ts
+++ b/packages/core/src/ai-edits/headless.ts
@@ -320,13 +320,20 @@ export class FolioDocumentStoryNotFoundError extends TaggedError(
   story: FolioEditableDocumentStoryHandle;
 }> {}
 
+type FolioResolvedStorySerializationMismatch =
+  | "story-missing"
+  | "revision-markup-remains"
+  | "text-projection"
+  | "block-projection";
+
 class FolioResolvedStorySerializationError extends TaggedError(
   "FolioResolvedStorySerializationError",
 )<{
   message: string;
   story: FolioEditableDocumentStoryHandle;
-  expectedText: string;
-  actualText: string | null;
+  mismatches: readonly FolioResolvedStorySerializationMismatch[];
+  expectedBlockCount: number;
+  actualBlockCount: number | null;
   remainingChangeCount: number | null;
 }> {}
 
@@ -1334,21 +1341,35 @@ export class FolioDocxReviewer {
     for (const { story, text, blocks } of this.resolvedStoryExpectations.values()) {
       const serialized = reopened.readReviewedStory({ story, view: "current-markup" });
       const serializedState = reopened.getEditableStoryState(story);
-      if (
-        serialized &&
-        serializedState &&
-        serialized.changes.length === 0 &&
-        formatStoryStateForLLM(serializedState, false) === text &&
-        JSON.stringify(createFolioAIEditSnapshot(serializedState.doc).blocks) ===
-          JSON.stringify(blocks)
-      ) {
+      const serializedText = serializedState
+        ? formatStoryStateForLLM(serializedState, false)
+        : null;
+      const serializedBlocks = serializedState
+        ? createFolioAIEditSnapshot(serializedState.doc).blocks
+        : null;
+      const mismatches: FolioResolvedStorySerializationMismatch[] = [];
+      if (!serialized || !serializedState) {
+        mismatches.push("story-missing");
+      } else {
+        if (serialized.changes.length > 0) {
+          mismatches.push("revision-markup-remains");
+        }
+        if (serializedText !== text) {
+          mismatches.push("text-projection");
+        }
+        if (JSON.stringify(serializedBlocks) !== JSON.stringify(blocks)) {
+          mismatches.push("block-projection");
+        }
+      }
+      if (mismatches.length === 0) {
         continue;
       }
       throw new FolioResolvedStorySerializationError({
         message: "Resolved document story did not persist to the serialized DOCX.",
         story,
-        expectedText: text,
-        actualText: serializedState ? formatStoryStateForLLM(serializedState, false) : null,
+        mismatches,
+        expectedBlockCount: blocks.length,
+        actualBlockCount: serializedBlocks?.length ?? null,
         remainingChangeCount: serialized?.changes.length ?? null,
       });
     }

--- a/packages/core/src/ai-edits/headless.ts
+++ b/packages/core/src/ai-edits/headless.ts
@@ -320,11 +320,15 @@ export class FolioDocumentStoryNotFoundError extends TaggedError(
   story: FolioEditableDocumentStoryHandle;
 }> {}
 
+const FOLIO_RESOLVED_STORY_SERIALIZATION_MISMATCHES = Object.freeze({
+  storyMissing: "story-missing",
+  revisionMarkupRemains: "revision-markup-remains",
+  textProjection: "text-projection",
+  blockProjection: "block-projection",
+} as const);
+
 type FolioResolvedStorySerializationMismatch =
-  | "story-missing"
-  | "revision-markup-remains"
-  | "text-projection"
-  | "block-projection";
+  (typeof FOLIO_RESOLVED_STORY_SERIALIZATION_MISMATCHES)[keyof typeof FOLIO_RESOLVED_STORY_SERIALIZATION_MISMATCHES];
 
 class FolioResolvedStorySerializationError extends TaggedError(
   "FolioResolvedStorySerializationError",
@@ -1349,16 +1353,16 @@ export class FolioDocxReviewer {
         : null;
       const mismatches: FolioResolvedStorySerializationMismatch[] = [];
       if (!serialized || !serializedState) {
-        mismatches.push("story-missing");
+        mismatches.push(FOLIO_RESOLVED_STORY_SERIALIZATION_MISMATCHES.storyMissing);
       } else {
         if (serialized.changes.length > 0) {
-          mismatches.push("revision-markup-remains");
+          mismatches.push(FOLIO_RESOLVED_STORY_SERIALIZATION_MISMATCHES.revisionMarkupRemains);
         }
         if (serializedText !== text) {
-          mismatches.push("text-projection");
+          mismatches.push(FOLIO_RESOLVED_STORY_SERIALIZATION_MISMATCHES.textProjection);
         }
         if (JSON.stringify(serializedBlocks) !== JSON.stringify(blocks)) {
-          mismatches.push("block-projection");
+          mismatches.push(FOLIO_RESOLVED_STORY_SERIALIZATION_MISMATCHES.blockProjection);
         }
       }
       if (mismatches.length === 0) {


### PR DESCRIPTION
Resolved-story serialization failures now report typed mismatch categories and structural counts instead of retaining expected and actual document text. A synthetic mismatch regression covers the structured error boundary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error reporting when a resolved story fails serialisation.
  - Error details now provide structural mismatch types, block counts and remaining changes without exposing document text.
  - This prevents potentially sensitive expected or actual text from appearing in serialisation errors.

- **Tests**
  - Added coverage confirming that resolved-story serialisation errors contain the appropriate structural details and do not leak document content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->