### PR TITLE
fix(core): bound headless revision resolution cost

### DIFF
--- a/.changeset/quick-headless-revisions.md
+++ b/.changeset/quick-headless-revisions.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Bound the cost of resolving large tracked-change batches in synchronous headless review workflows.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,6 +46,7 @@
     "./docx": "./src/docx/index.ts",
     "./docx/document-clone": "./src/docx/documentClone.ts",
     "./docx/paragraphPropertySource": null,
+    "./internal/*": null,
     "./*": "./src/*.ts"
   },
   "publishConfig": {

--- a/packages/core/src/ai-edits/headless.ts
+++ b/packages/core/src/ai-edits/headless.ts
@@ -37,11 +37,11 @@ import {
 } from "../docx/footnoteParser";
 import { parseDocx } from "../docx/parser";
 import { repackDocx } from "../docx/rezip";
+import { pluginsForHeadlessRevisionResolution } from "../internal/headlessRevisionResolutionGuard";
 import {
   acceptAIEditRevision,
-  acceptAllChanges,
   rejectAIEditRevision,
-  rejectAllChanges,
+  resolveAllChangesInHeadlessState,
 } from "../prosemirror/commands/comments";
 import { proseDocToBlocks, updateDocumentContent } from "../prosemirror/conversion/fromProseDoc";
 import {
@@ -411,20 +411,17 @@ export const isFolioReviewedView = (value: unknown): value is FolioReviewedView 
 export const isFolioResolvedReviewedView = (value: unknown): value is FolioResolvedReviewedView =>
   FOLIO_RESOLVED_REVIEWED_VIEWS.some((view) => view === value);
 
-const applyCommandToState = (state: EditorState, command: Command): EditorState => {
-  let nextState = state;
-  command(state, (transaction) => {
-    nextState = nextState.apply(transaction);
-  });
-  return nextState;
-};
-
 const resolveReviewedState = (state: EditorState, view: FolioReviewedView): EditorState => {
   if (view === "current-markup") {
     return state;
   }
-  return applyCommandToState(state, view === "original" ? rejectAllChanges() : acceptAllChanges());
+  return resolveAllChangesInHeadlessState(state, view === "original" ? "reject" : "accept");
 };
+
+const createHeadlessPlugins = (styles: Document["package"]["styles"]): Plugin[] => [
+  ...pluginsForHeadlessRevisionResolution(singletonManager.getPlugins()),
+  createDocumentStylesPlugin(styles),
+];
 
 const formatStoryStateForLLM = (state: EditorState, annotated: boolean): string => {
   const snapshot = createFolioAIEditSnapshot(state.doc);
@@ -617,14 +614,11 @@ export class FolioDocxReviewer {
       preloadFonts: false,
       password: options.password,
     });
-    // Same plugin set the live editor mounts: the change tracker feeds the
-    // selective-save key set, and the paraId allocator hands freshly inserted
-    // paragraphs a stable `w14:paraId`. No plugin `view()` runs headlessly, so
-    // the DOM-facing halves stay dormant.
-    const plugins: Plugin[] = [
-      ...singletonManager.getPlugins(),
-      createDocumentStylesPlugin(baseDocument.package.styles),
-    ];
+    // The change tracker feeds selective save, and the paraId allocator hands
+    // inserted paragraphs stable ids. Editor history and collaboration are
+    // intentionally absent: reviewer undo stores complete state snapshots,
+    // and headless resolution consumes its replacement transaction locally.
+    const plugins = createHeadlessPlugins(baseDocument.package.styles);
     // Allocate paraIds up front (the editor does this on load) so every block
     // anchors on a stable id and the selective-save path can key changed
     // paragraphs by paraId. Deterministic (not random) allocation so a
@@ -1282,15 +1276,15 @@ export class FolioDocxReviewer {
    * document still carries a redline nobody can see from the body.
    */
   acceptAll(): number {
-    return this.resolveEveryStory(acceptAllChanges());
+    return this.resolveEveryStory("accept");
   }
 
   /** Reject every tracked change in the package. See {@link acceptAll}. */
   rejectAll(): number {
-    return this.resolveEveryStory(rejectAllChanges());
+    return this.resolveEveryStory("reject");
   }
 
-  private resolveEveryStory(command: Command): number {
+  private resolveEveryStory(mode: "accept" | "reject"): number {
     let count = 0;
     for (const { handle } of this.listStories()) {
       const state = this.getEditableStoryState(handle);
@@ -1298,7 +1292,7 @@ export class FolioDocxReviewer {
         continue;
       }
       count += getTrackedChangesFromDoc(state.doc).length;
-      this.runStoryCommand(command, handle);
+      this.setEditableStoryState(handle, resolveAllChangesInHeadlessState(state, mode));
     }
     return count;
   }
@@ -1455,10 +1449,7 @@ export class FolioDocxReviewer {
       EditorState.create({
         schema,
         doc: ensureDeterministicParaIdsInDoc(storyDoc),
-        plugins: [
-          ...singletonManager.getPlugins(),
-          createDocumentStylesPlugin(this.baseDocument.package.styles),
-        ],
+        plugins: createHeadlessPlugins(this.baseDocument.package.styles),
       }),
     );
     this.secondaryStoryStates.set(key, { handle: story, initialState: state, state });

--- a/packages/core/src/internal/headlessRevisionResolution.ts
+++ b/packages/core/src/internal/headlessRevisionResolution.ts
@@ -1,0 +1,208 @@
+import { panic } from "better-result";
+import { Fragment, Slice, type Mark, type MarkType, type Node as PMNode } from "prosemirror-model";
+import type { Transaction } from "prosemirror-state";
+import { ReplaceStep, StepMap, type Mappable } from "prosemirror-transform";
+
+import { recreateProseNodeWithParagraphPropertySource } from "../docx/paragraphPropertySource";
+import { expectRunPropertyChangeMarkAttrs } from "../prosemirror/attrs";
+import { textFormattingToMarks } from "../prosemirror/conversion/toProseDoc";
+import { RUN_FORMATTING_MARK_NAMES } from "../prosemirror/runFormattingMarkNames";
+
+export type HeadlessRevisionResolutionMode = "accept" | "reject";
+
+type HeadlessDeleteRange = {
+  from: number;
+  to: number;
+};
+
+type HeadlessInlineContext = {
+  mode: HeadlessRevisionResolutionMode;
+  keepType: MarkType | undefined;
+  removeType: MarkType | undefined;
+  deleteRanges: HeadlessDeleteRange[];
+  changedParagraphRanges: HeadlessDeleteRange[];
+};
+
+export type HeadlessInlineChangeTracking = {
+  ranges: readonly HeadlessDeleteRange[];
+  mappingFrom: number;
+};
+
+/**
+ * A synchronous headless replacement with the granular position map of the
+ * inline deletions it applies. It must never enter history or collaboration;
+ * map and serialization fail loudly if that invariant is broken.
+ */
+class HeadlessInlineResolutionStep extends ReplaceStep {
+  private readonly positionMap: StepMap;
+
+  constructor(from: number, to: number, slice: Slice, positionMap: StepMap) {
+    super(from, to, slice);
+    this.positionMap = positionMap;
+  }
+
+  override getMap(): StepMap {
+    return this.positionMap;
+  }
+
+  override invert(doc: PMNode): ReplaceStep {
+    return new HeadlessInlineResolutionStep(
+      this.from,
+      this.from + this.slice.size,
+      doc.slice(this.from, this.to),
+      this.positionMap.invert(),
+    );
+  }
+
+  override map(_mapping: Mappable): never {
+    return panic("A headless revision-resolution step cannot be mapped");
+  }
+
+  override toJSON(): never {
+    return panic("A headless revision-resolution step cannot be serialized");
+  }
+}
+
+const marksEqual = (left: readonly Mark[], right: readonly Mark[]): boolean =>
+  left.length === right.length &&
+  left.every((mark, index) => {
+    const candidate = right[index];
+    return candidate !== undefined && mark.eq(candidate);
+  });
+
+const rebuildNode = (
+  source: PMNode,
+  attrs: PMNode["attrs"],
+  content: Fragment,
+  marks: readonly Mark[] = source.marks,
+): PMNode =>
+  recreateProseNodeWithParagraphPropertySource(source, {
+    attrs,
+    content,
+    marks,
+  });
+
+const resolveInlineNode = (
+  node: PMNode,
+  mode: HeadlessRevisionResolutionMode,
+  keepType: MarkType | undefined,
+  removeType: MarkType | undefined,
+): PMNode | null => {
+  let marks: readonly Mark[] = node.marks;
+  const runPropertyChangeMark = marks.find((mark) => mark.type.name === "runPropertyChange");
+  if (runPropertyChangeMark) {
+    const { changes } = expectRunPropertyChangeMarkAttrs(runPropertyChangeMark);
+    if (changes.length > 0) {
+      marks = marks.filter((mark) => mark !== runPropertyChangeMark);
+      if (mode === "reject") {
+        marks = marks.filter((mark) => !RUN_FORMATTING_MARK_NAMES.has(mark.type.name));
+        const previousFormatting = changes.at(0)?.previousFormatting;
+        for (const previousMark of textFormattingToMarks(previousFormatting)) {
+          marks = previousMark.addToSet(marks);
+        }
+        if (previousFormatting?.styleId) {
+          const characterStyle = node.type.schema.marks["characterStyle"];
+          if (characterStyle) {
+            marks = characterStyle
+              .create({ styleId: previousFormatting.styleId, _styleRPr: null })
+              .addToSet(marks);
+          }
+        }
+      }
+    }
+  }
+
+  if (removeType && node.marks.some((mark) => mark.type === removeType)) {
+    return null;
+  }
+  if (keepType) {
+    marks = marks.filter((mark) => mark.type !== keepType);
+  }
+  return marksEqual(marks, node.marks) ? node : node.mark(marks);
+};
+
+const resolveInlineContent = (
+  node: PMNode,
+  position: number,
+  context: HeadlessInlineContext,
+): PMNode | null => {
+  let resolvedNode = node;
+  if (node.isInline) {
+    const resolved = resolveInlineNode(node, context.mode, context.keepType, context.removeType);
+    if (resolved === null) {
+      context.deleteRanges.push({ from: position, to: position + node.nodeSize });
+      return null;
+    }
+    resolvedNode = resolved;
+    if (resolvedNode.isLeaf) {
+      return resolvedNode;
+    }
+  }
+
+  const children: PMNode[] = [];
+  const contentStart = resolvedNode.type.name === "doc" ? 0 : position + 1;
+  let contentChanged = false;
+  resolvedNode.forEach((child, offset) => {
+    const resolved = resolveInlineContent(child, contentStart + offset, context);
+    if (resolved) {
+      children.push(resolved);
+      contentChanged ||= resolved !== child;
+    } else {
+      contentChanged = true;
+    }
+  });
+
+  if (!contentChanged) {
+    return resolvedNode;
+  }
+  if (resolvedNode.type.name === "paragraph") {
+    context.changedParagraphRanges.push({ from: position, to: position + resolvedNode.nodeSize });
+  }
+  return rebuildNode(node, resolvedNode.attrs, Fragment.fromArray(children), resolvedNode.marks);
+};
+
+const coalesceDeleteRanges = (
+  deleteRanges: readonly HeadlessDeleteRange[],
+): HeadlessDeleteRange[] => {
+  const coalesced: HeadlessDeleteRange[] = [];
+  for (const range of deleteRanges) {
+    const previous = coalesced.at(-1);
+    if (previous && range.from <= previous.to) {
+      previous.to = Math.max(previous.to, range.to);
+    } else {
+      coalesced.push({ ...range });
+    }
+  }
+  return coalesced;
+};
+
+export const appendHeadlessInlineResolution = (
+  tr: Transaction,
+  mode: HeadlessRevisionResolutionMode,
+  keepType: MarkType | undefined,
+  removeType: MarkType | undefined,
+): HeadlessInlineChangeTracking | null => {
+  const context: HeadlessInlineContext = {
+    mode,
+    keepType,
+    removeType,
+    deleteRanges: [],
+    changedParagraphRanges: [],
+  };
+  const resolved = resolveInlineContent(tr.doc, -1, context);
+  if (!resolved || resolved.eq(tr.doc)) {
+    return null;
+  }
+  const deleteRanges = coalesceDeleteRanges(context.deleteRanges);
+  const positionMap = new StepMap(deleteRanges.flatMap(({ from, to }) => [from, to - from, 0]));
+  const mappingFrom = tr.steps.length;
+  tr.step(
+    new HeadlessInlineResolutionStep(
+      0,
+      tr.doc.content.size,
+      new Slice(resolved.content, 0, 0),
+      positionMap,
+    ),
+  );
+  return { ranges: context.changedParagraphRanges, mappingFrom };
+};

--- a/packages/core/src/internal/headlessRevisionResolutionGuard.ts
+++ b/packages/core/src/internal/headlessRevisionResolutionGuard.ts
@@ -1,0 +1,36 @@
+import { Plugin, PluginKey, type EditorState } from "prosemirror-state";
+
+const UNSAFE_PLUGIN_KEY_PREFIXES = ["collab$", "history$", "y-sync$", "y-undo$"] as const;
+
+const headlessRevisionResolutionKey = new PluginKey("folioHeadlessRevisionResolution");
+const headlessRevisionResolutionPlugin = new Plugin({ key: headlessRevisionResolutionKey });
+
+const pluginRuntimeKey = (plugin: Plugin): string | null => {
+  // ProseMirror exposes this key at runtime but marks it internal in its
+  // declarations. Reading it reflectively lets this boundary recognize the
+  // actual history and collaboration plugins, including suffixed instances.
+  const key = Reflect.get(plugin, "key");
+  return typeof key === "string" ? key : null;
+};
+
+const retainsOrTransportsSteps = (plugin: Plugin): boolean => {
+  const key = pluginRuntimeKey(plugin);
+  return key !== null && UNSAFE_PLUGIN_KEY_PREFIXES.some((prefix) => key.startsWith(prefix));
+};
+
+/**
+ * Whether a state can consume an unmapped replacement before it returns.
+ * Only the internal headless plugin set opts in; history and collaboration
+ * plugins always keep the state on the legacy editor-command path.
+ */
+export const stateAllowsHeadlessRevisionResolution = (state: EditorState): boolean =>
+  headlessRevisionResolutionKey.get(state) === headlessRevisionResolutionPlugin &&
+  !state.plugins.some(retainsOrTransportsSteps);
+
+/** Build the private plugin set for synchronous headless review states. */
+export const pluginsForHeadlessRevisionResolution = (
+  plugins: readonly Plugin[],
+): readonly Plugin[] => [
+  ...plugins.filter((plugin) => !retainsOrTransportsSteps(plugin)),
+  headlessRevisionResolutionPlugin,
+];

--- a/packages/core/src/prosemirror/commands/comments.bulk.test.ts
+++ b/packages/core/src/prosemirror/commands/comments.bulk.test.ts
@@ -1,0 +1,649 @@
+import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+import type { Mark, Node as PMNode } from "prosemirror-model";
+import { history } from "prosemirror-history";
+import { EditorState, Plugin, PluginKey, type Command, type Transaction } from "prosemirror-state";
+import { ySyncPlugin, yUndoPlugin } from "y-prosemirror";
+import * as Y from "yjs";
+
+import { FolioDocxReviewer } from "../../ai-edits/headless";
+import { parseDocx } from "../../docx/parser";
+import { createDocx, createEmptyDocx, repackDocx } from "../../docx/rezip";
+import {
+  pluginsForHeadlessRevisionResolution,
+  stateAllowsHeadlessRevisionResolution,
+} from "../../internal/headlessRevisionResolutionGuard";
+import type { HeaderFooter, TrackedRunChange } from "../../types/document";
+import { fromProseDoc } from "../conversion/fromProseDoc";
+import { toProseDoc } from "../conversion/toProseDoc";
+import {
+  getChangedParagraphIds,
+  hasStructuralChanges,
+  hasUntrackedChanges,
+  ParagraphChangeTrackerExtension,
+} from "../extensions/features/ParagraphChangeTrackerExtension";
+import { schema } from "../schema";
+import {
+  acceptChange,
+  acceptAllChanges,
+  rejectChange,
+  rejectAllChanges,
+  resolveAllChangesInHeadlessState,
+} from "./comments";
+
+const AUTHOR = "Reviewer";
+const DATE = "2026-09-09T00:00:00.000Z";
+const HEADER_RELATIONSHIP_ID = "rIdBulkResolutionHeader";
+const trackerExtension = ParagraphChangeTrackerExtension();
+const changeTrackerPlugin = trackerExtension.onSchemaReady({ schema }).plugins?.at(0);
+if (!changeTrackerPlugin) {
+  throw new Error("Expected the paragraph change tracker plugin.");
+}
+
+const stepCountKey = new PluginKey<number>("headlessBulkResolutionStepCount");
+const stepCountPlugin = new Plugin<number>({
+  key: stepCountKey,
+  state: {
+    init: () => 0,
+    apply: (transaction, previous) =>
+      transaction.docChanged ? transaction.steps.length : previous,
+  },
+});
+
+const serializedStepsKey = new PluginKey<readonly unknown[]>("headlessBulkSerializedSteps");
+const serializedStepsPlugin = new Plugin<readonly unknown[]>({
+  key: serializedStepsKey,
+  state: {
+    init: () => [],
+    apply: (transaction, previous) =>
+      transaction.docChanged ? transaction.steps.map((step) => step.toJSON()) : previous,
+  },
+});
+
+type AppliedCommand = {
+  state: EditorState;
+  transaction: Transaction;
+};
+
+const apply = (state: EditorState, command: Command): AppliedCommand => {
+  let transaction: Transaction | null = null;
+  expect(
+    command(state, (dispatched) => {
+      transaction = dispatched;
+    }),
+  ).toBe(true);
+  expect(transaction).not.toBeNull();
+  if (!transaction) {
+    throw new Error("Expected the revision command to dispatch.");
+  }
+  return { state: state.apply(transaction), transaction };
+};
+
+const revisionMark = (
+  type: "insertion" | "deletion",
+  revisionId: number,
+  moveKind?: "moveTo" | "moveFrom",
+): Mark =>
+  schema.marks[type].create({
+    revisionId,
+    author: AUTHOR,
+    date: DATE,
+    ...(moveKind ? { moveKind } : {}),
+  });
+
+type MarkedTextRunsOptions = {
+  type: "insertion" | "deletion";
+  idOffset: number;
+};
+
+const markedTextRuns = ({ type, idOffset }: MarkedTextRunsOptions): PMNode[] =>
+  Array.from({ length: 300 }, (_, index) =>
+    schema.text(`tracked-${index} `, [revisionMark(type, idOffset + index)]),
+  );
+
+const paragraphMark = (kind: "ins" | "del" | "moveTo" | "moveFrom", id: number) => ({
+  kind,
+  info: { id, author: AUTHOR, date: DATE },
+});
+
+const paragraph = (
+  seed: number,
+  index: number,
+  nextId: () => number,
+  nestedInline: "include" | "omit",
+): PMNode => {
+  const insertionId = nextId();
+  const deletionId = nextId();
+  const runPropertyId = nextId();
+  const comment = schema.marks.comment.create({ commentId: seed * 100 + index });
+  const runProperty = schema.marks.runPropertyChange.create({
+    changes: [
+      {
+        type: "runPropertyChange",
+        info: { id: runPropertyId, author: AUTHOR, date: DATE },
+        previousFormatting: { italic: true },
+        currentFormatting: { bold: true },
+      },
+    ],
+  });
+  const fieldHyperlink = schema.marks.hyperlink.create({
+    href: `#field-${seed}`,
+    anchor: `field-${seed}`,
+    _docxHyperlinkIndex: seed,
+  });
+  const content = [
+    schema.text(`old-${seed}-${index}`, [
+      revisionMark("deletion", deletionId, index % 5 === 0 ? "moveFrom" : undefined),
+    ]),
+    ...(index === 0
+      ? [schema.nodes.bookmarkBoundary.create({ type: "start", id: seed, name: `seed-${seed}` })]
+      : []),
+    schema.text(` anchor-${index} `, [comment]),
+    ...(index === 0 ? [schema.nodes.bookmarkBoundary.create({ type: "end", id: seed })] : []),
+    schema.text(`new-${seed}-${index}`, [
+      revisionMark("insertion", insertionId, index % 5 === 0 ? "moveTo" : undefined),
+    ]),
+    schema.text(` format-${index}`, [schema.marks.bold.create(), runProperty]),
+    schema.nodes.hardBreak.create({ breakType: index % 2 === 0 ? "column" : null }, null, [
+      revisionMark(index % 2 === 0 ? "insertion" : "deletion", nextId()),
+    ]),
+    schema.text(` alternate-old-${index}`, [revisionMark("deletion", nextId())]),
+    schema.text(` alternate-new-${index}`, [revisionMark("insertion", nextId())]),
+    schema.text(` alternate-format-${index}`, [runProperty]),
+    ...(index === 0 && nestedInline === "include"
+      ? [
+          schema.node(
+            "sdt",
+            {
+              tag: `nested-${seed}`,
+              rawPropertiesXml: `<w:sdtPr><w:tag w:val="nested-${seed}"/></w:sdtPr>`,
+            },
+            [
+              schema.text("sdt-old", [revisionMark("deletion", nextId())]),
+              schema.node(
+                "structuredField",
+                {
+                  fieldType: "REF",
+                  instruction: `REF nested_${seed}`,
+                  displayText: "",
+                },
+                [
+                  schema.text("field-old", [fieldHyperlink, revisionMark("deletion", nextId())]),
+                  schema.nodes.bookmarkBoundary.create(
+                    {
+                      type: "start",
+                      id: seed + 1000,
+                      name: `field-${seed}`,
+                    },
+                    null,
+                    [fieldHyperlink],
+                  ),
+                  schema.text("field-new", [fieldHyperlink, revisionMark("insertion", nextId())]),
+                  schema.nodes.bookmarkBoundary.create({ type: "end", id: seed + 1000 }, null, [
+                    fieldHyperlink,
+                  ]),
+                ],
+              ),
+              schema.text("sdt-new", [revisionMark("insertion", nextId())]),
+            ],
+          ),
+        ]
+      : []),
+  ];
+  const attrs: Record<string, unknown> = {
+    paraId: `${(seed * 100 + index).toString(16).padStart(8, "0")}`,
+  };
+  if (index % 3 === 0) {
+    attrs["alignment"] = "right";
+    attrs["_originalFormatting"] = { alignment: "right" };
+    attrs["_propertyChanges"] = [
+      {
+        type: "paragraphPropertyChange",
+        info: { id: nextId(), author: AUTHOR, date: DATE },
+        previousFormatting: { alignment: "left", keepNext: true },
+      },
+    ];
+  }
+  if (index % 4 === 1) {
+    attrs["pPrMark"] = paragraphMark(index % 2 === 0 ? "ins" : "del", nextId());
+  }
+  if (index === 2) {
+    attrs["sectionBreakType"] = "continuous";
+    attrs["_sectionProperties"] = {
+      sectionStart: "continuous",
+      pageSize: { width: 12_240, height: 15_840 },
+      propertyChanges: [
+        {
+          type: "sectionPropertyChange",
+          info: { id: nextId(), author: AUTHOR, date: DATE },
+          previousProperties: {
+            sectionStart: "nextPage",
+            pageSize: { width: 11_900, height: 16_800 },
+          },
+        },
+      ],
+    };
+  }
+  return schema.node("paragraph", attrs, content);
+};
+
+const nestedTable = (seed: number, nextId: () => number): PMNode => {
+  const emptyRunProperty = schema.marks.runPropertyChange.create({ changes: [] });
+  const nested = schema.node("table", null, [
+    schema.node("tableRow", null, [
+      schema.node("tableCell", null, [
+        schema.node("paragraph", null, [
+          schema.text("nested-old", [revisionMark("deletion", nextId())]),
+          schema.text("nested-new", [revisionMark("insertion", nextId())]),
+        ]),
+      ]),
+    ]),
+  ]);
+  const cellPropertyId = nextId();
+  const cellMarkerId = nextId();
+  const firstCell = schema.node(
+    "tableCell",
+    {
+      backgroundColor: "99CCFF",
+      tcPrChange: [
+        {
+          info: { id: cellPropertyId, author: AUTHOR, date: DATE },
+          previousFormatting: { backgroundColor: "FFFFFF", verticalAlign: "top" },
+        },
+      ],
+    },
+    [schema.node("paragraph"), nested, schema.node("paragraph", null, schema.text("tail"))],
+  );
+  const secondCell = schema.node(
+    "tableCell",
+    {
+      cellMarker: {
+        kind: seed % 2 === 0 ? "ins" : "del",
+        info: { revisionId: cellMarkerId, author: AUTHOR, date: DATE },
+      },
+    },
+    [schema.node("paragraph", null, schema.text("membership"))],
+  );
+  const changedRow = schema.node(
+    "tableRow",
+    {
+      height: 480,
+      trPrChange: [
+        {
+          info: { id: nextId(), author: AUTHOR, date: DATE },
+          previousFormatting: { height: 240, isHeader: true },
+        },
+      ],
+      ...(seed % 3 === 0 ? { trIns: { revisionId: nextId(), author: AUTHOR, date: DATE } } : {}),
+    },
+    [firstCell, secondCell],
+  );
+  const stableRow = schema.node("tableRow", null, [
+    schema.node("tableCell", null, [
+      schema.node("paragraph", null, schema.text("stable row", [emptyRunProperty])),
+    ]),
+  ]);
+  return schema.node(
+    "table",
+    {
+      width: 7200,
+      tblPrChange: [
+        {
+          info: { id: nextId(), author: AUTHOR, date: DATE },
+          previousFormatting: { width: 6400, justification: "center" },
+        },
+      ],
+    },
+    [stableRow, changedRow],
+  );
+};
+
+const generatedDocument = (
+  seed: number,
+  paragraphCount = 8,
+  nestedInline: "include" | "omit" = "include",
+): PMNode => {
+  let revisionId = seed * 1000 + 1;
+  const nextId = () => revisionId++;
+  const blocks: PMNode[] = [];
+  for (let index = 0; index < paragraphCount; index++) {
+    blocks.push(paragraph(seed, index, nextId, nestedInline));
+    if (index === 3) {
+      blocks.push(nestedTable(seed, nextId));
+    }
+  }
+  return schema.node("doc", null, blocks);
+};
+
+const secondaryStoryBuffer = async (): Promise<ArrayBuffer> => {
+  const document = await parseDocx(await createEmptyDocx(), {
+    detectVariables: false,
+    preloadFonts: false,
+  });
+  const content: TrackedRunChange[] = Array.from({ length: 300 }, (_, index) => ({
+    type: "insertion",
+    info: { id: index + 1, author: AUTHOR, date: DATE },
+    content: [{ type: "run", content: [{ type: "text", text: `item-${index} ` }] }],
+  }));
+  const header = {
+    type: "header",
+    hdrFtrType: "default",
+    content: [{ type: "paragraph", paraId: "70000001", content }],
+  } satisfies HeaderFooter;
+  document.package.headers = new Map([[HEADER_RELATIONSHIP_ID, header]]);
+  document.package.document.finalSectionProperties = {
+    ...document.package.document.finalSectionProperties,
+    headerReferences: [{ type: "default", rId: HEADER_RELATIONSHIP_ID }],
+  };
+  return repackDocx(document, { updateModifiedDate: false });
+};
+
+describe("headless bulk revision resolution equivalence", () => {
+  test("matches the legacy full-range semantics across generated nested revisions", () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 1, max: 100_000 }), (seed) => {
+        const doc = generatedDocument(seed, 40);
+
+        for (const mode of ["accept", "reject"] as const) {
+          const state = EditorState.create({
+            schema,
+            doc,
+            plugins: pluginsForHeadlessRevisionResolution([changeTrackerPlugin]),
+          });
+          const bulkState = resolveAllChangesInHeadlessState(state, mode);
+          const legacy = apply(
+            state,
+            mode === "accept"
+              ? acceptChange(0, doc.content.size)
+              : rejectChange(0, doc.content.size),
+          );
+
+          expect(bulkState.doc.toJSON()).toEqual(legacy.state.doc.toJSON());
+          const bulkTracker = {
+            paraIds: [...getChangedParagraphIds(bulkState)].toSorted(),
+            structural: hasStructuralChanges(bulkState),
+            untracked: hasUntrackedChanges(bulkState),
+          };
+          const legacyTracker = {
+            paraIds: [...getChangedParagraphIds(legacy.state)].toSorted(),
+            structural: hasStructuralChanges(legacy.state),
+            untracked: hasUntrackedChanges(legacy.state),
+          };
+          expect(bulkTracker).toEqual(legacyTracker);
+        }
+      }),
+      { seed: 2_609_090, numRuns: 24, verbose: true },
+    );
+  });
+
+  test("keeps the bulk transaction structurally bounded as the document grows", () => {
+    const stepCounts = [4, 400, 4_000].map((paragraphCount) => {
+      const insertion = revisionMark("insertion", 1);
+      const deletion = revisionMark("deletion", 2);
+      const doc = schema.node(
+        "doc",
+        null,
+        Array.from({ length: paragraphCount }, (_, index) =>
+          schema.node("paragraph", null, [
+            schema.text(`old-${index}`, [deletion]),
+            schema.text(`new-${index}`, [insertion]),
+          ]),
+        ),
+      );
+      const state = EditorState.create({
+        schema,
+        doc,
+        plugins: pluginsForHeadlessRevisionResolution([stepCountPlugin]),
+      });
+      const accepted = resolveAllChangesInHeadlessState(state, "accept");
+      const rejected = resolveAllChangesInHeadlessState(state, "reject");
+      return {
+        accept: stepCountKey.getState(accepted),
+        reject: stepCountKey.getState(rejected),
+      };
+    });
+
+    expect(stepCounts).toEqual([
+      { accept: 8, reject: 8 },
+      { accept: 1, reject: 1 },
+      { accept: 1, reject: 1 },
+    ]);
+
+    const doc = schema.node(
+      "doc",
+      null,
+      Array.from({ length: 400 }, (_, index) =>
+        schema.node("paragraph", null, [
+          schema.text(`old-${index}`, [revisionMark("deletion", 1)]),
+          schema.text(`new-${index}`, [revisionMark("insertion", 2)]),
+        ]),
+      ),
+    );
+    const editorState = EditorState.create({ schema, doc });
+    expect(apply(editorState, acceptAllChanges()).transaction.steps).toHaveLength(800);
+    expect(apply(editorState, rejectAllChanges()).transaction.steps).toHaveLength(800);
+  });
+});
+
+describe("headless bulk revision resolution isolation", () => {
+  test.each(["accept", "reject"] as const)(
+    "%s falls back to serializable legacy steps when history is present",
+    (mode) => {
+      const paragraphCount = 300;
+      const insertion = revisionMark("insertion", 1);
+      const deletion = revisionMark("deletion", 2);
+      const doc = schema.node(
+        "doc",
+        null,
+        Array.from({ length: paragraphCount }, (_, index) =>
+          schema.node("paragraph", null, [
+            schema.text(`old-${index}`, [deletion]),
+            schema.text(`new-${index}`, [insertion]),
+          ]),
+        ),
+      );
+      const state = EditorState.create({
+        schema,
+        doc,
+        plugins: [
+          ...pluginsForHeadlessRevisionResolution([stepCountPlugin, serializedStepsPlugin]),
+          history(),
+        ],
+      });
+
+      expect(stateAllowsHeadlessRevisionResolution(state)).toBe(false);
+      const resolved = resolveAllChangesInHeadlessState(state, mode);
+      const legacy = apply(
+        state,
+        mode === "accept" ? acceptChange(0, doc.content.size) : rejectChange(0, doc.content.size),
+      );
+
+      expect(resolved.doc.toJSON()).toEqual(legacy.state.doc.toJSON());
+      expect(stepCountKey.getState(resolved)).toBe(paragraphCount * 2);
+      expect(serializedStepsKey.getState(resolved)).toHaveLength(paragraphCount * 2);
+    },
+  );
+
+  test("rejects actual synchronization and undo plugins from the headless state boundary", () => {
+    const yDoc = new Y.Doc();
+    const state = EditorState.create({
+      schema,
+      doc: generatedDocument(73),
+      plugins: [
+        ...pluginsForHeadlessRevisionResolution([]),
+        ySyncPlugin(yDoc.getXmlFragment("prosemirror")),
+        yUndoPlugin(),
+      ],
+    });
+
+    expect(stateAllowsHeadlessRevisionResolution(state)).toBe(false);
+  });
+
+  test("rejects a collaboration-keyed plugin from the headless state boundary", () => {
+    const state = EditorState.create({
+      schema,
+      doc: generatedDocument(74),
+      plugins: [
+        ...pluginsForHeadlessRevisionResolution([]),
+        new Plugin({ key: new PluginKey("collab") }),
+      ],
+    });
+
+    expect(stateAllowsHeadlessRevisionResolution(state)).toBe(false);
+  });
+});
+
+describe("headless bulk revision state", () => {
+  test.each(["accept", "reject"] as const)(
+    "%s reports mark-only paragraphs to selective save without a structural fallback",
+    (mode) => {
+      const revision = revisionMark(mode === "accept" ? "insertion" : "deletion", 9);
+      const doc = schema.node("doc", null, [
+        schema.node("paragraph", { paraId: "changed" }, [
+          schema.text("tracked ", [revision]),
+          ...markedTextRuns({
+            type: mode === "accept" ? "insertion" : "deletion",
+            idOffset: 10_000,
+          }),
+        ]),
+        schema.node("paragraph", { paraId: "stable" }, schema.text("stable")),
+      ]);
+      const state = EditorState.create({
+        schema,
+        doc,
+        plugins: pluginsForHeadlessRevisionResolution([changeTrackerPlugin]),
+      });
+      const resolved = resolveAllChangesInHeadlessState(state, mode);
+
+      expect([...getChangedParagraphIds(resolved)]).toEqual(["changed"]);
+      expect(hasStructuralChanges(resolved)).toBe(false);
+    },
+  );
+});
+
+describe("bulk revision lifecycle", () => {
+  test.each(["accept", "reject"] as const)(
+    "%s resolves a bulk secondary story and persists it",
+    async (mode) => {
+      const story = {
+        type: "header",
+        relationshipId: HEADER_RELATIONSHIP_ID,
+      } as const;
+      const reviewer = await FolioDocxReviewer.fromBuffer(await secondaryStoryBuffer());
+      expect(reviewer.readReviewedStory({ story, view: "current-markup" })?.changes.length).toBe(
+        300,
+      );
+
+      if (mode === "accept") {
+        reviewer.acceptAll();
+      } else {
+        reviewer.rejectAll();
+      }
+      const expected = reviewer.readReviewedStory({ story, view: "current-markup" });
+      const reopened = await FolioDocxReviewer.fromBuffer(await reviewer.toBuffer());
+      const actual = reopened.readReviewedStory({ story, view: "current-markup" });
+
+      expect(actual?.changes).toEqual([]);
+      expect(actual?.text).toBe(expected?.text);
+    },
+  );
+
+  test.each(["accept", "reject"] as const)(
+    "%s survives save and reopen with no unresolved revision carriers",
+    async (mode) => {
+      const doc = generatedDocument(mode === "accept" ? 71 : 72, 8, "omit");
+      const reviewer = await FolioDocxReviewer.fromBuffer(await createDocx(fromProseDoc(doc)));
+      const before = reviewer.readReviewedStory({ view: "current-markup" });
+      expect(before?.changes.length).toBeGreaterThan(0);
+
+      if (mode === "accept") {
+        reviewer.acceptAll();
+      } else {
+        reviewer.rejectAll();
+      }
+      const expected = reviewer.readReviewedStory({ view: "current-markup" });
+      const reopened = await FolioDocxReviewer.fromBuffer(await reviewer.toBuffer());
+      const actual = reopened.readReviewedStory({ view: "current-markup" });
+
+      expect(actual?.changes).toEqual([]);
+      expect(actual?.snapshot.blocks).toEqual(expected?.snapshot.blocks);
+      expect(actual?.text).toBe(expected?.text);
+    },
+  );
+
+  test.each(["accept", "reject"] as const)(
+    "%s preserves nested inline containers and boundary atoms through save and reopen",
+    async (mode) => {
+      const seed = mode === "accept" ? 71 : 72;
+      const reviewer = await FolioDocxReviewer.fromBuffer(
+        await createDocx(fromProseDoc(generatedDocument(seed))),
+      );
+      if (mode === "accept") {
+        reviewer.acceptAll();
+      } else {
+        reviewer.rejectAll();
+      }
+      const expected = reviewer.readReviewedStory({ view: "current-markup" });
+      const saved = await reviewer.toBuffer();
+      const reopened = await FolioDocxReviewer.fromBuffer(saved);
+      const actual = reopened.readReviewedStory({ view: "current-markup" });
+      const roundTripped = toProseDoc(
+        await parseDocx(saved, { detectVariables: false, preloadFonts: false }),
+      );
+      let inlineSdt: PMNode | null = null;
+      let structuredField: PMNode | null = null;
+      const bookmarkBoundaries: PMNode[] = [];
+      roundTripped.descendants((node) => {
+        if (node.type.name === "sdt") {
+          inlineSdt = node;
+        } else if (node.type.name === "structuredField") {
+          structuredField = node;
+        } else if (node.type.name === "bookmarkBoundary") {
+          bookmarkBoundaries.push(node);
+        }
+      });
+
+      expect(actual?.changes).toEqual([]);
+      expect(actual?.text).toBe(expected?.text);
+      expect(inlineSdt?.attrs["tag"]).toBe(`nested-${seed}`);
+      expect(inlineSdt?.attrs["rawPropertiesXml"]).toContain(`<w:tag w:val="nested-${seed}"/>`);
+      expect(structuredField?.attrs["instruction"]).toContain(`REF nested_${seed}`);
+      expect(inlineSdt?.textContent).toContain(mode === "accept" ? "sdt-new" : "sdt-old");
+      expect(
+        bookmarkBoundaries
+          .filter((node) => node.attrs["id"] === seed + 1000)
+          .map((node) => node.attrs["type"]),
+      ).toEqual(["start", "end"]);
+    },
+  );
+
+  test.each(["accept", "reject"] as const)(
+    "%s persists a mark-only resolution through selective save and reopen",
+    async (mode) => {
+      const revision = revisionMark(mode === "accept" ? "insertion" : "deletion", 91);
+      const doc = schema.node("doc", null, [
+        schema.node("paragraph", { paraId: "00000091" }, [
+          schema.text("tracked ", [revision]),
+          ...markedTextRuns({
+            type: mode === "accept" ? "insertion" : "deletion",
+            idOffset: 20_000,
+          }),
+        ]),
+        schema.node("paragraph", { paraId: "00000092" }, schema.text("stable")),
+      ]);
+      const reviewer = await FolioDocxReviewer.fromBuffer(await createDocx(fromProseDoc(doc)));
+
+      if (mode === "accept") {
+        reviewer.acceptAll();
+      } else {
+        reviewer.rejectAll();
+      }
+      const expected = reviewer.readReviewedStory({ view: "current-markup" });
+      const reopened = await FolioDocxReviewer.fromBuffer(await reviewer.toBuffer());
+      const story = reopened.readReviewedStory({ view: "current-markup" });
+
+      expect(story?.changes).toEqual([]);
+      expect(story?.text).toBe(expected?.text);
+    },
+  );
+});

