### PR TITLE
fix: close split table fragments

### DIFF
--- a/.changeset/warm-tables-close.md
+++ b/.changeset/warm-tables-close.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve visible cell borders where a table row continues across pages.

--- a/packages/core/src/display-list/build/tablePrimitives.ts
+++ b/packages/core/src/display-list/build/tablePrimitives.ts
@@ -23,6 +23,7 @@ import {
   buildTableCellGrid,
 } from "../../layout-engine/measure/tableCellGrid";
 import { resolveTableCellPadding } from "../../layout-engine/types";
+import { tableFragmentBottomBorders } from "../../layout-engine/measure/tableFragmentBorderGeometry";
 import type {
   FlowBlock,
   Measure,
@@ -531,6 +532,44 @@ const paintTableBody = ({
   }
 };
 
+type PaintFragmentBottomBordersOptions = {
+  readonly composer: PageComposer;
+  readonly fragment: TableFragment;
+  readonly block: TableBlock;
+  readonly measure: TableMeasure;
+  readonly context: BuildContext;
+};
+
+const paintFragmentBottomBorders = ({
+  composer,
+  fragment,
+  block,
+  measure,
+  context,
+}: PaintFragmentBottomBordersOptions): void => {
+  if (fragment.continuesOnNext !== true || fragment.bottomClip === undefined) return;
+
+  const primitives: DisplayPrimitive[] = [];
+  for (const { left, width, border } of tableFragmentBottomBorders({
+    fragment,
+    block,
+    measure,
+  })) {
+    const stroke = strokeFor(border, context, "table fragment bottom border");
+    if (!stroke) continue;
+    const yPx = fragment.y + fragment.height - stroke.thicknessPx / 2;
+    primitives.push({
+      kind: "line",
+      x1Px: fragment.x + left,
+      y1Px: yPx,
+      x2Px: fragment.x + left + width,
+      y2Px: yPx,
+      stroke,
+    });
+  }
+  composer.push(primitives);
+};
+
 export type TableBlockPaintOptions = {
   readonly composer: PageComposer;
   readonly block: TableBlock;
@@ -653,4 +692,5 @@ export const paintTableFragment = ({
       regions: [...clipped.regions()],
     },
   ]);
+  paintFragmentBottomBorders({ composer, fragment, block, measure, context });
 };

