### PR TITLE
fix(core): replace structurally incompatible table comparisons

### DIFF
--- a/.changeset/exact-dissimilar-tables.md
+++ b/.changeset/exact-dissimilar-tables.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Replace structurally incompatible table pairs as one deleted and one inserted table when their target template is lossless, preserving exact accept/reject round trips without sacrificing granular row edits or package-bound content.

--- a/packages/core/src/ai-edits/table-template.ts
+++ b/packages/core/src/ai-edits/table-template.ts
@@ -86,26 +86,22 @@ const hasAuthoredValue = (value: unknown): boolean => {
   return !Array.isArray(value) || value.length > 0;
 };
 
-const losesAuthoredAttrs = (node: PMNode): boolean => {
-  let cleared: readonly string[] = [];
+const clearedAttrsOf = (node: PMNode): readonly string[] => {
   switch (node.type.spec["tableRole"]) {
     case "table":
-      cleared = CLEARED_TABLE_ATTRS;
-      break;
+      return CLEARED_TABLE_ATTRS;
     case "row":
-      cleared = CLEARED_ROW_ATTRS;
-      break;
+      return CLEARED_ROW_ATTRS;
     case "cell":
     case "header_cell":
-      cleared = CLEARED_CELL_ATTRS;
-      break;
+      return CLEARED_CELL_ATTRS;
     default:
-      if (node.isTextblock) {
-        cleared = CLEARED_PARAGRAPH_ATTRS;
-      }
+      return node.isTextblock ? CLEARED_PARAGRAPH_ATTRS : [];
   }
-  return cleared.some((name) => hasAuthoredValue(node.attrs[name]));
 };
+
+const losesAuthoredAttrs = (node: PMNode): boolean =>
+  clearedAttrsOf(node).some((name) => hasAuthoredValue(node.attrs[name]));
 
 /**
  * Whether a target table can cross into the base package without semantic
@@ -199,22 +195,18 @@ const insertionMarkOf = (schema: Schema, revision: TableStructureRevision | null
 };
 
 const copiedAttrs = (node: PMNode, context: TemplateContext): Record<string, unknown> => {
+  const sourceAttrs = node.isTextblock ? stripBlockIdentityAttrs(node.attrs) : node.attrs;
+  const attrs = withoutAttrs(sourceAttrs, clearedAttrsOf(node));
   switch (node.type.spec["tableRole"]) {
     case "table":
-      return withoutAttrs(node.attrs, CLEARED_TABLE_ATTRS);
-    case "row": {
-      const attrs = withoutAttrs(node.attrs, CLEARED_ROW_ATTRS);
+      return attrs;
+    case "row":
       return context.revision ? { ...attrs, trIns: context.revision } : attrs;
-    }
     case "cell":
-    case "header_cell": {
-      const attrs = withoutAttrs(node.attrs, CLEARED_CELL_ATTRS);
+    case "header_cell":
       return context.clampRowSpan ? { ...attrs, rowspan: 1 } : attrs;
-    }
     default:
-      return node.isTextblock
-        ? withoutAttrs(stripBlockIdentityAttrs(node.attrs), CLEARED_PARAGRAPH_ATTRS)
-        : node.attrs;
+      return attrs;
   }
 };
 

--- a/packages/core/src/ai-edits/table-template.ts
+++ b/packages/core/src/ai-edits/table-template.ts
@@ -79,6 +79,63 @@ const CLEARED_TABLE_ATTRS = ["tblPrChange", "_suggestedInsert"] as const;
 const CLEARED_ROW_ATTRS = ["trIns", "trDel", "trPrChange"] as const;
 const CLEARED_CELL_ATTRS = ["cellMarker", "tcPrChange"] as const;
 
+const hasAuthoredValue = (value: unknown): boolean => {
+  if (value === null || value === undefined || value === false || value === "") {
+    return false;
+  }
+  return !Array.isArray(value) || value.length > 0;
+};
+
+const losesAuthoredAttrs = (node: PMNode): boolean => {
+  let cleared: readonly string[] = [];
+  switch (node.type.spec["tableRole"]) {
+    case "table":
+      cleared = CLEARED_TABLE_ATTRS;
+      break;
+    case "row":
+      cleared = CLEARED_ROW_ATTRS;
+      break;
+    case "cell":
+    case "header_cell":
+      cleared = CLEARED_CELL_ATTRS;
+      break;
+    default:
+      if (node.isTextblock) {
+        cleared = CLEARED_PARAGRAPH_ATTRS;
+      }
+  }
+  return cleared.some((name) => hasAuthoredValue(node.attrs[name]));
+};
+
+/**
+ * Whether a target table can cross into the base package without semantic
+ * content being stripped from its template.
+ *
+ * Paragraph identities are deliberately excluded: they are regenerated in
+ * the receiving document. Package-owned relationships, annotations,
+ * bookmarks and unresolved revision metadata are not portable and therefore
+ * make a replacement unsafe. Callers can retain their granular plan instead.
+ */
+export const tableTemplateCanCrossPackageLosslessly = (template: PMNode): boolean => {
+  let portable = true;
+  const inspect = (node: PMNode): boolean => {
+    if (
+      PACKAGE_BOUND_NODE_NAMES.has(node.type.name) ||
+      node.marks.some(({ type }) => PACKAGE_BOUND_MARK_NAMES.has(type.name)) ||
+      losesAuthoredAttrs(node)
+    ) {
+      portable = false;
+      return false;
+    }
+    return true;
+  };
+  if (!inspect(template)) {
+    return false;
+  }
+  template.descendants(inspect);
+  return portable;
+};
+
 const withoutAttrs = (
   attrs: Record<string, unknown>,
   cleared: readonly string[],

--- a/packages/core/src/compare/README.md
+++ b/packages/core/src/compare/README.md
@@ -318,6 +318,15 @@ properties differ is rewritten to the target's and records the previous set as
 `w:tblPrChange` / `w:trPrChange` / `w:tcPrChange`, which is what a reject
 restores.
 
+Two tables are not forced into cell-level pairing when row and column
+operations cannot express their projected structure. The base table is then
+`table-delete` and the target is `table-insert`. Text edits and representable
+row or column changes remain granular; the whole-table fallback trades
+misleading cell edits for an exact accept/reject round trip. The fallback is
+not used when copying the target table would strip package-bound content: that
+case remains explicitly unverified instead of reporting a lossy replacement
+as exact.
+
 ## Limitations
 
 `benchmarks/compare` measures each of these; `benchmarks/compare/RESULTS.md`
@@ -341,18 +350,24 @@ carries the current numbers and the failing cases.
   drops them on any edited paragraph and the comparison cannot produce them. A
   consumer reading the runs sees the move; one that groups multi-paragraph
   moves by range name does not.
-- **Ambiguous column operations are refused** (2026-09-06). The comparison
-  emits `table-column-insert` / `table-column-delete` only when the unchanged
-  columns give one exact grid alignment. Grid coordinates and spans come from
-  `TableMap`; the snapshot's `cellIndex` remains a physical row-child index.
-  Repeated empty columns, edits that cut a horizontal span, and target columns
-  containing vertical spans stay unverified rather than being guessed.
-- **A table nested inside a cell cannot be added or removed** (2026-09-06). A
-  whole table added or removed at document level is `table-insert` /
-  `table-delete`; the same edit inside a cell would need `insertTable` to
-  place a table in a cell rather than as a document-level peer. A nested table
-  travels with the table that holds it, so one added or removed alongside its
-  parent keeps its own grid and properties.
+- **Ambiguous column operations are never guessed** (2026-09-06). The
+  comparison emits `table-column-insert` / `table-column-delete` only when the
+  unchanged columns give one exact grid alignment. Grid coordinates and spans
+  come from `TableMap`; the snapshot's `cellIndex` remains a physical
+  row-child index. When the table shape changed and a body-level insertion
+  anchor exists, an edit that cuts a span falls back to replacing the whole
+  table. A table-only story has no such anchor and remains unverified.
+- **A nested table is replaced with its outer table** (2026-09-09). There is
+  no operation that inserts a table directly inside a cell. When a nested
+  table was added or removed, the comparison therefore deletes and inserts
+  the whole outer table, preserving the nested table's grid and properties.
+  A table-only story cannot use that fallback because it has no body-level
+  insertion anchor.
+- **Moving a nested table between cells remains unverified** (2026-09-09).
+  The block snapshot identifies the innermost and outermost table but not the
+  full parent-cell path. Until it does, two nested tables in different parent
+  cells can align by document order without enough information to replace the
+  outer table safely.
 - **A paired table's grid is not moved** (2026-09-07). `w:tblGrid` changes are
   recorded with `w:tblGridChange`, which the editable model does not carry, so
   a table whose columns kept their text and changed their widths keeps the
@@ -367,8 +382,9 @@ carries the current numbers and the failing cases.
   document.
 - **`colspan` and `rowspan` are not moved on a paired cell** (2026-09-07). They
   shape the table's map, and changing one without restructuring the rows around
-  it leaves the map inconsistent with its own grid. A span that changed is a
-  row or column edit, not a property change.
+  it leaves the map inconsistent with its own grid. An unambiguous row or
+  column edit remains granular; otherwise the outer table is replaced as one
+  structural change when a body-level anchor is available.
 - **A numbering definition is reported, not represented** (2026-09-06). A list
   whose format, level template or start changed is a `numbering` change, and
   the redline cannot carry it: OOXML has no tracked-change grammar for

--- a/packages/core/src/compare/compare.ts
+++ b/packages/core/src/compare/compare.ts
@@ -44,7 +44,10 @@ import {
   type FolioRevisionStamp,
 } from "../ai-edits/headless";
 import { projectTableGeometry } from "../ai-edits/table-geometry";
-import type { FolioTableTemplates } from "../ai-edits/table-template";
+import {
+  tableTemplateCanCrossPackageLosslessly,
+  type FolioTableTemplates,
+} from "../ai-edits/table-template";
 import { numberingReferenceKeysOf } from "../ai-edits/snapshot";
 import type { FolioAIBlock, FolioAIEditSkipReason, FolioAIEditSnapshot } from "../ai-edits/types";
 import { createScopedWordDiffOptions, type WordDiffGranularity } from "../ai-edits/word-diff";
@@ -365,21 +368,47 @@ export const parseComparison = async (
 /** One story's plan, kept with the pair it belongs to. */
 export type PlannedStoryComparison = { pair: ComparedStoryPair; plan: CompareStoryPlan };
 
+const planCopiesNonPortableWholeTable = (
+  targetReviewer: FolioDocxReviewer,
+  pair: ComparedStoryPair,
+  plan: CompareStoryPlan,
+): boolean => {
+  const targetTables = new Map(
+    targetReviewer
+      .storyTables({ story: pair.targetStory })
+      .map(({ index, node }) => [index, node] as const),
+  );
+  return plan.tableTemplates.some(({ targetRowIndex, targetTableIndex }) => {
+    if (targetRowIndex !== undefined) {
+      return false;
+    }
+    const table = targetTables.get(targetTableIndex);
+    return table === undefined || !tableTemplateCanCrossPackageLosslessly(table);
+  });
+};
+
 /**
  * Stage 2: align every paired story and derive its operations. Pure — no
  * parsing, no serialization, no clock.
  */
 export const planComparison = ({
   pairs,
+  targetReviewer,
 }: ParsedComparison): Result<readonly PlannedStoryComparison[], CompareDocxOperationLimitError> => {
   const planned: PlannedStoryComparison[] = [];
   for (const pair of pairs) {
-    const plan = planStoryCompare({
-      story: pair.baseStory,
-      baseSnapshot: pair.baseSnapshot,
-      targetSnapshot: pair.targetSnapshot,
-      maxOperations: MAX_COMPARE_OPERATIONS,
-    });
+    const planPair = (wholeTableReplacement: "allow" | "avoid"): CompareStoryPlan | null =>
+      planStoryCompare({
+        story: pair.baseStory,
+        baseSnapshot: pair.baseSnapshot,
+        targetSnapshot: pair.targetSnapshot,
+        maxOperations: MAX_COMPARE_OPERATIONS,
+        wholeTableReplacement,
+      });
+    let plan = planPair("allow");
+    if (plan && planCopiesNonPortableWholeTable(targetReviewer, pair, plan)) {
+      plan = planPair("avoid");
+    }
     if (plan === null) {
       return Result.err(
         new CompareDocxOperationLimitError({

--- a/packages/core/src/compare/plan.test.ts
+++ b/packages/core/src/compare/plan.test.ts
@@ -42,6 +42,7 @@ const gridCell = (
   gridColumnIndex: number,
   columnSpan = 1,
   rowSpan = 1,
+  paragraphIndex = 0,
 ): FolioAIBlock => ({
   id,
   kind: "paragraph",
@@ -54,7 +55,7 @@ const gridCell = (
     gridColumnIndex,
     columnSpan,
     rowSpan,
-    paragraphIndex: 0,
+    paragraphIndex,
   },
 });
 
@@ -126,6 +127,88 @@ describe("table row pairing", () => {
       cell("b", "Delivery is due.", 1),
     ];
     expect(planOf(rows, rows).changes).toEqual([]);
+  });
+
+  test("a span change that cannot align by column replaces the whole table", () => {
+    const base = [
+      block("before", "Before the table."),
+      gridCell("a", "Shared", 0, 0, 0),
+      gridCell("b", "Shared", 0, 1, 1),
+      block("after", "After the table."),
+    ];
+    const target = [
+      block("before-target", "Before the table."),
+      gridCell("merged", "Shared", 0, 0, 0, 2),
+      block("after-target", "After the table."),
+    ];
+
+    const { changes, operations } = planOf(base, target);
+
+    expect(changes.map(({ kind }) => kind)).toEqual(["table-delete", "table-insert"]);
+    expect(operations).toEqual([
+      { id: "compare-1", type: "deleteTable", blockId: "a" },
+      {
+        id: "compare-2",
+        type: "insertTable",
+        blockId: "after",
+        position: "before",
+        rows: [["Shared"]],
+      },
+    ]);
+  });
+
+  test("a compatible row insertion remains one row insertion", () => {
+    const base = [
+      block("before", "Before the table."),
+      cell("kept", "Shared obligation", 0),
+      block("after", "After the table."),
+    ];
+    const target = [
+      block("before-target", "Before the table."),
+      cell("kept-target", "Shared obligation", 0),
+      cell("added", "Additional obligation", 1),
+      block("after-target", "After the table."),
+    ];
+
+    const { changes } = planOf(base, target);
+
+    expect(changes.map(({ kind }) => kind)).toEqual(["table-row-insert"]);
+  });
+
+  test("text-only rewrites in the same table shape stay cell-level", () => {
+    const base = [
+      block("before", "Before the table."),
+      cell("old", "Original obligation", 0),
+      block("after", "After the table."),
+    ];
+    const target = [
+      block("before-target", "Before the table."),
+      cell("new", "Entirely different language", 0),
+      block("after-target", "After the table."),
+    ];
+
+    const { changes } = planOf(base, target);
+
+    expect(changes.map(({ kind }) => kind)).toEqual(["replace"]);
+  });
+
+  test("paragraph-count changes inside one cell do not replace the table", () => {
+    const base = [
+      block("before", "Before the table."),
+      gridCell("kept", "Shared opening", 0, 0, 0),
+      gridCell("removed-a", "Removed middle", 0, 0, 0, 1, 1, 1),
+      gridCell("removed-b", "Removed ending", 0, 0, 0, 1, 1, 2),
+      block("after", "After the table."),
+    ];
+    const target = [
+      block("before-target", "Before the table."),
+      gridCell("kept-target", "Shared opening revised", 0, 0, 0),
+      block("after-target", "After the table."),
+    ];
+
+    const { changes } = planOf(base, target);
+
+    expect(changes.map(({ kind }) => kind)).toEqual(["replace", "delete", "delete"]);
   });
 });
 

--- a/packages/core/src/compare/plan.test.ts
+++ b/packages/core/src/compare/plan.test.ts
@@ -34,15 +34,26 @@ const cell = (id: string, text: string, rowIndex: number, tableIndex = 0): Folio
   },
 });
 
+type GridCellGeometry = {
+  rowIndex: number;
+  cellIndex: number;
+  gridColumnIndex: number;
+  columnSpan?: number;
+  rowSpan?: number;
+  paragraphIndex?: number;
+};
+
 const gridCell = (
   id: string,
   text: string,
-  rowIndex: number,
-  cellIndex: number,
-  gridColumnIndex: number,
-  columnSpan = 1,
-  rowSpan = 1,
-  paragraphIndex = 0,
+  {
+    rowIndex,
+    cellIndex,
+    gridColumnIndex,
+    columnSpan = 1,
+    rowSpan = 1,
+    paragraphIndex = 0,
+  }: GridCellGeometry,
 ): FolioAIBlock => ({
   id,
   kind: "paragraph",
@@ -132,13 +143,18 @@ describe("table row pairing", () => {
   test("a span change that cannot align by column replaces the whole table", () => {
     const base = [
       block("before", "Before the table."),
-      gridCell("a", "Shared", 0, 0, 0),
-      gridCell("b", "Shared", 0, 1, 1),
+      gridCell("a", "Shared", { rowIndex: 0, cellIndex: 0, gridColumnIndex: 0 }),
+      gridCell("b", "Shared", { rowIndex: 0, cellIndex: 1, gridColumnIndex: 1 }),
       block("after", "After the table."),
     ];
     const target = [
       block("before-target", "Before the table."),
-      gridCell("merged", "Shared", 0, 0, 0, 2),
+      gridCell("merged", "Shared", {
+        rowIndex: 0,
+        cellIndex: 0,
+        gridColumnIndex: 0,
+        columnSpan: 2,
+      }),
       block("after-target", "After the table."),
     ];
 
@@ -195,14 +211,32 @@ describe("table row pairing", () => {
   test("paragraph-count changes inside one cell do not replace the table", () => {
     const base = [
       block("before", "Before the table."),
-      gridCell("kept", "Shared opening", 0, 0, 0),
-      gridCell("removed-a", "Removed middle", 0, 0, 0, 1, 1, 1),
-      gridCell("removed-b", "Removed ending", 0, 0, 0, 1, 1, 2),
+      gridCell("kept", "Shared opening", {
+        rowIndex: 0,
+        cellIndex: 0,
+        gridColumnIndex: 0,
+      }),
+      gridCell("removed-a", "Removed middle", {
+        rowIndex: 0,
+        cellIndex: 0,
+        gridColumnIndex: 0,
+        paragraphIndex: 1,
+      }),
+      gridCell("removed-b", "Removed ending", {
+        rowIndex: 0,
+        cellIndex: 0,
+        gridColumnIndex: 0,
+        paragraphIndex: 2,
+      }),
       block("after", "After the table."),
     ];
     const target = [
       block("before-target", "Before the table."),
-      gridCell("kept-target", "Shared opening revised", 0, 0, 0),
+      gridCell("kept-target", "Shared opening revised", {
+        rowIndex: 0,
+        cellIndex: 0,
+        gridColumnIndex: 0,
+      }),
       block("after-target", "After the table."),
     ];
 
@@ -310,13 +344,33 @@ describe("document-terminal paragraph carrier", () => {
     // that carrier and the rest go in front of it, which is what makes the
     // mark count work out without deleting a mark the format keeps.
     const base = [
-      gridCell("a0", "Alpha clause states the agreed position.", 0, 0, 0),
-      gridCell("b0", "Payment falls due within thirty days of invoice.", 0, 1, 1),
+      gridCell("a0", "Alpha clause states the agreed position.", {
+        rowIndex: 0,
+        cellIndex: 0,
+        gridColumnIndex: 0,
+      }),
+      gridCell("b0", "Payment falls due within thirty days of invoice.", {
+        rowIndex: 0,
+        cellIndex: 1,
+        gridColumnIndex: 1,
+      }),
     ];
     const target = [
-      gridCell("ta", "Alpha clause states the agreed position.", 0, 0, 0),
-      gridCell("tb", "Notices travel to the address named above.", 0, 0, 0),
-      gridCell("tc", "Governing law is that of the named place.", 0, 0, 0),
+      gridCell("ta", "Alpha clause states the agreed position.", {
+        rowIndex: 0,
+        cellIndex: 0,
+        gridColumnIndex: 0,
+      }),
+      gridCell("tb", "Notices travel to the address named above.", {
+        rowIndex: 0,
+        cellIndex: 0,
+        gridColumnIndex: 0,
+      }),
+      gridCell("tc", "Governing law is that of the named place.", {
+        rowIndex: 0,
+        cellIndex: 0,
+        gridColumnIndex: 0,
+      }),
     ];
 
     const { operations } = planOf(base, target);
@@ -374,18 +428,18 @@ describe("document-terminal paragraph carrier", () => {
 describe("table column pairing", () => {
   test("an inserted middle column is one structural edit and leaves its neighbours paired", () => {
     const base = [
-      gridCell("a0", "Account", 0, 0, 0),
-      gridCell("b0", "Amount", 0, 1, 1),
-      gridCell("a1", "Fees", 1, 0, 0),
-      gridCell("b1", "100", 1, 1, 1),
+      gridCell("a0", "Account", { rowIndex: 0, cellIndex: 0, gridColumnIndex: 0 }),
+      gridCell("b0", "Amount", { rowIndex: 0, cellIndex: 1, gridColumnIndex: 1 }),
+      gridCell("a1", "Fees", { rowIndex: 1, cellIndex: 0, gridColumnIndex: 0 }),
+      gridCell("b1", "100", { rowIndex: 1, cellIndex: 1, gridColumnIndex: 1 }),
     ];
     const target = [
-      gridCell("a0-target", "Account", 0, 0, 0),
-      gridCell("x0", "Currency", 0, 1, 1),
-      gridCell("b0-target", "Amount", 0, 2, 2),
-      gridCell("a1-target", "Fees", 1, 0, 0),
-      gridCell("x1", "EUR", 1, 1, 1),
-      gridCell("b1-target", "100", 1, 2, 2),
+      gridCell("a0-target", "Account", { rowIndex: 0, cellIndex: 0, gridColumnIndex: 0 }),
+      gridCell("x0", "Currency", { rowIndex: 0, cellIndex: 1, gridColumnIndex: 1 }),
+      gridCell("b0-target", "Amount", { rowIndex: 0, cellIndex: 2, gridColumnIndex: 2 }),
+      gridCell("a1-target", "Fees", { rowIndex: 1, cellIndex: 0, gridColumnIndex: 0 }),
+      gridCell("x1", "EUR", { rowIndex: 1, cellIndex: 1, gridColumnIndex: 1 }),
+      gridCell("b1-target", "100", { rowIndex: 1, cellIndex: 2, gridColumnIndex: 2 }),
     ];
 
     const { changes, operations } = planOf(base, target);
@@ -404,17 +458,34 @@ describe("table column pairing", () => {
 
   test("a candidate column that cuts a merged cell is not guessed from physical indexes", () => {
     const base = [
-      gridCell("merged", "Account details", 0, 0, 0, 2),
-      gridCell("tail", "Status", 0, 1, 2),
-      gridCell("a1", "Fees", 1, 0, 0),
-      gridCell("removed", "EUR", 1, 1, 1),
-      gridCell("tail1", "Open", 1, 2, 2),
+      gridCell("merged", "Account details", {
+        rowIndex: 0,
+        cellIndex: 0,
+        gridColumnIndex: 0,
+        columnSpan: 2,
+      }),
+      gridCell("tail", "Status", { rowIndex: 0, cellIndex: 1, gridColumnIndex: 2 }),
+      gridCell("a1", "Fees", { rowIndex: 1, cellIndex: 0, gridColumnIndex: 0 }),
+      gridCell("removed", "EUR", { rowIndex: 1, cellIndex: 1, gridColumnIndex: 1 }),
+      gridCell("tail1", "Open", { rowIndex: 1, cellIndex: 2, gridColumnIndex: 2 }),
     ];
     const target = [
-      gridCell("a0-target", "Account details", 0, 0, 0),
-      gridCell("tail-target", "Status", 0, 1, 1),
-      gridCell("a1-target", "Fees", 1, 0, 0),
-      gridCell("tail1-target", "Open", 1, 1, 1),
+      gridCell("a0-target", "Account details", {
+        rowIndex: 0,
+        cellIndex: 0,
+        gridColumnIndex: 0,
+      }),
+      gridCell("tail-target", "Status", {
+        rowIndex: 0,
+        cellIndex: 1,
+        gridColumnIndex: 1,
+      }),
+      gridCell("a1-target", "Fees", { rowIndex: 1, cellIndex: 0, gridColumnIndex: 0 }),
+      gridCell("tail1-target", "Open", {
+        rowIndex: 1,
+        cellIndex: 1,
+        gridColumnIndex: 1,
+      }),
     ];
 
     const { changes } = planOf(base, target);
@@ -426,18 +497,18 @@ describe("table column pairing", () => {
 
   test("a deleted middle column uses a physical-cell anchor for its grid coordinate", () => {
     const base = [
-      gridCell("a0", "Account", 0, 0, 0),
-      gridCell("x0", "Currency", 0, 1, 1),
-      gridCell("b0", "Status", 0, 2, 2),
-      gridCell("a1", "Fees", 1, 0, 0),
-      gridCell("x1", "EUR", 1, 1, 1),
-      gridCell("b1", "Open", 1, 2, 2),
+      gridCell("a0", "Account", { rowIndex: 0, cellIndex: 0, gridColumnIndex: 0 }),
+      gridCell("x0", "Currency", { rowIndex: 0, cellIndex: 1, gridColumnIndex: 1 }),
+      gridCell("b0", "Status", { rowIndex: 0, cellIndex: 2, gridColumnIndex: 2 }),
+      gridCell("a1", "Fees", { rowIndex: 1, cellIndex: 0, gridColumnIndex: 0 }),
+      gridCell("x1", "EUR", { rowIndex: 1, cellIndex: 1, gridColumnIndex: 1 }),
+      gridCell("b1", "Open", { rowIndex: 1, cellIndex: 2, gridColumnIndex: 2 }),
     ];
     const target = [
-      gridCell("a0-target", "Account", 0, 0, 0),
-      gridCell("b0-target", "Status", 0, 1, 1),
-      gridCell("a1-target", "Fees", 1, 0, 0),
-      gridCell("b1-target", "Open", 1, 1, 1),
+      gridCell("a0-target", "Account", { rowIndex: 0, cellIndex: 0, gridColumnIndex: 0 }),
+      gridCell("b0-target", "Status", { rowIndex: 0, cellIndex: 1, gridColumnIndex: 1 }),
+      gridCell("a1-target", "Fees", { rowIndex: 1, cellIndex: 0, gridColumnIndex: 0 }),
+      gridCell("b1-target", "Open", { rowIndex: 1, cellIndex: 1, gridColumnIndex: 1 }),
     ];
 
     const { changes, operations } = planOf(base, target);
@@ -447,11 +518,14 @@ describe("table column pairing", () => {
   });
 
   test("repeated empty columns stay ambiguous", () => {
-    const base = [gridCell("a", "", 0, 0, 0), gridCell("b", "", 0, 1, 1)];
+    const base = [
+      gridCell("a", "", { rowIndex: 0, cellIndex: 0, gridColumnIndex: 0 }),
+      gridCell("b", "", { rowIndex: 0, cellIndex: 1, gridColumnIndex: 1 }),
+    ];
     const target = [
-      gridCell("a-target", "", 0, 0, 0),
-      gridCell("x", "", 0, 1, 1),
-      gridCell("b-target", "", 0, 2, 2),
+      gridCell("a-target", "", { rowIndex: 0, cellIndex: 0, gridColumnIndex: 0 }),
+      gridCell("x", "", { rowIndex: 0, cellIndex: 1, gridColumnIndex: 1 }),
+      gridCell("b-target", "", { rowIndex: 0, cellIndex: 2, gridColumnIndex: 2 }),
     ];
 
     expect(planOf(base, target).changes.some(({ kind }) => kind === "table-column-insert")).toBe(
@@ -460,12 +534,15 @@ describe("table column pairing", () => {
   });
 
   test("several inserted columns retain target order at one boundary", () => {
-    const base = [gridCell("a", "Account", 0, 0, 0), gridCell("b", "Status", 0, 1, 1)];
+    const base = [
+      gridCell("a", "Account", { rowIndex: 0, cellIndex: 0, gridColumnIndex: 0 }),
+      gridCell("b", "Status", { rowIndex: 0, cellIndex: 1, gridColumnIndex: 1 }),
+    ];
     const target = [
-      gridCell("a-target", "Account", 0, 0, 0),
-      gridCell("x", "Currency", 0, 1, 1),
-      gridCell("y", "Region", 0, 2, 2),
-      gridCell("b-target", "Status", 0, 3, 3),
+      gridCell("a-target", "Account", { rowIndex: 0, cellIndex: 0, gridColumnIndex: 0 }),
+      gridCell("x", "Currency", { rowIndex: 0, cellIndex: 1, gridColumnIndex: 1 }),
+      gridCell("y", "Region", { rowIndex: 0, cellIndex: 2, gridColumnIndex: 2 }),
+      gridCell("b-target", "Status", { rowIndex: 0, cellIndex: 3, gridColumnIndex: 3 }),
     ];
 
     expect(planOf(base, target).operations).toEqual([
@@ -488,14 +565,14 @@ describe("table column pairing", () => {
 
   test("several deleted columns use their own physical-cell anchors", () => {
     const base = [
-      gridCell("a", "Account", 0, 0, 0),
-      gridCell("x", "Currency", 0, 1, 1),
-      gridCell("y", "Region", 0, 2, 2),
-      gridCell("b", "Status", 0, 3, 3),
+      gridCell("a", "Account", { rowIndex: 0, cellIndex: 0, gridColumnIndex: 0 }),
+      gridCell("x", "Currency", { rowIndex: 0, cellIndex: 1, gridColumnIndex: 1 }),
+      gridCell("y", "Region", { rowIndex: 0, cellIndex: 2, gridColumnIndex: 2 }),
+      gridCell("b", "Status", { rowIndex: 0, cellIndex: 3, gridColumnIndex: 3 }),
     ];
     const target = [
-      gridCell("a-target", "Account", 0, 0, 0),
-      gridCell("b-target", "Status", 0, 1, 1),
+      gridCell("a-target", "Account", { rowIndex: 0, cellIndex: 0, gridColumnIndex: 0 }),
+      gridCell("b-target", "Status", { rowIndex: 0, cellIndex: 1, gridColumnIndex: 1 }),
     ];
 
     expect(planOf(base, target).operations).toEqual([

--- a/packages/core/src/compare/plan.ts
+++ b/packages/core/src/compare/plan.ts
@@ -304,16 +304,24 @@ const groupTables = (blocks: readonly FolioAIBlock[]): FolioAIBlock[][] => {
  * whatever nests inside it — the nth nested table of one answers to the nth of
  * the other.
  */
-const buildTableSegmentSteps = (
+type TableStructurePlan = {
+  steps: CompareStep[];
+  representable: boolean;
+};
+
+const buildTableSegmentPlan = (
   baseBlocks: readonly FolioAIBlock[],
   targetBlocks: readonly FolioAIBlock[],
-): CompareStep[] => {
+): TableStructurePlan => {
   const baseTables = groupTables(baseBlocks);
   const targetTables = groupTables(targetBlocks);
   const steps: CompareStep[] = [];
   const paired = Math.min(baseTables.length, targetTables.length);
+  let representable = baseTables.length === targetTables.length;
   for (let index = 0; index < paired; index++) {
-    steps.push(...buildTableSteps(baseTables[index] ?? [], targetTables[index] ?? []));
+    const table = buildTablePlan(baseTables[index] ?? [], targetTables[index] ?? []);
+    steps.push(...table.steps);
+    representable &&= table.representable;
   }
   for (const blocks of baseTables.slice(paired)) {
     const location = blocks.at(0)?.table;
@@ -327,7 +335,7 @@ const buildTableSegmentSteps = (
       steps.push({ type: "targetTable", blocks, location });
     }
   }
-  return steps;
+  return { steps, representable };
 };
 
 /**
@@ -354,29 +362,21 @@ const rowSimilarity = (
   return rowCellTexts(base).length === rowCellTexts(target).length ? text : text / 2;
 };
 
-/**
- * Align one table's rows.
- *
- * Exact text first, then SIMILARITY rather than position. Positional fallback
- * is what made a deleted row plus a few cell edits report as a change in every
- * row of the table: each row was paired with the one below it, so every cell
- * differed. Pairing on similarity, and stepping one row on the side whose next
- * row matches better, keeps the deletion where it happened.
- */
-const alignTableRows = (
+type TableRowAlignment =
+  | {
+      type: "pair";
+      baseRow: readonly FolioAIBlock[];
+      targetRow: readonly FolioAIBlock[];
+    }
+  | { type: "baseOnly"; row: readonly FolioAIBlock[] }
+  | { type: "targetOnly"; row: readonly FolioAIBlock[] };
+
+/** Pair table rows once so planning and representability checks cannot drift. */
+const pairTableRows = (
   baseRows: readonly FolioAIBlock[][],
   targetRows: readonly FolioAIBlock[][],
-  baseColumnKeys?: ReadonlyMap<number, number>,
-  targetColumnKeys?: ReadonlyMap<number, number>,
-): CompareStep[] => {
-  const steps: CompareStep[] = [];
-  const pushRow = (row: readonly FolioAIBlock[], side: "base" | "target"): void => {
-    const location = rowLocation(row);
-    if (location) {
-      steps.push({ type: side === "base" ? "baseRow" : "targetRow", blocks: row, location });
-    }
-  };
-
+): TableRowAlignment[] => {
+  const aligned: TableRowAlignment[] = [];
   let baseCursor = 0;
   let targetCursor = 0;
   while (baseCursor < baseRows.length && targetCursor < targetRows.length) {
@@ -390,45 +390,122 @@ const alignTableRows = (
       const baseAhead = rowSimilarity(baseRows[baseCursor + 1], targetRow);
       const targetAhead = rowSimilarity(baseRow, targetRows[targetCursor + 1]);
       if (baseAhead >= ROW_PAIR_SIMILARITY && baseAhead > here && baseAhead >= targetAhead) {
-        pushRow(baseRow, "base");
+        aligned.push({ type: "baseOnly", row: baseRow });
         baseCursor += 1;
         continue;
       }
       if (targetAhead >= ROW_PAIR_SIMILARITY && targetAhead > here) {
-        pushRow(targetRow, "target");
+        aligned.push({ type: "targetOnly", row: targetRow });
         targetCursor += 1;
         continue;
       }
     }
-    steps.push(...alignRowCells(baseRow, targetRow, baseColumnKeys, targetColumnKeys));
+    aligned.push({ type: "pair", baseRow, targetRow });
     baseCursor += 1;
     targetCursor += 1;
   }
   for (const row of baseRows.slice(baseCursor)) {
-    pushRow(row, "base");
+    aligned.push({ type: "baseOnly", row });
   }
   for (const row of targetRows.slice(targetCursor)) {
-    pushRow(row, "target");
+    aligned.push({ type: "targetOnly", row });
+  }
+  return aligned;
+};
+
+/**
+ * Align one table's rows.
+ *
+ * Exact text first, then SIMILARITY rather than position. Positional fallback
+ * is what made a deleted row plus a few cell edits report as a change in every
+ * row of the table: each row was paired with the one below it, so every cell
+ * differed. Pairing on similarity, and stepping one row on the side whose next
+ * row matches better, keeps the deletion where it happened.
+ */
+const alignTableRows = (
+  rows: readonly TableRowAlignment[],
+  baseColumnKeys?: ReadonlyMap<number, number>,
+  targetColumnKeys?: ReadonlyMap<number, number>,
+): CompareStep[] => {
+  const steps: CompareStep[] = [];
+  const pushRow = (row: readonly FolioAIBlock[], side: "base" | "target"): void => {
+    const location = rowLocation(row);
+    if (location) {
+      steps.push({ type: side === "base" ? "baseRow" : "targetRow", blocks: row, location });
+    }
+  };
+
+  for (const alignment of rows) {
+    if (alignment.type === "baseOnly") {
+      pushRow(alignment.row, "base");
+      continue;
+    }
+    if (alignment.type === "targetOnly") {
+      pushRow(alignment.row, "target");
+      continue;
+    }
+    steps.push(
+      ...alignRowCells(alignment.baseRow, alignment.targetRow, baseColumnKeys, targetColumnKeys),
+    );
   }
   return steps;
 };
 
-const buildTableSteps = (
+const rowCellSpansEqual = (
+  baseRow: readonly FolioAIBlock[],
+  targetRow: readonly FolioAIBlock[],
+): boolean => {
+  const cells = (row: readonly FolioAIBlock[]): FolioAIBlockTableLocation[] => {
+    const byPhysicalIndex = new Map<number, FolioAIBlockTableLocation>();
+    for (const block of row) {
+      const table = block.table ?? panic("A table row contains a body block");
+      if (!byPhysicalIndex.has(table.cellIndex)) {
+        byPhysicalIndex.set(table.cellIndex, table);
+      }
+    }
+    return [...byPhysicalIndex.values()];
+  };
+  const baseCells = cells(baseRow);
+  const targetCells = cells(targetRow);
+  if (baseCells.length !== targetCells.length) {
+    return false;
+  }
+  return baseCells.every((base, index) => {
+    const target = targetCells[index];
+    return (
+      target !== undefined &&
+      base.gridColumnIndex === target.gridColumnIndex &&
+      base.columnSpan === target.columnSpan &&
+      base.rowSpan === target.rowSpan
+    );
+  });
+};
+
+const rowHasVerticalSpan = (row: readonly FolioAIBlock[]): boolean =>
+  row.some(({ table }) => table !== undefined && table.rowSpan > 1);
+
+const buildTablePlan = (
   baseBlocks: readonly FolioAIBlock[],
   targetBlocks: readonly FolioAIBlock[],
-): CompareStep[] => {
+): TableStructurePlan => {
   const columns = alignTableColumns(baseBlocks, targetBlocks);
-  return columns
-    ? [
-        ...columns.steps,
-        ...alignTableRows(
-          groupRows(columns.baseBlocks),
-          groupRows(columns.targetBlocks),
-          columns.baseColumnKeys,
-          columns.targetColumnKeys,
-        ),
-      ]
-    : alignTableRows(groupRows(baseBlocks), groupRows(targetBlocks));
+  const rows = pairTableRows(
+    groupRows(columns?.baseBlocks ?? baseBlocks),
+    groupRows(columns?.targetBlocks ?? targetBlocks),
+  );
+  const representable = rows.every((row) => {
+    if (row.type === "pair") {
+      return columns !== null || rowCellSpansEqual(row.baseRow, row.targetRow);
+    }
+    return !rowHasVerticalSpan(row.row);
+  });
+  return {
+    representable,
+    steps: [
+      ...(columns?.steps ?? []),
+      ...alignTableRows(rows, columns?.baseColumnKeys, columns?.targetColumnKeys),
+    ],
+  };
 };
 
 const buildBodySteps = (
@@ -473,6 +550,7 @@ const unpairedSegmentSteps = (segment: DocumentSegment, side: "base" | "target")
 type BuildStepsOptions = {
   baseSnapshot: FolioAIEditSnapshot;
   targetSnapshot: FolioAIEditSnapshot;
+  wholeTableReplacement: "allow" | "avoid";
 };
 
 /**
@@ -592,20 +670,29 @@ const alignedSteps = (
   baseBlocks: readonly FolioAIBlock[],
   targetBlocks: readonly FolioAIBlock[],
   terminalCarrierPair: TerminalCarrierPair | null,
+  wholeTableReplacement: BuildStepsOptions["wholeTableReplacement"],
 ): CompareStep[] => {
   const alignedBaseBlocks = terminalCarrierPair ? baseBlocks.slice(0, -1) : baseBlocks;
   const alignedTargetBlocks = terminalCarrierPair ? targetBlocks.slice(0, -1) : targetBlocks;
+  const canReplaceWholeTable =
+    wholeTableReplacement === "allow" && alignedBaseBlocks.some(({ table }) => table === undefined);
   const steps: CompareStep[] = [];
   for (const { baseSegment, targetSegment } of alignSegments(
     splitSegments(alignedBaseBlocks),
     splitSegments(alignedTargetBlocks),
   )) {
     if (baseSegment && targetSegment) {
-      steps.push(
-        ...(baseSegment.kind === "table"
-          ? buildTableSegmentSteps(baseSegment.blocks, targetSegment.blocks)
-          : buildBodySteps(baseSegment.blocks, targetSegment.blocks)),
-      );
+      if (baseSegment.kind !== "table") {
+        steps.push(...buildBodySteps(baseSegment.blocks, targetSegment.blocks));
+        continue;
+      }
+      const table = buildTableSegmentPlan(baseSegment.blocks, targetSegment.blocks);
+      if (canReplaceWholeTable && !table.representable) {
+        steps.push(...unpairedSegmentSteps(baseSegment, "base"));
+        steps.push(...unpairedSegmentSteps(targetSegment, "target"));
+        continue;
+      }
+      steps.push(...table.steps);
       continue;
     }
     if (baseSegment) {
@@ -695,7 +782,11 @@ const addedTerminalCarrierIsStranded = (
   );
 };
 
-const buildSteps = ({ baseSnapshot, targetSnapshot }: BuildStepsOptions): CompareStep[] => {
+const buildSteps = ({
+  baseSnapshot,
+  targetSnapshot,
+  wholeTableReplacement,
+}: BuildStepsOptions): CompareStep[] => {
   const baseBlocks = baseSnapshot.blocks;
   const targetBlocks = targetSnapshot.blocks;
   const baseLast = baseBlocks.at(-1);
@@ -712,7 +803,12 @@ const buildSteps = ({ baseSnapshot, targetSnapshot }: BuildStepsOptions): Compar
     carrierPair !== null &&
     isEmptyParagraphNode(carrierPair.baseBlock, baseSnapshot) &&
     isEmptyParagraphNode(carrierPair.targetBlock, targetSnapshot);
-  const steps = alignedSteps(baseBlocks, targetBlocks, bothStoriesEndBlank ? carrierPair : null);
+  const steps = alignedSteps(
+    baseBlocks,
+    targetBlocks,
+    bothStoriesEndBlank ? carrierPair : null,
+    wholeTableReplacement,
+  );
   // Otherwise the reservation is a repair, not a preference, and the alignment
   // is what says whether it is needed: pairing the two last paragraphs where
   // the ordinary alignment reaches the carrier would trade a plain "this
@@ -734,7 +830,7 @@ const buildSteps = ({ baseSnapshot, targetSnapshot }: BuildStepsOptions): Compar
   ) {
     return steps;
   }
-  return alignedSteps(baseBlocks, targetBlocks, carrierPair);
+  return alignedSteps(baseBlocks, targetBlocks, carrierPair, wholeTableReplacement);
 };
 
 /**
@@ -1401,6 +1497,8 @@ export type PlanStoryCompareOptions = {
   targetSnapshot: FolioAIEditSnapshot;
   /** Cap on generated operations; the caller turns `null` into its own error. */
   maxOperations: number;
+  /** Avoid structural fallback when copying the target table would lose package-bound content. */
+  wholeTableReplacement?: "allow" | "avoid";
 };
 
 /**
@@ -1412,8 +1510,9 @@ export const planStoryCompare = ({
   baseSnapshot,
   targetSnapshot,
   maxOperations,
+  wholeTableReplacement = "allow",
 }: PlanStoryCompareOptions): CompareStoryPlan | null => {
-  const steps = buildSteps({ baseSnapshot, targetSnapshot });
+  const steps = buildSteps({ baseSnapshot, targetSnapshot, wholeTableReplacement });
   const paragraphMarkPlans = detectParagraphMarkEdits(steps);
   // The step after each paragraph-mark plan is part of it, so neither the move
   // pass nor the main loop may claim it again.

--- a/packages/core/src/compare/plan.ts
+++ b/packages/core/src/compare/plan.ts
@@ -436,17 +436,28 @@ const alignTableRows = (
   };
 
   for (const alignment of rows) {
-    if (alignment.type === "baseOnly") {
-      pushRow(alignment.row, "base");
-      continue;
+    switch (alignment.type) {
+      case "baseOnly":
+        pushRow(alignment.row, "base");
+        break;
+      case "targetOnly":
+        pushRow(alignment.row, "target");
+        break;
+      case "pair":
+        steps.push(
+          ...alignRowCells(
+            alignment.baseRow,
+            alignment.targetRow,
+            baseColumnKeys,
+            targetColumnKeys,
+          ),
+        );
+        break;
+      default: {
+        const unreachable: never = alignment;
+        panic("Unhandled table row alignment", { alignment: unreachable });
+      }
     }
-    if (alignment.type === "targetOnly") {
-      pushRow(alignment.row, "target");
-      continue;
-    }
-    steps.push(
-      ...alignRowCells(alignment.baseRow, alignment.targetRow, baseColumnKeys, targetColumnKeys),
-    );
   }
   return steps;
 };

--- a/packages/core/src/compare/probes.test.ts
+++ b/packages/core/src/compare/probes.test.ts
@@ -1104,10 +1104,10 @@ describe("single-mutation probes", () => {
     );
   });
 
-  test("unrepresentable_difference: refused by default, emitted and named on request", async () => {
+  test("ambiguous_column_change: replaces the table instead of guessing a column", async () => {
     // Every column is empty, so there is no evidence for which of the three
     // target columns is new. Guessing would produce a plausible but misleading
-    // structural change; the conservative alignment leaves it unrepresented.
+    // column edit; replacing the table preserves both reviewed views exactly.
     const base = await buildBodySequenceDocx([
       { kind: "paragraph", text: "The schedule below records the agreed fees." },
       { kind: "table", rows: [["", ""]] },
@@ -1119,30 +1119,18 @@ describe("single-mutation probes", () => {
       { kind: "paragraph", text: "This agreement is governed by the stated law." },
     ]);
 
-    const refused = await compareDocx(base, target, OPTIONS);
-    expect(refused.isErr()).toBe(true);
-    if (refused.isErr()) {
-      const error = refused.error;
-      expect(error._tag).toBe("CompareDocxRoundTripError");
-      if (error._tag === "CompareDocxRoundTripError") {
-        expect(error.invariant).toBe("accept-reproduces-target");
-        expect(error.cause).toBe("container");
-        expect(error.failures.length).toBeGreaterThan(0);
-        // Structural facts only: nothing a document said.
-        expect(error.failures.at(0)?.detail).not.toContain("schedule below");
-      }
+    const result = await compareDocx(base, target, OPTIONS);
+    if (result.isErr()) {
+      throw result.error;
     }
-
-    const emitted = await compareDocx(base, target, { ...OPTIONS, onUnverified: "emit" });
-    if (emitted.isErr()) {
-      throw emitted.error;
-    }
-    expect(emitted.value.buffer.byteLength).toBeGreaterThan(0);
-    expect(emitted.value.changes.length).toBeGreaterThan(0);
-    expect(emitted.value.verification.status).toBe("unverified");
-    if (emitted.value.verification.status === "unverified") {
-      expect(emitted.value.verification.failures.map(({ cause }) => cause)).toContain("container");
-    }
+    expect(result.value.verification.status).toBe("verified");
+    expect(result.value.changes.map(({ kind }) => kind)).toEqual(["table-delete", "table-insert"]);
+    expect(await projectView(result.value.buffer, "final")).toEqual(
+      await projectView(target, "final"),
+    );
+    expect(await projectView(result.value.buffer, "original")).toEqual(
+      await projectView(base, "final"),
+    );
   });
 
   test("append_paragraph_then_table: additions past the last block keep target order", async () => {

--- a/packages/core/src/compare/tableGeometry.test.ts
+++ b/packages/core/src/compare/tableGeometry.test.ts
@@ -360,7 +360,14 @@ type GeneratedCell = {
   shadingFill?: string;
 };
 
-const buildCell = (column: number, gridSpan: number, content: string, shaded: boolean) => {
+type BuildCellOptions = {
+  column: number;
+  gridSpan: number;
+  content: string;
+  shaded: boolean;
+};
+
+const buildCell = ({ column, gridSpan, content, shaded }: BuildCellOptions) => {
   const cell: GeneratedCell = {
     content,
     width: COLUMN_WIDTHS.slice(column, column + gridSpan).reduce((sum, width) => sum + width, 0),
@@ -381,7 +388,7 @@ const cellArbitrary = (column: number, spanAllowance: number): fc.Arbitrary<Gene
       gridSpan: fc.integer({ min: 1, max: Math.max(1, spanAllowance) }),
       shaded: fc.boolean(),
     })
-    .map(({ content, gridSpan, shaded }) => buildCell(column, gridSpan, content, shaded));
+    .map(({ content, gridSpan, shaded }) => buildCell({ column, gridSpan, content, shaded }));
 
 const buildRow = (cells: readonly GeneratedCell[], header: boolean, height: number | null) => {
   const row: { cells: readonly GeneratedCell[]; header?: boolean; height?: number } = { cells };
@@ -428,9 +435,9 @@ describe("table geometry round trip", () => {
       rows: [
         {
           cells: [
-            buildCell(0, 1, "Shared", false),
-            buildCell(1, 1, "Shared", false),
-            buildCell(2, 1, "Shared", false),
+            buildCell({ column: 0, gridSpan: 1, content: "Shared", shaded: false }),
+            buildCell({ column: 1, gridSpan: 1, content: "Shared", shaded: false }),
+            buildCell({ column: 2, gridSpan: 1, content: "Shared", shaded: false }),
           ],
         },
       ],
@@ -439,7 +446,10 @@ describe("table geometry round trip", () => {
       ...baseTable,
       rows: [
         {
-          cells: [buildCell(0, 2, "Shared", false), buildCell(2, 1, "Shared", false)],
+          cells: [
+            buildCell({ column: 0, gridSpan: 2, content: "Shared", shaded: false }),
+            buildCell({ column: 2, gridSpan: 1, content: "Shared", shaded: false }),
+          ],
         },
       ],
     } as const satisfies BodyItem;

--- a/packages/core/src/compare/tableGeometry.test.ts
+++ b/packages/core/src/compare/tableGeometry.test.ts
@@ -420,6 +420,173 @@ const tableArbitrary = (): fc.Arbitrary<BodyItem> =>
   }));
 
 describe("table geometry round trip", () => {
+  test("replaces a table whose paired cell spans cannot be revised in place", async () => {
+    const baseTable = {
+      kind: "table",
+      columnWidths: [...COLUMN_WIDTHS],
+      properties: { width: { value: 6000, type: "dxa" }, borderSize: 4 },
+      rows: [
+        {
+          cells: [
+            buildCell(0, 1, "Shared", false),
+            buildCell(1, 1, "Shared", false),
+            buildCell(2, 1, "Shared", false),
+          ],
+        },
+      ],
+    } as const satisfies BodyItem;
+    const targetTable = {
+      ...baseTable,
+      rows: [
+        {
+          cells: [buildCell(0, 2, "Shared", false), buildCell(2, 1, "Shared", false)],
+        },
+      ],
+    } as const satisfies BodyItem;
+    const base = await buildBodySequenceDocx([INTRO, baseTable, OUTRO]);
+    const target = await buildBodySequenceDocx([INTRO, targetTable, OUTRO]);
+
+    const result = await compareDocx(base, target, OPTIONS);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value.verification.status).toBe("verified");
+    expect(result.value.changes.map(({ kind }) => kind)).toEqual(["table-delete", "table-insert"]);
+
+    const compared = await FolioDocxReviewer.fromBuffer(result.value.buffer);
+    expect(projectTableGeometry(compared.storyTables({ view: "final" }))).toEqual(
+      projectTableGeometry((await FolioDocxReviewer.fromBuffer(target)).storyTables()),
+    );
+    expect(projectTableGeometry(compared.storyTables({ view: "original" }))).toEqual(
+      projectTableGeometry((await FolioDocxReviewer.fromBuffer(base)).storyTables()),
+    );
+  });
+
+  test("replaces a table when inserted rows carry a vertical merge", async () => {
+    const kept = "The retained row identifies the same obligation on both sides.";
+    const baseTable = {
+      kind: "table",
+      columnWidths: [2400, 2400],
+      rows: [[kept, kept]],
+    } as const satisfies BodyItem;
+    const targetTable = {
+      ...baseTable,
+      rows: [
+        ...baseTable.rows,
+        [{ content: "New merged owner", verticalMerge: "restart" }, "Right upper cell"],
+        [{ content: "", verticalMerge: "continue" }, "Right lower cell"],
+      ],
+    } as const satisfies BodyItem;
+    const base = await buildBodySequenceDocx([INTRO, baseTable, OUTRO]);
+    const target = await buildBodySequenceDocx([INTRO, targetTable, OUTRO]);
+
+    const result = await compareDocx(base, target, OPTIONS);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value.verification.status).toBe("verified");
+    expect(result.value.changes.map(({ kind }) => kind)).toEqual(["table-delete", "table-insert"]);
+
+    const compared = await FolioDocxReviewer.fromBuffer(result.value.buffer);
+    expect(projectTableGeometry(compared.storyTables({ view: "final" }))).toEqual(
+      projectTableGeometry((await FolioDocxReviewer.fromBuffer(target)).storyTables()),
+    );
+    expect(projectTableGeometry(compared.storyTables({ view: "original" }))).toEqual(
+      projectTableGeometry((await FolioDocxReviewer.fromBuffer(base)).storyTables()),
+    );
+  });
+
+  test("keeps a representable long row addition granular", async () => {
+    const baseTable = {
+      kind: "table",
+      columnWidths: [2400, 2400],
+      rows: [["Alpha", "Beta"]],
+    } as const satisfies BodyItem;
+    const targetTable = {
+      ...baseTable,
+      rows: [
+        ...baseTable.rows,
+        ["one two three four five six seven eight nine ten", "Additional owner"],
+      ],
+    } as const satisfies BodyItem;
+    const base = await buildBodySequenceDocx([INTRO, baseTable, OUTRO]);
+    const target = await buildBodySequenceDocx([INTRO, targetTable, OUTRO]);
+
+    const result = await compareDocx(base, target, OPTIONS);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value.verification.status).toBe("verified");
+    expect(result.value.changes.map(({ kind }) => kind)).toEqual(["table-row-insert"]);
+  });
+
+  test("does not replace a table when its template would lose a hyperlink", async () => {
+    const linkedParagraph = {
+      kind: "paragraph",
+      text: [{ text: "Shared", href: "https://example.com" }],
+    } as const satisfies BodyItem;
+    const baseTable = {
+      kind: "table",
+      columnWidths: [2400, 2400],
+      rows: [[{ content: [linkedParagraph] }, "Shared"]],
+    } as const satisfies BodyItem;
+    const targetTable = {
+      ...baseTable,
+      rows: [[{ content: [linkedParagraph], gridSpan: 2 }]],
+    } as const satisfies BodyItem;
+    const base = await buildBodySequenceDocx([INTRO, baseTable, OUTRO]);
+    const target = await buildBodySequenceDocx([INTRO, targetTable, OUTRO]);
+
+    const strict = await compareDocx(base, target, OPTIONS);
+    expect(strict.isErr()).toBe(true);
+    if (strict.isErr()) {
+      expect(strict.error._tag).toBe("CompareDocxRoundTripError");
+    }
+
+    const emitted = await compareDocx(base, target, { ...OPTIONS, onUnverified: "emit" });
+    if (emitted.isErr()) {
+      throw emitted.error;
+    }
+    expect(emitted.value.verification.status).toBe("unverified");
+    expect(emitted.value.changes.map(({ kind }) => kind)).not.toContain("table-insert");
+    expect(await documentXml(emitted.value.buffer)).toContain("<w:hyperlink ");
+  });
+
+  test("keeps a nested-table relocation explicitly unverified", async () => {
+    const nested = {
+      kind: "table",
+      columnWidths: [2400],
+      rows: [["Nested schedule"]],
+    } as const satisfies BodyItem;
+    const paragraph = (text: string) => ({ kind: "paragraph", text }) as const;
+    const baseTable = {
+      kind: "table",
+      columnWidths: [2400, 2400],
+      rows: [[{ content: [paragraph("Left"), nested, paragraph("After nested")] }, "Right"]],
+    } as const satisfies BodyItem;
+    const targetTable = {
+      ...baseTable,
+      rows: [["Left", { content: [paragraph("Right"), nested, paragraph("After nested")] }]],
+    } as const satisfies BodyItem;
+    const base = await buildBodySequenceDocx([INTRO, baseTable, OUTRO]);
+    const target = await buildBodySequenceDocx([INTRO, targetTable, OUTRO]);
+
+    const strict = await compareDocx(base, target, OPTIONS);
+    expect(strict.isErr()).toBe(true);
+    if (strict.isErr()) {
+      expect(strict.error._tag).toBe("CompareDocxRoundTripError");
+    }
+
+    const emitted = await compareDocx(base, target, { ...OPTIONS, onUnverified: "emit" });
+    if (emitted.isErr()) {
+      throw emitted.error;
+    }
+    expect(emitted.value.verification.status).toBe("unverified");
+    if (emitted.value.verification.status === "unverified") {
+      expect(emitted.value.verification.failures.map(({ cause }) => cause)).toContain("container");
+    }
+  });
+
   test(
     "accepting reproduces the target's table model and rejecting reproduces the base's",
     async () => {
@@ -427,19 +594,11 @@ describe("table geometry round trip", () => {
         fc.asyncProperty(tableArbitrary(), tableArbitrary(), async (baseTable, targetTable) => {
           const base = await buildBodySequenceDocx([INTRO, baseTable, OUTRO]);
           const target = await buildBodySequenceDocx([INTRO, targetTable, OUTRO]);
-          const result = await compareDocx(base, target, {
-            ...OPTIONS,
-            onUnverified: "emit",
-          });
+          const result = await compareDocx(base, target, OPTIONS);
           if (result.isErr()) {
             throw result.error;
           }
-          // An unproven redline is a separate finding the rest of the suite
-          // owns; what is asserted here is that whatever it did produce
-          // round-trips at the table model.
-          if (result.value.verification.status === "unverified") {
-            return;
-          }
+          expect(result.value.verification.status).toBe("verified");
           const compared = await FolioDocxReviewer.fromBuffer(result.value.buffer);
           expect(projectTableGeometry(compared.storyTables({ view: "final" }))).toEqual(
             projectTableGeometry((await FolioDocxReviewer.fromBuffer(target)).storyTables()),


### PR DESCRIPTION
## Summary

- replace paired tables as one deletion and insertion when row, cell, span, vertical-merge, or nested-table structure cannot be expressed safely by granular operations
- retain granular text, row, and column edits whenever the structural plan is representable
- preflight target table templates and retain an explicitly unverified granular result when a cross-package copy would strip relationships or annotations
- share row and column alignment between representability checks and operation planning

## Validation

- full folio-core test suite
- focused table geometry, comparison probe, and planner tests
- core typecheck and repository build
- lint and formatting checks on changed files
- API report and declaration-budget checks
- deterministic comparison and performance regression gates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved document comparisons for complex tables, including merged cells, changing spans, inserted rows and paragraph changes.
  * Tables that cannot be safely edited in place can now be replaced as a whole, improving round-trip accuracy.
  * Granular row and cell edits remain available when the table structure supports them.

* **Bug Fixes**
  * Improved preservation of hyperlinks and other package-bound content during table comparisons.
  * Ambiguous column changes now produce a verified whole-table result where possible, rather than being rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->