### PR TITLE
fix(core): preserve terminal table replacements

### DIFF
--- a/.changeset/exact-terminal-table-replacements.md
+++ b/.changeset/exact-terminal-table-replacements.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve terminal table replacements across tracked-change acceptance, rejection, and reopen.

--- a/packages/core/src/ai-edits/snapshot.ts
+++ b/packages/core/src/ai-edits/snapshot.ts
@@ -56,10 +56,10 @@ export const isFolioAIContentBlock = ({ text }: Pick<FolioAIBlock, "text">): boo
  * container-edge rule then applies and the addition cannot be rejected
  * cleanly.
  *
- * A body always ends with a paragraph — a table may not be the last child of a
- * body or a cell, so a package that ends in a table carries a trailing, often
- * empty, paragraph after it — so this is only `null` for a story with no
- * body-level paragraph at all, which is a malformed document.
+ * A body may validly end with a table immediately before its final section
+ * properties. Such a story has no body paragraph to anchor to, so this returns
+ * `null`; callers that can place a peer beside the table use its outer boundary
+ * instead.
  */
 export const trailingBodyBlockId = ({ blocks }: FolioAIEditSnapshot): string | null => {
   for (let index = blocks.length - 1; index >= 0; index--) {

--- a/packages/core/src/compare/README.md
+++ b/packages/core/src/compare/README.md
@@ -157,6 +157,12 @@ say it went.
   needed: pairing the two ends where the chain does reach the carrier would
   trade a plain "this paragraph was removed" for a removal plus a rewrite that
   reads nothing like the edit.
+- **A replacement table at the story's end follows the carrier.** A body may
+  validly place a table immediately before its final section properties. When
+  an empty base carrier follows the table being replaced, the redline orders
+  the deleted source table, the carrier with its deleted paragraph mark, then
+  the inserted target table. Accepting removes the source and carrier;
+  rejecting removes the target and restores the carrier.
 - **An inserted mark at a container's end rotates the same way.** The break was
   ADDED, and rejecting an added break closes the paragraph it ends back over
   the NEXT one — which a container's last paragraph does not have, so the mark

--- a/packages/core/src/compare/__fixtures__/body-sequence.ts
+++ b/packages/core/src/compare/__fixtures__/body-sequence.ts
@@ -247,10 +247,9 @@ const collectHrefs = (items: readonly BodyItem[], hrefs: string[]): void => {
 const EMPTY_PARAGRAPH = { kind: "paragraph", text: "" } as const satisfies BodyItem;
 
 /**
- * A container may not end with a table: the format requires a paragraph after
- * one, and a body's section properties do not supply it. One rule for both
- * containers, because a fixture that is well formed in a cell and malformed in
- * the body would be measuring two different things.
+ * Most fixtures add a paragraph after a table so later paragraph insertions
+ * have an explicit anchor. Tests for a schema-valid terminal table remove that
+ * convenience paragraph deliberately.
  */
 const closedSequence = (items: readonly BodyItem[]): readonly BodyItem[] => {
   const last = items.at(-1);

--- a/packages/core/src/compare/plan.test.ts
+++ b/packages/core/src/compare/plan.test.ts
@@ -268,6 +268,40 @@ describe("document-terminal paragraph carrier", () => {
     ]);
   });
 
+  test("places a replacement terminal table after its deletable base carrier", () => {
+    const base = [
+      gridCell("source", "Source terminal table", {
+        rowIndex: 0,
+        cellIndex: 0,
+        gridColumnIndex: 0,
+      }),
+      block("base-carrier", ""),
+    ];
+    const target = [
+      gridCell("target", "Target terminal table", {
+        rowIndex: 0,
+        cellIndex: 0,
+        gridColumnIndex: 0,
+        columnSpan: 2,
+      }),
+    ];
+
+    const { changes, operations } = planOf(base, target);
+
+    expect(changes.map(({ kind }) => kind)).toEqual(["table-delete", "table-insert", "delete"]);
+    expect(operations).toEqual([
+      { id: "compare-1", type: "deleteTable", blockId: "source" },
+      {
+        id: "compare-2",
+        type: "insertTable",
+        blockId: "base-carrier",
+        position: "after",
+        rows: [["Target terminal table"]],
+      },
+      { id: "compare-3", type: "deleteBlock", blockId: "base-carrier" },
+    ]);
+  });
+
   test("still compares paragraph properties on the reserved carrier", () => {
     const baseCarrier = block("base-carrier", "");
     const targetCarrier = { ...block("target-carrier", ""), styleId: "CustomStyle" };

--- a/packages/core/src/compare/plan.ts
+++ b/packages/core/src/compare/plan.ts
@@ -1207,6 +1207,7 @@ type TrailingDeletionOptions = {
   targetSnapshot: FolioAIEditSnapshot;
   /** The plan so far, rewritten around each container it empties. */
   operations: readonly FolioAIEditOperation[];
+  tableTemplates: readonly CompareTableTemplateRequest[];
   nextOperationId: () => string;
 };
 
@@ -1221,8 +1222,8 @@ type TrailingRun = {
   chainStart: FolioAIBlock | null;
   /** Indexes into the plan of the paragraph insertions placed in the run. */
   insertIndexes: readonly number[];
-  /** A table the plan places inside the run, which no rule here covers. */
-  holdsAnInsertedTable: boolean;
+  /** Indexes into the plan of tables placed inside the run. */
+  tableInsertIndexes: readonly number[];
 };
 
 /**
@@ -1262,12 +1263,13 @@ const withTrailingDeletionRules = ({
   baseSnapshot,
   targetSnapshot,
   operations,
+  tableTemplates,
   nextOperationId,
 }: TrailingDeletionOptions): FolioAIEditOperation[] => {
   const plan = [...operations];
   const deletionIndexByBlockId = new Map<string, number>();
   const insertIndexesByAnchor = new Map<string, number[]>();
-  const tableAnchorIds = new Set<string>();
+  const tableInsertIndexesByAnchor = new Map<string, number[]>();
   // A block whose own mark the plan already moves is not a chain start: a
   // split has put a second paragraph after it, and a merge has spent its mark.
   const markedBlockIds = new Set<string>();
@@ -1285,7 +1287,9 @@ const withTrailingDeletionRules = ({
         break;
       }
       case "insertTable": {
-        tableAnchorIds.add(operation.blockId);
+        const placed = tableInsertIndexesByAnchor.get(operation.blockId) ?? [];
+        placed.push(index);
+        tableInsertIndexesByAnchor.set(operation.blockId, placed);
         break;
       }
       case "splitBlock":
@@ -1313,8 +1317,8 @@ const withTrailingDeletionRules = ({
   const trailingRunOf = (container: string, carrier: FolioAIBlock): TrailingRun => {
     const blockIds: string[] = [];
     const insertIndexes: number[] = [];
+    const tableInsertIndexes: number[] = [];
     let chainStart: FolioAIBlock | null = null;
-    let holdsAnInsertedTable = false;
     let index =
       indexById.get(carrier.id) ??
       panic("A container's last block is not in the snapshot it came from", {
@@ -1331,7 +1335,7 @@ const withTrailingDeletionRules = ({
       }
       blockIds.push(block.id);
       insertIndexes.push(...(insertIndexesByAnchor.get(block.id) ?? []));
-      holdsAnInsertedTable ||= tableAnchorIds.has(block.id);
+      tableInsertIndexes.push(...(tableInsertIndexesByAnchor.get(block.id) ?? []));
     }
     // The plan emits operations in target order, so the plan's own order is
     // the order the inserted paragraphs have to end up in. Numerically: the
@@ -1341,11 +1345,15 @@ const withTrailingDeletionRules = ({
       blockIds,
       chainStart,
       insertIndexes: insertIndexes.toSorted((left, right) => left - right),
-      holdsAnInsertedTable,
+      tableInsertIndexes: tableInsertIndexes.toSorted((left, right) => left - right),
     };
   };
 
   const targetLastByContainer = lastBlockByContainer(targetSnapshot.blocks);
+  const terminalTargetTableIndex = targetSnapshot.blocks.at(-1)?.table?.outerTableIndex;
+  const targetTableIndexByOperationId = new Map(
+    tableTemplates.map(({ operationId, targetTableIndex }) => [operationId, targetTableIndex]),
+  );
   const dropped = new Set<number>();
   const appended: FolioAIEditOperation[] = [];
   for (const [container, carrier] of lastBlockByContainer(blocks)) {
@@ -1354,10 +1362,32 @@ const withTrailingDeletionRules = ({
       continue;
     }
     const run = trailingRunOf(container, carrier);
-    if (run.holdsAnInsertedTable) {
-      // A table between the chain and the carrier leaves a deleted mark with
-      // no paragraph to join, and the self-check reports what it could not
-      // prove rather than the plan guessing at a shape.
+    if (run.tableInsertIndexes.length > 0) {
+      const tableInsertIndex =
+        run.tableInsertIndexes.length === 1 ? run.tableInsertIndexes.at(0) : undefined;
+      const tableInsert = tableInsertIndex === undefined ? undefined : plan[tableInsertIndex];
+      if (
+        container !== "body" ||
+        !isEmptyParagraphNode(carrier, baseSnapshot) ||
+        tableInsertIndex === undefined ||
+        terminalTargetTableIndex === undefined ||
+        tableInsert?.type !== "insertTable" ||
+        targetTableIndexByOperationId.get(tableInsert.id) !== terminalTargetTableIndex
+      ) {
+        // A table within a trailing paragraph run otherwise interrupts the
+        // deletion chain. Keep the conservative plan and let verification
+        // report that its ownership could not be reproduced.
+        continue;
+      }
+      // The body schema permits the target table to precede `sectPr`
+      // directly. Put the base's otherwise-final carrier immediately before
+      // that table: its deleted mark can then remove the empty paragraph,
+      // while rejecting the table insertion restores the original ending.
+      plan[tableInsertIndex] = {
+        ...tableInsert,
+        blockId: carrier.id,
+        position: "after",
+      };
       continue;
     }
     const lastInsertIndex = run.insertIndexes.at(-1);
@@ -1540,11 +1570,10 @@ export const planStoryCompare = ({
   const tableTemplates: CompareTableTemplateRequest[] = [];
   /**
    * The anchor everything past the base document's content hangs from: its
-   * last BODY-LEVEL paragraph, which the format guarantees exists because a
-   * table may not be the last child of a body. Anchoring to the last block
-   * instead put the anchor inside a table whenever the story ended with one,
-   * and an insertion anchored there escapes to the table's boundary, where no
-   * paragraph mark can express the break it added.
+   * last BODY-LEVEL paragraph, when it has one. Anchoring to the last block
+   * instead puts the anchor inside a terminal table, and a paragraph insertion
+   * then escapes to the table's boundary where no paragraph mark can express
+   * the break it added.
    *
    * The applier orders insertions that resolve to one position by their order
    * in this array, so the tail is emitted where its step sits rather than
@@ -1893,6 +1922,7 @@ export const planStoryCompare = ({
     baseSnapshot,
     targetSnapshot,
     operations,
+    tableTemplates,
     nextOperationId,
   });
 

--- a/packages/core/src/compare/probes.test.ts
+++ b/packages/core/src/compare/probes.test.ts
@@ -114,6 +114,21 @@ const withNumberingFormats = async (
 const documentPartOf = async (buffer: ArrayBuffer): Promise<string> =>
   await partOf(buffer, "word/document.xml");
 
+const withoutTerminalBodyParagraph = async (buffer: ArrayBuffer): Promise<ArrayBuffer> => {
+  const zip = await JSZip.loadAsync(buffer);
+  const documentEntry = zip.file("word/document.xml");
+  if (!documentEntry) {
+    throw new Error("The fixture has no main document part.");
+  }
+  const documentXml = await documentEntry.async("string");
+  const withoutCarrier = documentXml.replace(/<w:p\b[^>]*><\/w:p>(?=<w:sectPr>)/u, "");
+  if (withoutCarrier === documentXml) {
+    throw new Error("The fixture has no terminal empty body paragraph.");
+  }
+  zip.file("word/document.xml", withoutCarrier);
+  return await zip.generateAsync({ type: "arraybuffer" });
+};
+
 /** Every `w:p` element of a document part, as raw XML. */
 const paragraphsOf = (documentXml: string): string[] =>
   documentXml.match(/<w:p[ >][\s\S]*?<\/w:p>/gu) ?? [];
@@ -881,6 +896,62 @@ describe("single-mutation probes", () => {
     expect(await projectView(result.value.buffer, "original")).toEqual(
       await projectView(base, "final"),
     );
+  });
+
+  test("replace_terminal_table: the base carrier owns the deletion before the target table", async () => {
+    const base = await buildBodySequenceDocx([
+      { kind: "table", rows: [["Source terminal table"]] },
+      { kind: "paragraph", text: "" },
+    ]);
+    const target = await withoutTerminalBodyParagraph(
+      await buildBodySequenceDocx([
+        {
+          kind: "table",
+          rows: [[{ content: "Target terminal table", gridSpan: 2 }]],
+        },
+      ]),
+    );
+    expect(await projectView(base, "final")).toHaveLength(2);
+    expect(await projectView(target, "final")).toHaveLength(1);
+    expect(await documentPartOf(target)).toMatch(/<\/w:tbl><w:sectPr>/u);
+
+    const result = await compareDocx(base, target, OPTIONS);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    expect(result.value.changes.map(({ kind }) => kind)).toEqual([
+      "table-delete",
+      "table-insert",
+      "delete",
+    ]);
+    const pendingXml = await documentPartOf(result.value.buffer);
+    expect(pendingXml).toMatch(
+      /<w:tbl>[\s\S]*?<w:trPr><w:del\b[^>]*\/><\/w:trPr>[\s\S]*?Source terminal table/u,
+    );
+    expect(pendingXml).toMatch(
+      /Source terminal table[\s\S]*?<\/w:tbl><w:p\b[^>]*><w:pPr><w:rPr><w:del\b[\s\S]*?<\/w:p><w:tbl>[\s\S]*?Target terminal table/u,
+    );
+    expect(pendingXml).toMatch(
+      /<w:tbl>[\s\S]*?<w:trPr><w:ins\b[^>]*\/><\/w:trPr>[\s\S]*?Target terminal table/u,
+    );
+    expect(pendingXml).toMatch(/<\/w:tbl><w:sectPr>/u);
+
+    const acceptedReviewer = await FolioDocxReviewer.fromBuffer(result.value.buffer);
+    acceptedReviewer.acceptAll();
+    const accepted = await acceptedReviewer.toBuffer();
+    const rejectedReviewer = await FolioDocxReviewer.fromBuffer(result.value.buffer);
+    rejectedReviewer.rejectAll();
+    const rejected = await rejectedReviewer.toBuffer();
+
+    const acceptedReopened = await FolioDocxReviewer.fromBuffer(accepted);
+    const rejectedReopened = await FolioDocxReviewer.fromBuffer(rejected);
+    expect(acceptedReopened.readReviewedStory({ view: "current-markup" })?.changes).toEqual([]);
+    expect(rejectedReopened.readReviewedStory({ view: "current-markup" })?.changes).toEqual([]);
+    expect(await projectView(accepted, "final")).toEqual(await projectView(target, "final"));
+    expect(await projectView(rejected, "final")).toEqual(await projectView(base, "final"));
+    expect(await documentPartOf(accepted)).toMatch(/<\/w:tbl><w:sectPr>/u);
+    expect(await documentPartOf(rejected)).toMatch(/<\/w:p><w:sectPr>/u);
   });
 
   /**


### PR DESCRIPTION
A terminal target table can validly sit directly before the body section properties. When it replaces a source table followed by an empty paragraph carrier, order the tracked ownership as deleted source table, deleted carrier paragraph mark, then inserted target table.

This preserves the exact target after acceptance and restores the exact base after rejection, including save and reopen.