--- a/packages/core/src/prosemirror/commands/comments.ts
+++ b/packages/core/src/prosemirror/commands/comments.ts
@@ -8,6 +8,11 @@ import type { Mark, MarkType, Node as PMNode } from "prosemirror-model";
 import type { Command, EditorState, Transaction } from "prosemirror-state";
 import { removeRow, TableMap } from "prosemirror-tables";
 
+import {
+  appendHeadlessInlineResolution,
+  type HeadlessInlineChangeTracking,
+} from "../../internal/headlessRevisionResolution";
+import { stateAllowsHeadlessRevisionResolution } from "../../internal/headlessRevisionResolutionGuard";
 import type {
   ParagraphFormatting,
   RunPropertyChange,
@@ -25,7 +30,10 @@ import {
   paragraphEndsItsContainer,
 } from "../containerFinalParagraph";
 import { textFormattingToMarks } from "../conversion/toProseDoc";
-import { markStructuralChange } from "../extensions/features/ParagraphChangeTrackerExtension";
+import {
+  markChangedParagraphRanges,
+  markStructuralChange,
+} from "../extensions/features/ParagraphChangeTrackerExtension";
 import { getDocumentStyleResolver } from "../plugins/documentStyles";
 import { holdsNoContent } from "../zeroWidthAnchors";
 import { getFolioNodeRevisionCarriers } from "../revisionCarriers";
@@ -101,6 +109,12 @@ export function removeCommentMark(commentId: number): Command {
   };
 }
 
