### PR TITLE
fix: reconcile imported layout

### DIFF
--- a/.changeset/calm-zip-clocks.md
+++ b/.changeset/calm-zip-clocks.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve source part timestamps when normalizing paragraph identifiers so repeated normalization stays byte-deterministic.

--- a/.changeset/steady-page-flow.md
+++ b/.changeset/steady-page-flow.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve intended pagination around continuous sections, cached page markers, and paragraph-mark formatting.

--- a/.changeset/steady-page-flow.md
+++ b/.changeset/steady-page-flow.md
@@ -2,4 +2,4 @@
 "@stll/folio-core": patch
 ---
 
-Preserve intended pagination around continuous sections, cached page markers, and paragraph-mark formatting.
+Preserve intended pagination around continuous sections, cached page markers, positioned objects, page furniture, and paragraph-mark formatting.

--- a/packages/core/src/__tests__/layout-pipeline.integration.test.ts
+++ b/packages/core/src/__tests__/layout-pipeline.integration.test.ts
@@ -541,12 +541,16 @@ describe("Layout Engine - Page Production", () => {
       expect(layout.pages[0]?.fragments.map(({ blockId }) => blockId)).toEqual([0, 1]);
     });
 
-    test("rendered page break preserves a fitting keep-next heading boundary", () => {
+    test("a fitting keep-next chain ignores a stale rendered page break", () => {
       const blocks: FlowBlock[] = [
         makeParagraphBlock(0, "Before heading", 1),
         {
           ...makeParagraphBlock(1, "Kept heading", 16, { keepNext: true }),
-          attrs: { keepNext: true, renderedPageBreakBefore: true },
+          attrs: {
+            keepNext: true,
+            renderedPageBreakBefore: true,
+            spacing: { before: 24 },
+          },
         },
         makeParagraphBlock(2, "Kept body", 29),
       ];
@@ -558,9 +562,8 @@ describe("Layout Engine - Page Production", () => {
 
       const layout = layoutDocument(blocks, measures, makeLayoutOptions());
 
-      expect(layout.pages).toHaveLength(2);
-      expect(layout.pages[0]?.fragments.map(({ blockId }) => blockId)).toEqual([0]);
-      expect(layout.pages[1]?.fragments.map(({ blockId }) => blockId)).toEqual([1, 2]);
+      expect(layout.pages).toHaveLength(1);
+      expect(layout.pages[0]?.fragments.map(({ blockId }) => blockId)).toEqual([0, 1, 2]);
     });
 
     test("rendered page break moves a paragraph that would cross the current page", () => {

--- a/packages/core/src/controller/layoutPipeline.ts
+++ b/packages/core/src/controller/layoutPipeline.ts
@@ -402,6 +402,9 @@ export function runLayoutPipeline<THfPMs>(
     if (defaultTabStop !== undefined) {
       flowOpts.defaultTabStopTwips = defaultTabStop;
     }
+    if (document?.package.settings?.splitPageBreakAndParagraphMark === true) {
+      flowOpts.splitPageBreakAndParagraphMark = true;
+    }
     if (document?.package.settings?.lineBreakRules) {
       flowOpts.lineBreakRules = document.package.settings.lineBreakRules;
     }

--- a/packages/core/src/docx/ensureParaIds.test.ts
+++ b/packages/core/src/docx/ensureParaIds.test.ts
@@ -36,13 +36,14 @@ const documentXml = (body: string, extraRootAttrs = ""): string =>
   `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <w:document ${W_NS}${extraRootAttrs}><w:body>${body}<w:sectPr/></w:body></w:document>`;
 
-const buildDocx = async (parts: Record<string, string>): Promise<Uint8Array> => {
+const buildDocx = async (parts: Record<string, string>, entryDate?: Date): Promise<Uint8Array> => {
   const zip = new JSZip();
-  zip.file("[Content_Types].xml", CONTENT_TYPES);
-  zip.file("_rels/.rels", ROOT_RELS);
-  zip.file("word/_rels/document.xml.rels", DOCUMENT_RELS);
+  const options = entryDate === undefined ? undefined : { date: entryDate };
+  zip.file("[Content_Types].xml", CONTENT_TYPES, options);
+  zip.file("_rels/.rels", ROOT_RELS, options);
+  zip.file("word/_rels/document.xml.rels", DOCUMENT_RELS, options);
   for (const [path, content] of Object.entries(parts)) {
-    zip.file(path, content);
+    zip.file(path, content, options);
   }
   return zip.generateAsync({ type: "uint8array" });
 };
@@ -161,13 +162,20 @@ describe("ensureParaIds", () => {
   });
 
   test("is deterministic: same input bytes produce identical output bytes", async () => {
-    const input = await buildDocx({
-      "word/document.xml": documentXml(`${PARA("One")}${PARA("Two")}`),
-    });
+    const entryDate = new Date("2001-02-03T04:05:06.000Z");
+    const input = await buildDocx(
+      {
+        "word/document.xml": documentXml(`${PARA("One")}${PARA("Two")}`),
+      },
+      entryDate,
+    );
 
     const first = await ensureParaIds(input);
     const second = await ensureParaIds(input);
     expect(first.docx).toEqual(second.docx);
+
+    const outputZip = await JSZip.loadAsync(first.docx);
+    expect(outputZip.file("word/document.xml")?.date).toEqual(entryDate);
   });
 
   test("is idempotent: a normalized document short-circuits to the input bytes", async () => {

--- a/packages/core/src/docx/ensureParaIds.ts
+++ b/packages/core/src/docx/ensureParaIds.ts
@@ -570,7 +570,15 @@ const ensureParaIdsInternal = async (
   }
 
   for (const [partPath, content] of updates) {
-    zip.file(partPath, content, { compression: "DEFLATE", compressionOptions: { level: 6 } });
+    const sourceEntry = zip.file(partPath);
+    if (sourceEntry === null) {
+      throw createEnsureParaIdsError(`Package part disappeared during normalization: ${partPath}`);
+    }
+    zip.file(partPath, content, {
+      compression: "DEFLATE",
+      compressionOptions: { level: 6 },
+      date: sourceEntry.date,
+    });
   }
   const output = await zip.generateAsync({
     type: "uint8array",

--- a/packages/core/src/layout-bridge/convert/headerFooterLayout.test.ts
+++ b/packages/core/src/layout-bridge/convert/headerFooterLayout.test.ts
@@ -12,6 +12,7 @@ import {
   convertHeaderFooterPmDocToContent,
   convertHeaderFooterToContent,
   normalizeHeaderFooterMeasureBlocks,
+  reserveHeaderFooterFullWidthWrapBands,
 } from "./headerFooterLayout";
 
 const DETACHED_WATERMARK_HOST = Symbol.for("stll.detachedWatermarkHost");
@@ -112,6 +113,70 @@ function measureBlocks(blocks: FlowBlock[]): Measure[] {
     };
   });
 }
+
+describe("reserveHeaderFooterFullWidthWrapBands", () => {
+  test.each(["header", "footer"] as const)(
+    "advances past a paragraph-relative wrapping image that spans a %s story",
+    (section) => {
+      const blocks: FlowBlock[] = [
+        paragraph({
+          runs: [
+            {
+              kind: "image",
+              src: "synthetic.png",
+              width: 520,
+              height: 40,
+              wrapType: "square",
+              position: {
+                horizontal: { relativeTo: "column", posOffset: -100_000 },
+                vertical: { relativeTo: "paragraph", posOffset: 95_250 },
+              },
+            },
+          ],
+        }),
+      ];
+
+      const measures = reserveHeaderFooterFullWidthWrapBands({
+        blocks,
+        measures: [{ kind: "paragraph", lines: [], totalHeight: 12 }],
+        contentWidth: 456,
+        metrics: { ...metrics, section },
+      });
+
+      expect(measures[0]).toMatchObject({ kind: "paragraph", totalHeight: 62 });
+    },
+  );
+
+  test("does not reserve a band when story content can wrap beside the image", () => {
+    const blocks: FlowBlock[] = [
+      paragraph({
+        runs: [
+          {
+            kind: "image",
+            src: "synthetic.png",
+            width: 120,
+            height: 40,
+            wrapType: "square",
+            position: {
+              horizontal: { relativeTo: "column", posOffset: 0 },
+              vertical: { relativeTo: "paragraph", posOffset: 95_250 },
+            },
+          },
+        ],
+      }),
+    ];
+    const original = { kind: "paragraph" as const, lines: [], totalHeight: 12 };
+
+    expect(
+      reserveHeaderFooterFullWidthWrapBands({
+        blocks,
+        measures: [original],
+        contentWidth: 456,
+        metrics,
+      })[0],
+    ).toBe(original);
+  });
+});
 
 describe("calculateHeaderFooterVisualBounds", () => {
   test("accounts for page-anchored floating table bounds", () => {

--- a/packages/core/src/layout-bridge/convert/headerFooterLayout.ts
+++ b/packages/core/src/layout-bridge/convert/headerFooterLayout.ts
@@ -33,7 +33,11 @@ import type {
   TableBlock,
   TableMeasure,
 } from "../../layout-engine/types";
-import { isFloatingImageRun, isFloatingTextBoxBlock } from "../../layout-engine/types";
+import {
+  isFloatingImageRun,
+  isFloatingTextBoxBlock,
+  isTextWrappingFloatingImageRun,
+} from "../../layout-engine/types";
 import { headerFooterToProseDoc } from "../../prosemirror/conversion/toProseDoc";
 import { cloneParagraphWithPropertySource } from "../../docx/paragraphPropertySource";
 import type { BlockContent, HeaderFooter, StyleDefinitions, Theme } from "../../types/document";
@@ -851,6 +855,83 @@ export function convertHeaderFooterPmDocToContent(
 // 6. Shared tail — blocks → HeaderFooterContent
 // =============================================================================
 
+type HorizontalImageLeftOptions = {
+  run: ImageRun;
+  contentWidth: number;
+  metrics: HeaderFooterMetrics;
+};
+
+function horizontalImageLeft({ run, contentWidth, metrics }: HorizontalImageLeftOptions): number {
+  const horizontal = run.position?.horizontal;
+  if (horizontal?.posOffset !== undefined) {
+    const frameLeft = horizontal.relativeTo === "page" ? -metrics.margins.left : 0;
+    return frameLeft + emuToPixels(horizontal.posOffset);
+  }
+
+  const alignment = getPositionAlignment(horizontal);
+  const frameWidth = horizontal?.relativeTo === "page" ? metrics.pageSize.w : contentWidth;
+  const frameLeft = horizontal?.relativeTo === "page" ? -metrics.margins.left : 0;
+  if (alignment === "center") {
+    return frameLeft + (frameWidth - run.width) / 2;
+  }
+  if (alignment === "right" || alignment === "outside") {
+    return frameLeft + frameWidth - run.width;
+  }
+  return frameLeft;
+}
+
+/**
+ * A paragraph-relative wrapping image that spans the whole story width leaves
+ * no side on which following content can flow. Retain the host paragraph's
+ * line box and reserve the complete anchored extent after it.
+ */
+type ReserveHeaderFooterFullWidthWrapBandsOptions = {
+  blocks: FlowBlock[];
+  measures: Measure[];
+  contentWidth: number;
+  metrics: HeaderFooterMetrics;
+};
+
+export function reserveHeaderFooterFullWidthWrapBands({
+  blocks,
+  measures,
+  contentWidth,
+  metrics,
+}: ReserveHeaderFooterFullWidthWrapBandsOptions): Measure[] {
+  return measures.map((measure, index) => {
+    const block = blocks[index];
+    if (block?.kind !== "paragraph" || measure.kind !== "paragraph") {
+      return measure;
+    }
+
+    let reservedHeight = 0;
+    for (const run of block.runs) {
+      if (run.kind !== "image" || !isTextWrappingFloatingImageRun(run)) {
+        continue;
+      }
+      const relativeTo = run.position?.vertical?.relativeTo;
+      if (relativeTo !== undefined && relativeTo !== "paragraph" && relativeTo !== "line") {
+        continue;
+      }
+      const distLeft = run.distLeft ?? 0;
+      const left = horizontalImageLeft({ run, contentWidth, metrics }) - distLeft;
+      const right = left + run.width + distLeft + (run.distRight ?? 0);
+      if (left > 0 || right < contentWidth) {
+        continue;
+      }
+      const offset = emuToPixels(run.position?.vertical?.posOffset ?? 0);
+      reservedHeight = Math.max(
+        reservedHeight,
+        Math.max(0, offset) + run.height + (run.distBottom ?? 0),
+      );
+    }
+
+    return reservedHeight > 0
+      ? { ...measure, totalHeight: measure.totalHeight + reservedHeight }
+      : measure;
+  });
+}
+
 function finalizeHeaderFooterContent(
   blocks: FlowBlock[],
   contentWidth: number,
@@ -862,7 +943,13 @@ function finalizeHeaderFooterContent(
   }
 
   const blocksForMeasure = normalizeHeaderFooterMeasureBlocks(blocks, metrics.section);
-  const measures = options.measureBlocks(blocksForMeasure, contentWidth);
+  const measuredBlocks = options.measureBlocks(blocksForMeasure, contentWidth);
+  const measures = reserveHeaderFooterFullWidthWrapBands({
+    blocks,
+    measures: measuredBlocks,
+    contentWidth,
+    metrics,
+  });
   let flowHeight = 0;
   for (let i = 0; i < measures.length; i++) {
     const m = measures[i];

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -225,6 +225,46 @@ describe("toFlowBlocks paragraph formatting", () => {
     ]);
   });
 
+  test("coalesces a trailing page break into an incoming continuous section", () => {
+    const doc = schema.node("doc", { _finalSectionStart: "continuous" }, [
+      schema.node(
+        "paragraph",
+        {
+          _sectionProperties: {},
+          _trailingPageBreak: true,
+        },
+        [schema.text("Synthetic section ending")],
+      ),
+      schema.node("pageBreak"),
+      schema.node("paragraph", null, [schema.text("Synthetic continuation")]),
+    ]);
+
+    expect(toFlowBlocks(doc).map((block) => block.kind)).toEqual([
+      "paragraph",
+      "sectionBreak",
+      "paragraph",
+    ]);
+  });
+
+  test("keeps the trailing page break when its paragraph mark moves", () => {
+    const doc = schema.node("doc", { _finalSectionStart: "continuous" }, [
+      schema.node(
+        "paragraph",
+        {
+          _sectionProperties: {},
+          _trailingPageBreak: true,
+        },
+        [schema.text("Synthetic section ending")],
+      ),
+      schema.node("pageBreak"),
+      schema.node("paragraph", null, [schema.text("Synthetic continuation")]),
+    ]);
+
+    expect(
+      toFlowBlocks(doc, { splitPageBreakAndParagraphMark: true }).map((block) => block.kind),
+    ).toEqual(["paragraph", "pageBreak", "paragraph", "sectionBreak", "paragraph"]);
+  });
+
   test("keeps text-box anchors out of paragraph layout", () => {
     const paragraph = toFlowBlocks(
       schema.node("doc", null, [

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -144,6 +144,8 @@ export type ToFlowBlocksOptions = {
   fontAlternates?: FontAlternates;
   /** Page content height in pixels (pageHeight - marginTop - marginBottom). Images taller than this are scaled down to fit. */
   pageContentHeight?: number;
+  /** Whether a trailing page break moves its paragraph mark to the next page. */
+  splitPageBreakAndParagraphMark?: boolean;
   /** Shared list counters for nested containers. */
   listCounters?: Map<number, number[]>;
   /** Latest concrete counters by abstract numbering definition. */
@@ -1979,6 +1981,7 @@ function convertParagraph(
     attrs.shading !== undefined;
   if (runs.length === 0 && pmAttrs._pageBreakCarrier === true && !hasVisibleParagraphPayload) {
     attrs.suppressEmptyParagraphHeight = true;
+    attrs.paginationRole = "trailing-section-break-carrier";
   }
 
   const bookmarkNames = pmAttrs.bookmarks?.map((b) => b.name);
@@ -2769,6 +2772,45 @@ function applySectionStartsToBoundaries(
   return result;
 }
 
+/**
+ * A trailing page break belongs to its section-ending paragraph. When the
+ * paragraph mark stays on the current page, an immediately following
+ * continuous section resumes there too; the synthetic page and carrier are
+ * not physical layout boundaries.
+ */
+function coalesceTrailingPageBreakBeforeContinuousSection(
+  blocks: readonly FlowBlock[],
+  splitPageBreakAndParagraphMark: boolean,
+): FlowBlock[] {
+  if (splitPageBreakAndParagraphMark) {
+    return [...blocks];
+  }
+
+  const result: FlowBlock[] = [];
+  for (let index = 0; index < blocks.length; index += 1) {
+    const block = blocks[index];
+    const carrier = blocks[index + 1];
+    const section = blocks[index + 2];
+    const isGeneratedCarrier =
+      carrier?.kind === "paragraph" &&
+      carrier.runs.length === 0 &&
+      carrier.attrs?.paginationRole === "trailing-section-break-carrier";
+    if (
+      block?.kind === "pageBreak" &&
+      isGeneratedCarrier &&
+      section?.kind === "sectionBreak" &&
+      section.type === "continuous"
+    ) {
+      index += 1;
+      continue;
+    }
+    if (block) {
+      result.push(block);
+    }
+  }
+  return result;
+}
+
 function readFinalSectionStart(doc: PMNode): NonNullable<SectionBreakBlock["type"]> | undefined {
   const sectionStart = doc.attrs["_finalSectionStart"];
   switch (sectionStart) {
@@ -3055,6 +3097,7 @@ export function toFlowBlocks(doc: PMNode, options: ToFlowBlocksOptions = {}): Fl
                 delete carrierSpacing.before;
               }
               const carrierAttrs: ParagraphAttrs = {
+                paginationRole: "trailing-section-break-carrier",
                 ...(carrierSpacing ? { spacing: carrierSpacing } : {}),
                 ...(sourceAttrs?.automaticSpacing?.after === true
                   ? { automaticSpacing: { after: true } }
@@ -3207,7 +3250,11 @@ export function toFlowBlocks(doc: PMNode, options: ToFlowBlocksOptions = {}): Fl
     tableCellLinePitch,
   });
   const boundaryBlocks = applySectionStartsToBoundaries(griddedBlocks, readFinalSectionStart(doc));
-  return groupParagraphFrames(boundaryBlocks, nextBlockId);
+  const reconciledBlocks = coalesceTrailingPageBreakBeforeContinuousSection(
+    boundaryBlocks,
+    options.splitPageBreakAndParagraphMark === true,
+  );
+  return groupParagraphFrames(reconciledBlocks, nextBlockId);
 }
 
 type SectionDocumentGridOptions = {

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -1981,7 +1981,6 @@ function convertParagraph(
     attrs.shading !== undefined;
   if (runs.length === 0 && pmAttrs._pageBreakCarrier === true && !hasVisibleParagraphPayload) {
     attrs.suppressEmptyParagraphHeight = true;
-    attrs.paginationRole = "trailing-section-break-carrier";
   }
 
   const bookmarkNames = pmAttrs.bookmarks?.map((b) => b.name);
@@ -2792,9 +2791,12 @@ function coalesceTrailingPageBreakBeforeContinuousSection(
     const carrier = blocks[index + 1];
     const section = blocks[index + 2];
     const isGeneratedCarrier =
+      block?.kind === "pageBreak" &&
       carrier?.kind === "paragraph" &&
       carrier.runs.length === 0 &&
-      carrier.attrs?.paginationRole === "trailing-section-break-carrier";
+      block.pmStart !== undefined &&
+      block.pmStart === carrier.pmStart &&
+      carrier.pmStart === carrier.pmEnd;
     if (
       block?.kind === "pageBreak" &&
       isGeneratedCarrier &&
@@ -3097,7 +3099,6 @@ export function toFlowBlocks(doc: PMNode, options: ToFlowBlocksOptions = {}): Fl
                 delete carrierSpacing.before;
               }
               const carrierAttrs: ParagraphAttrs = {
-                paginationRole: "trailing-section-break-carrier",
                 ...(carrierSpacing ? { spacing: carrierSpacing } : {}),
                 ...(sourceAttrs?.automaticSpacing?.after === true
                   ? { automaticSpacing: { after: true } }

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -1652,7 +1652,10 @@ function layoutTextBox(
       kind: "textBox",
       blockId: block.id,
       x,
-      y: state.topMargin + bandTop,
+      y:
+        block.position?.vertical?.relativeTo === "page"
+          ? sectionMarginTop + bandTop
+          : state.topMargin + bandTop,
       width: measure.width,
       height: measure.height,
       isPositioned: true,
@@ -1686,15 +1689,27 @@ function layoutTextBox(
             (fragment) => fragment.kind === "paragraph" && fragment.blockId === anchorBlockId,
           )
         : undefined;
-    const y = isPageFrameRelativeAnchor(vertical?.relativeTo)
-      ? state.topMargin +
+    const bandGeometry = {
+      pageHeight: sectionPageHeight,
+      marginTop: sectionMarginTop,
+      marginBottom: sectionMarginBottom,
+      boxHeight: measure.height,
+    };
+    let y;
+    if (vertical?.relativeTo === "page") {
+      y = sectionMarginTop + bandTopContentY(vertical, bandGeometry);
+    } else if (isPageFrameRelativeAnchor(vertical?.relativeTo)) {
+      y =
+        state.topMargin +
         bandTopContentY(vertical, {
           pageHeight: sectionPageHeight,
           marginTop: sectionMarginTop,
           marginBottom: sectionMarginBottom,
           boxHeight: measure.height,
-        })
-      : (anchorParagraph?.y ?? state.cursorY) + emuToPixels(vertical?.posOffset ?? 0);
+        });
+    } else {
+      y = (anchorParagraph?.y ?? state.cursorY) + emuToPixels(vertical?.posOffset ?? 0);
+    }
     const fragment: TextBoxFragment = {
       kind: "textBox",
       blockId: block.id,

--- a/packages/core/src/layout-engine/renderedBreakReconciliation.test.ts
+++ b/packages/core/src/layout-engine/renderedBreakReconciliation.test.ts
@@ -91,11 +91,15 @@ describe("rendered break reconciliation", () => {
     expect(decision.state).toEqual(INITIAL_RENDERED_BREAK_STATE);
   });
 
-  test("a fitting cached marker remains authoritative on a keep-next paragraph", () => {
+  test("a fitting cached marker remains advisory on a spaced keep-next paragraph", () => {
     const previous = paragraph(1);
     const decision = reconcileBreakBeforeBlock({
       state: INITIAL_RENDERED_BREAK_STATE,
-      block: paragraph(2, { keepNext: true, renderedPageBreakBefore: true }),
+      block: paragraph(2, {
+        keepNext: true,
+        renderedPageBreakBefore: true,
+        spacing: { before: 24 },
+      }),
       previousBlock: previous,
       page: page([paragraphFragment(1)]),
       blocksById: new Map([["1", previous]]),
@@ -103,7 +107,7 @@ describe("rendered break reconciliation", () => {
       renderedBreakNeedsSnap: false,
     });
 
-    expect(decision.pageAdvance).toBe("physical");
+    expect(decision.pageAdvance).toBe("none");
     expect(decision.state).toEqual(INITIAL_RENDERED_BREAK_STATE);
   });
 

--- a/packages/core/src/layout-engine/renderedBreakReconciliation.ts
+++ b/packages/core/src/layout-engine/renderedBreakReconciliation.ts
@@ -92,11 +92,13 @@ export const reconcileBreakBeforeBlock = ({
       (continuesNumberedSequence(previousBlock, block) ||
         continuesTabbedParagraphSequence(previousBlock, block)));
   // A keep-with-next paragraph carries the marker boundary into its linked
-  // content, so its own height is not enough to classify the marker as stale.
+  // content. The keep-next pass measures and moves that whole chain after
+  // reconciliation, so the cached marker remains advisory while it fits.
   const markerNeedsSnap =
     renderedBreakNeedsSnap ||
-    block.attrs?.keepNext === true ||
-    ((block.attrs?.spacing?.before ?? 0) > 0 && previousBlock?.kind !== "sectionBreak") ||
+    ((block.attrs?.spacing?.before ?? 0) > 0 &&
+      block.attrs?.keepNext !== true &&
+      previousBlock?.kind !== "sectionBreak") ||
     previousBlock?.kind === "table";
   const forcePageBreak =
     markerNeedsSnap && !markerAlreadySatisfied && pageHasVisibleBodyContent(page, blocksById);

--- a/packages/core/src/layout-engine/textbox-band.test.ts
+++ b/packages/core/src/layout-engine/textbox-band.test.ts
@@ -222,12 +222,9 @@ describe("topAndBottom band text box layout", () => {
     expect(box?.y).toBe(MARGINS.top + paraMeasure.totalHeight + 96);
   });
 
-  test("band uses the section top margin, not a page's first-page margin", () => {
-    // On a title page the first-page top margin can differ from the section
-    // margin. The measure pass reserves the band using the section margin, so
-    // the box must too — otherwise box and band desync. The box's
-    // content-relative top (fragment.y - page top margin) must equal the band's
-    // content top (= -section margin for a page-relative offset-0 banner).
+  test("page-relative placement does not inherit an expanded first-page body margin", () => {
+    // Header clearance can expand the body's first-page top margin. A page-
+    // relative object still uses the physical page as its coordinate frame.
     const FIRST_PAGE_TOP = 200;
     const layout = layoutDocument([banner("page"), para("p")], [boxMeasure, paraMeasure], {
       ...OPTIONS,
@@ -235,10 +232,8 @@ describe("topAndBottom band text box layout", () => {
     });
     const page = layout.pages[0]!;
     const box = page.fragments.find((f) => f.kind === "textBox") as TextBoxFragment | undefined;
-    // y = firstPageTop + (0 - sectionMarginTop) = 200 - 96 = 104, so the
-    // content-relative top is 104 - 200 = -96 = -section margin (band-aligned).
-    expect(box?.y).toBe(FIRST_PAGE_TOP - MARGINS.top);
-    expect((box?.y ?? 0) - page.margins.top).toBe(-MARGINS.top);
+    expect(box?.y).toBe(0);
+    expect((box?.y ?? 0) - page.margins.top).toBe(-FIRST_PAGE_TOP);
   });
 
   test("band uses the current section top margin after a section break", () => {

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -447,6 +447,8 @@ export type ListNumPr = {
  * Paragraph block attributes.
  */
 export type ParagraphAttrs = {
+  /** Internal structural role used while reconciling authored pagination. */
+  paginationRole?: "trailing-section-break-carrier";
   alignment?: "left" | "center" | "right" | "justify";
   /** Document-generation policy for justified line fitting. */
   justificationCompatibility?: { type: "legacy" };

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -447,8 +447,6 @@ export type ListNumPr = {
  * Paragraph block attributes.
  */
 export type ParagraphAttrs = {
-  /** Internal structural role used while reconciling authored pagination. */
-  paginationRole?: "trailing-section-break-carrier";
   alignment?: "left" | "center" | "right" | "justify";
   /** Document-generation policy for justified line fitting. */
   justificationCompatibility?: { type: "legacy" };

--- a/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
@@ -669,6 +669,53 @@ describe("toProseDoc", () => {
     );
   });
 
+  test("keeps named paragraph-mark emphasis and color off unformatted body text", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              formatting: {
+                styleId: "Body",
+                runProperties: {
+                  bold: true,
+                  color: { rgb: "E63946" },
+                },
+              },
+              content: [
+                {
+                  type: "run",
+                  formatting: {},
+                  content: [{ type: "text", text: "Synthetic clause text" }],
+                },
+              ],
+            },
+          ],
+        },
+        styles: {
+          styles: [
+            {
+              styleId: "Body",
+              type: "paragraph",
+              default: true,
+              rPr: { fontSize: 11 },
+            },
+          ],
+        },
+      },
+    };
+
+    const doc = toProseDoc(document, { styles: document.package.styles });
+    const paragraph = doc.firstChild;
+    const text = paragraph?.firstChild;
+
+    expect(text?.marks.some((mark) => mark.type.name === "bold")).toBe(false);
+    expect(text?.marks.some((mark) => mark.type.name === "textColor")).toBe(false);
+    expect(paragraph?.attrs.defaultTextFormatting?.bold).toBeUndefined();
+    expect(paragraph?.attrs.defaultTextFormatting?.color).toBeUndefined();
+  });
+
   test("does not inherit paragraph mark all-caps onto visible text", () => {
     const document: Document = {
       package: {

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -478,7 +478,7 @@ function convertParagraph(
   // Paragraph-mark-only visual decorations (highlight, shading) paint the
   // paragraph glyph alone. Strip them from the body-run inheritance path.
   let inheritableParagraphRunFormatting: TextFormatting | undefined;
-  if (paragraphRunFormatting && !isTocParagraph) {
+  if (paragraphRunFormatting && !isTocParagraph && paragraph.formatting?.styleId === undefined) {
     inheritableParagraphRunFormatting =
       stripParagraphMarkFormattingForBodyRuns(paragraphRunFormatting);
   }
@@ -505,26 +505,22 @@ function convertParagraph(
       fontFamily: paragraphStyleFontFamily,
     });
   }
-  // With a named paragraph style, w:pPr/w:rPr formats the paragraph mark and
-  // only fills gaps in the style's body-run defaults. Style-less generated
-  // documents use the paragraph mark as their highest-precedence run default.
-  const paragraphMarkPrecedesStyle = paragraph.formatting?.styleId !== undefined;
-  const ordinaryDefaultRunFormatting = paragraphMarkPrecedesStyle
-    ? mergeTextFormatting(inheritableParagraphRunFormatting, baseRunFormatting)
-    : mergeTextFormatting(baseRunFormatting, inheritableParagraphRunFormatting);
-  const defaultToggleCascade = paragraphMarkPrecedesStyle
-    ? cascadeStyleTextFormatting([{ cascade: orderedToggleFormatting, type: "carried" }], {
-        ordinaryFormatting: ordinaryDefaultRunFormatting,
-      })
-    : cascadeStyleTextFormatting(
-        [
-          { cascade: orderedToggleFormatting, type: "carried" },
-          { formatting: inheritableParagraphRunFormatting, type: "direct" },
-        ],
-        {
-          ordinaryFormatting: ordinaryDefaultRunFormatting,
-        },
-      );
+  // w:pPr/w:rPr formats the paragraph mark, not the visible runs of a named
+  // paragraph style. Style-less generated documents historically use it as
+  // their highest-precedence run default.
+  const ordinaryDefaultRunFormatting = mergeTextFormatting(
+    baseRunFormatting,
+    inheritableParagraphRunFormatting,
+  );
+  const defaultToggleCascade = cascadeStyleTextFormatting(
+    [
+      { cascade: orderedToggleFormatting, type: "carried" },
+      { formatting: inheritableParagraphRunFormatting, type: "direct" },
+    ],
+    {
+      ordinaryFormatting: ordinaryDefaultRunFormatting,
+    },
+  );
   const defaultRunFormatting = defaultToggleCascade.formatting;
   const getInheritedRunFormatting = (
     formatting: TextFormatting | undefined,
@@ -547,7 +543,6 @@ function convertParagraph(
       baseRunFormatting,
       inheritableParagraphRunFormatting,
       formatting,
-      paragraphMarkPrecedesStyle,
     );
     const paragraphMarkOverrides = getParagraphMarkSuppressionOverrides({
       directFormatting: formatting,
@@ -1074,7 +1069,9 @@ function paragraphFormattingToAttrs(
     set(
       "defaultTextFormatting",
       resolveParagraphDefaultTextFormatting(styleId, formatting, styleResolver, {
-        includeParagraphMarkRunProperties: tableOfContentsLevel === undefined,
+        includeParagraphMarkRunProperties:
+          tableOfContentsLevel === undefined &&
+          (styleId === undefined || paragraph.content.length === 0),
       }),
     );
 
@@ -1405,16 +1402,12 @@ function suppressParagraphMarkFormatting(
   base: TextFormatting | undefined,
   paragraphMark: TextFormatting | undefined,
   direct: TextFormatting | undefined,
-  paragraphMarkPrecedesStyle = false,
 ): TextFormatting | undefined {
   if (!paragraphMark) {
     return base;
   }
 
-  const result =
-    (paragraphMarkPrecedesStyle
-      ? mergeTextFormatting(paragraphMark, base)
-      : mergeTextFormatting(base, paragraphMark)) ?? {};
+  const result = mergeTextFormatting(base, paragraphMark) ?? {};
   for (const key of PARAGRAPH_MARK_BOOLEAN_KEYS) {
     suppressBooleanParagraphMark(result, base, paragraphMark, direct, key);
   }
@@ -1589,11 +1582,6 @@ function resolveParagraphDefaultTextFormatting(
     },
   );
   const bodyRunDefaults = orderedBodyToggleFormatting.formatting;
-  if (styleId !== undefined) {
-    return cascadeStyleTextFormatting([{ cascade: orderedBodyToggleFormatting, type: "carried" }], {
-      ordinaryFormatting: mergeTextFormatting(paragraphRunProperties, bodyRunDefaults),
-    }).formatting;
-  }
   return cascadeStyleTextFormatting(
     [
       { cascade: orderedBodyToggleFormatting, type: "carried" },

--- a/parity/__tests__/wordTruth.test.ts
+++ b/parity/__tests__/wordTruth.test.ts
@@ -29,6 +29,10 @@ describe("Word automation scripts", () => {
     expect(script).toContain("set candidatePath to POSIX path of");
     expect(script).toContain("if candidatePath is stagedDocumentPath then");
     expect(script).toContain("set theDoc to contents of candidateDocument");
+    expect(script).toContain("set print revisions of theDoc to false");
+    expect(script).toContain("set documentView to view of active window of theDoc");
+    expect(script).toContain("set revisions view of documentView to revisions view final");
+    expect(script).toContain("set show revisions and comments of documentView to false");
     expect(script).not.toContain("active document");
   });
 

--- a/parity/wordTruth.ts
+++ b/parity/wordTruth.ts
@@ -125,6 +125,10 @@ export const buildExportScript = ({ docxPath, pdfPath }: BuildExportScriptOption
 			delay 0.25
 		end repeat
 		if theDoc is missing value then error "Word did not expose the staged document after opening it"
+		set print revisions of theDoc to false
+		set documentView to view of active window of theDoc
+		set revisions view of documentView to revisions view final
+		set show revisions and comments of documentView to false
 		save as theDoc file name "${outFile}" file format format PDF
 	end tell
 end timeout`;


### PR DESCRIPTION
## Summary

- reconcile imported pagination hints around continuous sections and keep-next chains
- preserve page-relative positioning when page furniture expands the body margin
- reserve full-width wrapped artwork in header and footer flow
- keep paragraph-mark formatting from leaking into visible named-style text
- keep parity reference exports deterministic
- cover the behavior with synthetic regression fixtures and add a patch changeset

Validated with the full test suite, type checks, lint, formatting verification, and dependency audit.