--- a/packages/core/src/display-list/clippedTableRegions.test.ts
+++ b/packages/core/src/display-list/clippedTableRegions.test.ts
@@ -108,6 +108,7 @@ test("clipped table-row continuations keep editing regions", () => {
               {
                 id: "body-cell",
                 padding: { top: 0, right: 0, bottom: 0, left: 0 },
+                borders: { bottom: { width: 2, style: "solid", color: "#123456" } },
                 blocks: [
                   {
                     kind: "paragraph",
@@ -153,6 +154,20 @@ test("clipped table-row continuations keep editing regions", () => {
       if (clipPrimitive?.kind !== "clipGroup") {
         return;
       }
+      const fragmentBottomBorder = page.primitives.find(
+        (primitive) =>
+          primitive.kind === "line" &&
+          primitive.stroke.color.r === 0x12 &&
+          primitive.stroke.color.g === 0x34 &&
+          primitive.stroke.color.b === 0x56,
+      );
+      expect(fragmentBottomBorder).toMatchObject({
+        kind: "line",
+        x1Px: clipPrimitive.rect.xPx,
+        x2Px: clipPrimitive.rect.xPx + clipPrimitive.rect.widthPx,
+        y1Px: clipPrimitive.rect.yPx + clipPrimitive.rect.heightPx - 1,
+        y2Px: clipPrimitive.rect.yPx + clipPrimitive.rect.heightPx - 1,
+      });
 
       const pageRegions = flattenRegions(page.regions);
       const clipRegions = flattenRegions(clipPrimitive.regions);

--- a/packages/core/src/layout-engine/measure/tableFragmentBorderGeometry.property.test.ts
+++ b/packages/core/src/layout-engine/measure/tableFragmentBorderGeometry.property.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "bun:test";
+import fc from "fast-check";
+
+import { tableFragmentBottomBorders } from "./tableFragmentBorderGeometry";
+
+test("a split row projects every visible bottom border onto its fragment edge", () => {
+  fc.assert(
+    fc.property(
+      fc.array(
+        fc.record({
+          width: fc.integer({ min: 8, max: 160 }),
+          borderWidth: fc.integer({ min: 0, max: 8 }),
+          style: fc.constantFrom("solid", "dashed", "dotted", "double", "none", "nil"),
+        }),
+        { minLength: 1, maxLength: 8 },
+      ),
+      (columns) => {
+        const cells = columns.map(({ borderWidth, style }, index) => ({
+          id: `cell-${String(index)}`,
+          blocks: [],
+          borders: { bottom: { width: borderWidth, style, color: "#123456" } },
+        }));
+        const columnWidths = columns.map(({ width }) => width);
+        const block = {
+          kind: "table",
+          id: "table",
+          rows: [{ id: "row", cells }],
+          columnWidths,
+        } as const;
+        const measure = {
+          kind: "table",
+          rows: [
+            {
+              cells: columnWidths.map((width) => ({ blocks: [], width, height: 100 })),
+              height: 100,
+            },
+          ],
+          columnWidths,
+          totalWidth: columnWidths.reduce((total, width) => total + width, 0),
+          totalHeight: 100,
+        } as const;
+        const fragment = {
+          kind: "table",
+          blockId: "table",
+          x: 0,
+          y: 0,
+          width: measure.totalWidth,
+          height: 40,
+          fromRow: 0,
+          toRow: 1,
+          bottomClip: 40,
+          continuesOnNext: true,
+        } as const;
+
+        const borders = tableFragmentBottomBorders({ fragment, block, measure });
+        let left = 0;
+        const expected = columns.flatMap(({ width, style }) => {
+          const segment = style === "none" || style === "nil" ? [] : [{ left, width, style }];
+          left += width;
+          return segment;
+        });
+
+        expect(
+          borders.map(({ left: segmentLeft, width, border }) => ({
+            left: segmentLeft,
+            width,
+            style: border.style,
+          })),
+        ).toEqual(expected);
+      },
+    ),
+  );
+});

--- a/packages/core/src/layout-engine/measure/tableFragmentBorderGeometry.ts
+++ b/packages/core/src/layout-engine/measure/tableFragmentBorderGeometry.ts
@@ -1,0 +1,48 @@
+import type { CellBorderSpec, TableBlock, TableFragment, TableMeasure } from "../types";
+import {
+  buildTableCellGrid,
+  buildTableCellPlacements,
+  type TableCellPlacements,
+} from "./tableCellGrid";
+
+type TableFragmentBottomBorder = {
+  readonly left: number;
+  readonly width: number;
+  readonly border: CellBorderSpec;
+};
+
+type TableFragmentBottomBordersOptions = {
+  readonly fragment: TableFragment;
+  readonly block: TableBlock;
+  readonly measure: TableMeasure;
+  readonly placements?: TableCellPlacements;
+};
+
+const isVisible = (border: CellBorderSpec | undefined): border is CellBorderSpec =>
+  border !== undefined && border.style !== "none" && border.style !== "nil";
+
+export const tableFragmentBottomBorders = ({
+  fragment,
+  block,
+  measure,
+  placements: suppliedPlacements,
+}: TableFragmentBottomBordersOptions): readonly TableFragmentBottomBorder[] => {
+  if (fragment.continuesOnNext !== true || fragment.bottomClip === undefined) return [];
+
+  const splitRow = block.rows.at(fragment.toRow - 1);
+  if (!splitRow) return [];
+  const placements =
+    suppliedPlacements ??
+    buildTableCellPlacements({
+      grid: buildTableCellGrid(block.rows, measure.columnWidths.length),
+      columnWidths: measure.columnWidths,
+      bidi: block.bidi === true,
+    });
+  return splitRow.cells.flatMap((cell) => {
+    const placement = placements.get(cell);
+    const border = cell.borders?.bottom;
+    return placement && isVisible(border)
+      ? [{ left: placement.left, width: placement.width, border }]
+      : [];
+  });
+};

--- a/packages/core/src/layout-painter/renderTable.ts
+++ b/packages/core/src/layout-painter/renderTable.ts
@@ -50,6 +50,7 @@ import {
   resolveTableInlineOffset,
   resolveTableInlinePlacement,
 } from "../layout-engine/measure/tableInlinePlacement";
+import { tableFragmentBottomBorders } from "../layout-engine/measure/tableFragmentBorderGeometry";
 import { emuToPixels } from "../utils/units";
 import { applySanitizedImageSrc } from "../utils/sanitizeImageSrc";
 import { resolveAnchoredImagePosition, type PageGeometry } from "./anchoredImagePosition";
@@ -1257,6 +1258,26 @@ export function renderTableFragment(
 
     contentParent.append(rowEl);
     y += rowMeasure.height;
+  }
+
+  for (const { left, width, border } of tableFragmentBottomBorders({
+    fragment,
+    block,
+    measure,
+    placements: cellPlacements,
+  })) {
+    const borderEl = doc.createElement("div");
+    borderEl.className = CELL_BOTTOM_BORDER_CLASS;
+    borderEl.style.position = "absolute";
+    borderEl.style.left = `${left}px`;
+    borderEl.style.top = "0";
+    borderEl.style.width = `${width}px`;
+    borderEl.style.height = `${fragment.height}px`;
+    borderEl.style.boxSizing = "border-box";
+    borderEl.style.pointerEvents = "none";
+    borderEl.style.zIndex = "1";
+    applyBorder(borderEl, "bottom", border);
+    tableEl.append(borderEl);
   }
 
   // Add row resize handles at each row boundary (between consecutive rows)

--- a/packages/core/src/layout-painter/renderTableFragment.test.ts
+++ b/packages/core/src/layout-painter/renderTableFragment.test.ts
@@ -284,6 +284,57 @@ describe("renderTableFragment continuation row boundaries", () => {
 });
 
 describe("renderTableFragment split-row cell content", () => {
+  test("projects the split row bottom border onto the fragment edge", () => {
+    const block: TableBlock = {
+      kind: "table",
+      id: "synthetic-table",
+      rows: [
+        {
+          id: "synthetic-row",
+          cells: [
+            {
+              id: "synthetic-cell",
+              blocks: [],
+              borders: { bottom: { width: 2, style: "solid", color: "#123456" } },
+            },
+          ],
+        },
+      ],
+      columnWidths: [80],
+    };
+    const measure: TableMeasure = {
+      kind: "table",
+      rows: [{ cells: [{ blocks: [], width: 80, height: 100 }], height: 100 }],
+      columnWidths: [80],
+      totalWidth: 80,
+      totalHeight: 100,
+    };
+    const fragment: TableFragment = {
+      kind: "table",
+      blockId: "synthetic-table",
+      x: 0,
+      y: 0,
+      width: 80,
+      height: 30,
+      fromRow: 0,
+      toRow: 1,
+      bottomClip: 30,
+      continuesOnNext: true,
+    };
+
+    const table = renderTableFragment(fragment, block, measure, renderContext, {
+      document: fakeDocument,
+    }) as unknown as FakeElement;
+    const border = findByClass(table, "layout-table-cell-bottom-border").at(0);
+
+    expect(border?.style).toMatchObject({
+      left: "0px",
+      width: "80px",
+      height: "30px",
+    });
+    expect(border?.style["borderBottom"]).toContain("solid");
+  });
+
   test("clips ordinary cell content to each intersecting row slice", () => {
     const block: TableBlock = {
       kind: "table",


### PR DESCRIPTION
Projects each visible cell bottom border onto a page-ending row slice. A shared geometry helper keeps the display-list and DOM painters aligned; a generated property test covers varying columns, widths, and border styles.