+type ResolveMode = "accept" | "reject";
+
+const BULK_INLINE_RESOLUTION_THRESHOLD = 256;
+
+type ResolveExecution = "legacy" | "headless-bulk-inline";
+
 /**
  * Resolve a tracked change: accept or reject.
  * - Accept: keep insertions (remove mark), delete deletions (remove text)
@@ -118,6 +132,7 @@ function resolveChange(
   to: number,
   mode: "accept" | "reject",
   revisionIds?: readonly number[],
+  execution: ResolveExecution = "legacy",
 ): Command {
   return (state, dispatch) => {
     const insertionType = state.schema.marks["insertion"];
@@ -130,6 +145,12 @@ function resolveChange(
     // A range-wide removal lets ProseMirror coalesce one revision split by
     // inline formatting. The id-scoped path must keep matching each mark.
     const removeKeptMarksInBulk = revisionSet === null && keepType !== undefined;
+    const canBulkInlineResolution =
+      execution === "headless-bulk-inline" &&
+      revisionSet === null &&
+      from === 0 &&
+      to === state.doc.content.size &&
+      stateAllowsHeadlessRevisionResolution(state);
     const matchesRevision = (mark: { attrs: Record<string, unknown> }) =>
       revisionSet === null ||
       (typeof mark.attrs["revisionId"] === "number" && revisionSet.has(mark.attrs["revisionId"]));
@@ -140,6 +161,8 @@ function resolveChange(
       const pPrMarkOps: PPrMarkOp[] = [];
       const tableRowStructuralOps: TableRowStructuralOp[] = [];
       const tableCellStructuralOps: TableCellStructuralOp[] = [];
+      const deferredRunPropertyChanges: ResolveRunPropertyChangeOptions[] = [];
+      let bulkInlineCarrierCount = 0;
 
       state.doc.nodesBetween(from, to, (node, pos): boolean => {
         if (node.type.name === "paragraph") {
@@ -296,6 +319,35 @@ function resolveChange(
         const runPropertyChangeMark = node.marks.find(
           (mark) => mark.type.name === "runPropertyChange",
         );
+        const resolvesRunPropertyChange =
+          runPropertyChangeMark !== undefined &&
+          expectRunPropertyChangeMarkAttrs(runPropertyChangeMark).changes.length > 0;
+        const removesNode =
+          removeType !== undefined &&
+          node.marks.some((mark) => mark.type === removeType && matchesRevision(mark));
+        const removesKeptMark =
+          keepType !== undefined &&
+          node.marks.some((mark) => mark.type === keepType && matchesRevision(mark));
+        if (canBulkInlineResolution) {
+          if (resolvesRunPropertyChange) {
+            deferredRunPropertyChanges.push({
+              tr,
+              node,
+              from: rangeFrom,
+              to: rangeTo,
+              mark: runPropertyChangeMark,
+              mode,
+              revisionSet,
+            });
+          }
+          if (removesNode) {
+            deleteRanges.push({ from: rangeFrom, to: rangeTo });
+          }
+          if (resolvesRunPropertyChange || removesNode || removesKeptMark) {
+            bulkInlineCarrierCount++;
+          }
+          return true;
+        }
         if (runPropertyChangeMark) {
           resolveRunPropertyChange({
             tr,
@@ -308,7 +360,7 @@ function resolveChange(
           });
         }
 
-        if (removeType && node.marks.some((m) => m.type === removeType && matchesRevision(m))) {
+        if (removesNode) {
           deleteRanges.push({ from: rangeFrom, to: rangeTo });
         }
 
@@ -322,27 +374,39 @@ function resolveChange(
         return true;
       });
 
-      if (removeKeptMarksInBulk) {
-        tr.removeMark(from, to, keepType);
-      }
-
-      let rangesToDelete = deleteRanges;
-      if (revisionSet === null) {
-        // Adjacent inline ranges have no paragraph boundary between them, so
-        // one replacement has the same mapping outside the deleted content.
-        const coalescedDeleteRanges: { from: number; to: number }[] = [];
-        for (const range of deleteRanges) {
-          const previous = coalescedDeleteRanges.at(-1);
-          if (previous && range.from <= previous.to) {
-            previous.to = Math.max(previous.to, range.to);
-            continue;
-          }
-          coalescedDeleteRanges.push({ from: range.from, to: range.to });
+      let bulkInlineChangeTracking: HeadlessInlineChangeTracking | null = null;
+      // The linear rewrite pays a fixed whole-document cost. The existing
+      // steps are faster for small batches and retain their compact slices.
+      const useBulkInlineResolution =
+        canBulkInlineResolution && bulkInlineCarrierCount >= BULK_INLINE_RESOLUTION_THRESHOLD;
+      if (useBulkInlineResolution) {
+        bulkInlineChangeTracking = appendHeadlessInlineResolution(tr, mode, keepType, removeType);
+      } else {
+        for (const deferred of deferredRunPropertyChanges) {
+          resolveRunPropertyChange(deferred);
         }
-        rangesToDelete = coalescedDeleteRanges;
-      }
-      for (const range of rangesToDelete.toReversed()) {
-        tr.delete(range.from, range.to);
+        if (removeKeptMarksInBulk) {
+          tr.removeMark(from, to, keepType);
+        }
+
+        let rangesToDelete = deleteRanges;
+        if (revisionSet === null) {
+          // Adjacent inline ranges have no paragraph boundary between them, so
+          // one replacement has the same mapping outside the deleted content.
+          const coalescedDeleteRanges: { from: number; to: number }[] = [];
+          for (const range of deleteRanges) {
+            const previous = coalescedDeleteRanges.at(-1);
+            if (previous && range.from <= previous.to) {
+              previous.to = Math.max(previous.to, range.to);
+              continue;
+            }
+            coalescedDeleteRanges.push({ from: range.from, to: range.to });
+          }
+          rangesToDelete = coalescedDeleteRanges;
+        }
+        for (const range of rangesToDelete.toReversed()) {
+          tr.delete(range.from, range.to);
+        }
       }
 
       // Process paragraph-mark ops from end → start so earlier positions stay
@@ -520,6 +584,10 @@ function resolveChange(
       }
       if (resolvedTableCellStructure) {
         markStructuralChange(tr);
+      }
+
+      if (bulkInlineChangeTracking) {
+        markChangedParagraphRanges(tr, bulkInlineChangeTracking);
       }
 
       if (tr.steps.length > 0) {
@@ -1179,6 +1247,30 @@ export function acceptAllChanges(): Command {
  */
 export function rejectAllChanges(): Command {
   return (state, dispatch) => rejectChange(0, state.doc.content.size)(state, dispatch);
+}
+
+/**
+ * Resolve a complete state synchronously for a headless reader or writer.
+ *
+ * @internal The replacement transaction is consumed here and never exposed:
+ * it is deliberately not an editor command and must not be transported or
+ * mapped through concurrent edits.
+ */
+export function resolveAllChangesInHeadlessState(
+  state: EditorState,
+  mode: ResolveMode,
+): EditorState {
+  let resolvedState = state;
+  resolveChange(
+    0,
+    state.doc.content.size,
+    mode,
+    undefined,
+    "headless-bulk-inline",
+  )(state, (transaction) => {
+    resolvedState = state.apply(transaction);
+  });
+  return resolvedState;
 }
 
 /**

--- a/packages/core/src/prosemirror/extensions/features/ParagraphChangeTrackerExtension.ts
+++ b/packages/core/src/prosemirror/extensions/features/ParagraphChangeTrackerExtension.ts
@@ -27,6 +27,23 @@ export const paragraphChangeTrackerKey = new PluginKey<ParagraphChangeTrackerSta
 const CLEAR_META = "clear";
 const IGNORE_META = "ignore";
 const STRUCTURAL_META = "structural";
+const CHANGED_PARAGRAPH_RANGES_META = "folioChangedParagraphRanges";
+
+type ChangedParagraphRangeBatch = {
+  ranges: readonly { from: number; to: number }[];
+  mappingFrom: number;
+};
+
+type ChangedParagraphRangesMeta = {
+  type: "changed-paragraph-ranges";
+  batches: readonly ChangedParagraphRangeBatch[];
+};
+
+const isChangedParagraphRangesMeta = (value: unknown): value is ChangedParagraphRangesMeta =>
+  typeof value === "object" &&
+  value !== null &&
+  "type" in value &&
+  value.type === "changed-paragraph-ranges";
 
 export type ParagraphChangeTrackerState = {
   /** Set of paraIds that were modified since last clear */
@@ -134,6 +151,7 @@ function createParagraphChangeTrackerPlugin(): Plugin<ParagraphChangeTrackerStat
       },
       apply(tr: Transaction, prevState: ParagraphChangeTrackerState): ParagraphChangeTrackerState {
         const meta = tr.getMeta(paragraphChangeTrackerKey);
+        const changedParagraphRangesMeta = tr.getMeta(CHANGED_PARAGRAPH_RANGES_META);
         // Check for explicit clear meta
         if (meta === CLEAR_META) {
           return {
@@ -166,6 +184,30 @@ function createParagraphChangeTrackerPlugin(): Plugin<ParagraphChangeTrackerStat
           hasUntrackedChanges: prevState.hasUntrackedChanges,
           paragraphCount: newCount,
         };
+
+        if (isChangedParagraphRangesMeta(changedParagraphRangesMeta)) {
+          for (const batch of changedParagraphRangesMeta.batches) {
+            const remap = tr.mapping.slice(batch.mappingFrom);
+            for (const range of batch.ranges) {
+              const from = mapStepPosition(remap, range.from, 1);
+              const to = mapStepPosition(remap, range.to, -1);
+              if (to <= from) {
+                continue;
+              }
+              const { ids, hasUntracked } = collectAffectedParaIdsFromMarkLikeStep(
+                tr.doc,
+                from,
+                to,
+              );
+              for (const id of ids) {
+                newState.changedParaIds.add(id);
+              }
+              if (hasUntracked) {
+                newState.hasUntrackedChanges = true;
+              }
+            }
+          }
+        }
 
         // Check for structural changes (paragraph count changed)
         if (prevState.paragraphCount !== newCount) {
@@ -289,6 +331,24 @@ export function ignoreTrackedChanges(tr: Transaction): Transaction {
 
 export function markStructuralChange(tr: Transaction): Transaction {
   return tr.setMeta(paragraphChangeTrackerKey, STRUCTURAL_META);
+}
+
+type MarkChangedParagraphRangesOptions = {
+  ranges: readonly { from: number; to: number }[];
+  mappingFrom: number;
+};
+
+/** Record mark-only paragraph changes whose replacement step has a granular map. */
+export function markChangedParagraphRanges(
+  tr: Transaction,
+  batch: MarkChangedParagraphRangesOptions,
+): Transaction {
+  const previous = tr.getMeta(CHANGED_PARAGRAPH_RANGES_META);
+  const batches = isChangedParagraphRangesMeta(previous) ? [...previous.batches, batch] : [batch];
+  return tr.setMeta(CHANGED_PARAGRAPH_RANGES_META, {
+    type: "changed-paragraph-ranges",
+    batches,
+  } satisfies ChangedParagraphRangesMeta);
 }
 
 export const ParagraphChangeTrackerExtension = createExtension({


### PR DESCRIPTION
## Summary

- add a bounded inline-revision rewrite for large synchronous headless accept-all and reject-all operations
- retain the existing editor, history, collaboration, selection, undo, and revision-scoped command paths
- preserve granular deletion mapping for later paragraph, section, row, cell, and change-tracker updates
- recurse through non-leaf inline containers while preserving opaque attributes and boundary atoms

## Validation

- full folio-core test suite
- generated accept/reject equivalence across nested tables, secondary stories, formatting and property changes
- save/reopen lifecycle coverage plus history and synchronization fallback checks
- core typecheck and build; lint and formatting checks on changed files
- API report, declaration-budget, deterministic-output, and input-mutation checks

Generated benchmark, 2 warm-ups and 5 measured iterations per build:

| Case | Metric | Before | After | Change |
| --- | --- | ---: | ---: | ---: |
| 320-block rewrite | wall | 138.6ms | 102.8ms | -25.8% |
| 320-block rewrite | apply | 84.7ms | 50.0ms | -40.9% |
| 2,200-block structural | wall | 4,171.8ms | 2,055.0ms | -50.7% |
| 2,200-block structural | apply | 3,814.5ms | 1,709.2ms | -55.2% |
| 2,200-block structural | accept all | 743.8ms / 5,095 steps | 174.9ms / 411 steps | -76.5% |
| 2,200-block structural | reject all | 741.9ms / 5,295 steps | 232.4ms / 611 steps | -68.7% |

Generated outputs and change lists were identical between builds. A separate 100-pair latency sample remained neutral: p50 changed from 3.212ms to 3.217ms (+0.16%), while mean latency improved 1.08%.