### PR TITLE
fix(core): resolve tracked section endpoints

### DIFF
--- a/.changeset/steady-section-boundaries.md
+++ b/.changeset/steady-section-boundaries.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Resolve tracked section endpoints under paragraph-mark ownership.

--- a/packages/core/src/ai-edits/headless.ts
+++ b/packages/core/src/ai-edits/headless.ts
@@ -39,6 +39,10 @@ import { parseDocx } from "../docx/parser";
 import { repackDocx } from "../docx/rezip";
 import { pluginsForHeadlessRevisionResolution } from "../internal/headlessRevisionResolutionGuard";
 import {
+  type TrackedSectionEndpointRemoval,
+  withTrackedSectionEndpointRemoval,
+} from "../internal/sectionEndpointResolution";
+import {
   acceptAIEditRevision,
   rejectAIEditRevision,
   resolveAllChangesInHeadlessState,
@@ -52,6 +56,7 @@ import {
 import { ensureBaseDirectionInState } from "../prosemirror/extensions/features/AutoBidiDetectionExtension";
 import {
   getChangedParagraphIds,
+  getTrackedSectionEndpointRemoval,
   hasStructuralChanges,
   hasUntrackedChanges,
 } from "../prosemirror/extensions/features/ParagraphChangeTrackerExtension";
@@ -378,6 +383,26 @@ type FolioResolvedStoryExpectation = {
   story: FolioEditableDocumentStoryHandle;
   text: string;
   blocks: FolioAIBlock[];
+};
+
+type FolioReviewerStateSnapshot = {
+  mainState: EditorState;
+  secondaryStoryStates: readonly FolioSecondaryStoryState[];
+  createdComments: readonly Comment[];
+  resolvedOverrides: ReadonlyMap<number, boolean>;
+  resolvedStoryExpectations: readonly FolioResolvedStoryExpectation[];
+};
+
+type FolioSavePath =
+  | { type: "full-repack" }
+  | { type: "selective-first"; changedParaIds: Set<string> };
+
+type FolioSaveSnapshot = {
+  document: Document;
+  path: FolioSavePath;
+  changedNoteParaIds: ReadonlySet<string>;
+  sectionEndpointRemoval: TrackedSectionEndpointRemoval | null;
+  resolvedStoryExpectations: readonly FolioResolvedStoryExpectation[];
 };
 
 type ApplyDocumentOperationsInternalOptions = {
@@ -1299,15 +1324,62 @@ export class FolioDocxReviewer {
 
   /** The current document model with edits merged back in. */
   toDocument(): Document {
-    const document = updateDocumentContent(this.baseDocument, this.state.doc);
-    this.mergeEditedSecondaryStories(document);
-    if (this.createdComments.length > 0 || this.resolvedOverrides.size > 0) {
-      document.package.document.comments = this.withResolvedOverrides([
-        ...(document.package.document.comments ?? []),
-        ...this.createdComments,
-      ]);
+    return this.documentFromStateSnapshot(this.captureReviewerState());
+  }
+
+  private captureReviewerState(): FolioReviewerStateSnapshot {
+    const secondaryStoryStates: FolioSecondaryStoryState[] = [];
+    for (const { handle, initialState, state } of this.secondaryStoryStates.values()) {
+      secondaryStoryStates.push({ handle, initialState, state });
+    }
+    return {
+      mainState: this.state,
+      secondaryStoryStates,
+      createdComments: [...this.createdComments],
+      resolvedOverrides: new Map(this.resolvedOverrides),
+      resolvedStoryExpectations: [...this.resolvedStoryExpectations.values()],
+    };
+  }
+
+  private documentFromStateSnapshot(snapshot: FolioReviewerStateSnapshot): Document {
+    const document = updateDocumentContent(this.baseDocument, snapshot.mainState.doc);
+    this.mergeEditedSecondaryStories(document, snapshot.secondaryStoryStates);
+    if (snapshot.createdComments.length > 0 || snapshot.resolvedOverrides.size > 0) {
+      document.package.document.comments = this.withResolvedOverrides(
+        [...(document.package.document.comments ?? []), ...snapshot.createdComments],
+        snapshot.resolvedOverrides,
+      );
     }
     return document;
+  }
+
+  private captureSaveSnapshot(): FolioSaveSnapshot {
+    const snapshot = this.captureReviewerState();
+    const changedParaIds = new Set(getChangedParagraphIds(snapshot.mainState));
+    let structuralChange = hasStructuralChanges(snapshot.mainState);
+    let untrackedChanges = hasUntrackedChanges(snapshot.mainState);
+    const changedNoteParaIds = new Set<string>();
+    for (const entry of snapshot.secondaryStoryStates) {
+      if (entry.handle.type !== "footnote" && entry.handle.type !== "endnote") {
+        continue;
+      }
+      for (const paraId of getChangedParagraphIds(entry.state)) {
+        changedParaIds.add(paraId);
+        changedNoteParaIds.add(paraId);
+      }
+      structuralChange ||= hasStructuralChanges(entry.state);
+      untrackedChanges ||= hasUntrackedChanges(entry.state);
+    }
+    return {
+      document: this.documentFromStateSnapshot(snapshot),
+      path:
+        structuralChange || untrackedChanges
+          ? { type: "full-repack" }
+          : { type: "selective-first", changedParaIds },
+      changedNoteParaIds,
+      sectionEndpointRemoval: getTrackedSectionEndpointRemoval(snapshot.mainState),
+      resolvedStoryExpectations: snapshot.resolvedStoryExpectations,
+    };
   }
 
   /**
@@ -1317,26 +1389,36 @@ export class FolioDocxReviewer {
    * structural edits — the same two-tier path the editor's save uses.
    */
   async toBuffer(): Promise<ArrayBuffer> {
-    const document = this.toDocument();
-    const selective = await this.trySelectiveSave(document);
+    const save = this.captureSaveSnapshot();
+    const selective =
+      save.path.type === "selective-first"
+        ? await this.trySelectiveSave(save.document, save.path.changedParaIds)
+        : null;
     if (selective) {
-      await this.assertResolvedStoriesSerialized(selective);
+      await this.assertResolvedStoriesSerialized(selective, save.resolvedStoryExpectations);
       return selective;
     }
-    const buffer = await repackDocx(
-      { ...document, originalBuffer: this.originalBuffer },
-      { changedNoteParaIds: this.getChangedNoteParaIds() },
-    );
-    await this.assertResolvedStoriesSerialized(buffer);
+    const repackDocument = { ...save.document, originalBuffer: this.originalBuffer };
+    const buffer = save.sectionEndpointRemoval
+      ? await withTrackedSectionEndpointRemoval({
+          document: repackDocument,
+          resolution: save.sectionEndpointRemoval,
+          repack: () => repackDocx(repackDocument, { changedNoteParaIds: save.changedNoteParaIds }),
+        })
+      : await repackDocx(repackDocument, { changedNoteParaIds: save.changedNoteParaIds });
+    await this.assertResolvedStoriesSerialized(buffer, save.resolvedStoryExpectations);
     return buffer;
   }
 
-  private async assertResolvedStoriesSerialized(buffer: ArrayBuffer): Promise<void> {
-    if (this.resolvedStoryExpectations.size === 0) {
+  private async assertResolvedStoriesSerialized(
+    buffer: ArrayBuffer,
+    expectations: readonly FolioResolvedStoryExpectation[],
+  ): Promise<void> {
+    if (expectations.length === 0) {
       return;
     }
     const reopened = await FolioDocxReviewer.fromBuffer(buffer);
-    for (const { story, text, blocks } of this.resolvedStoryExpectations.values()) {
+    for (const { story, text, blocks } of expectations) {
       const serialized = reopened.readReviewedStory({ story, view: "current-markup" });
       const serializedState = reopened.getEditableStoryState(story);
       const serializedText = serializedState
@@ -1373,44 +1455,21 @@ export class FolioDocxReviewer {
     }
   }
 
-  private getChangedNoteParaIds(): Set<string> {
-    const changed = new Set<string>();
-    for (const entry of this.secondaryStoryStates.values()) {
-      if (entry.handle.type !== "footnote" && entry.handle.type !== "endnote") {
-        continue;
-      }
-      for (const paraId of getChangedParagraphIds(entry.state)) {
-        changed.add(paraId);
-      }
-    }
-    return changed;
-  }
-
   /**
    * Attempt the selective patch, treating a throw the same as a decline. Odd
    * source XML can make the paragraph diff throw rather than return `null`; a
    * full repack is the correct lossless fallback in both cases, so the fallback
    * is the graceful handling — no separate error surface is needed here.
    */
-  private async trySelectiveSave(document: Document): Promise<ArrayBuffer | null> {
-    const changedParaIds = new Set(getChangedParagraphIds(this.state));
-    let structuralChange = hasStructuralChanges(this.state);
-    let untrackedChanges = hasUntrackedChanges(this.state);
-    for (const entry of this.secondaryStoryStates.values()) {
-      if (entry.handle.type !== "footnote" && entry.handle.type !== "endnote") {
-        continue;
-      }
-      for (const paraId of getChangedParagraphIds(entry.state)) {
-        changedParaIds.add(paraId);
-      }
-      structuralChange ||= hasStructuralChanges(entry.state);
-      untrackedChanges ||= hasUntrackedChanges(entry.state);
-    }
+  private async trySelectiveSave(
+    document: Document,
+    changedParaIds: Set<string>,
+  ): Promise<ArrayBuffer | null> {
     try {
       return await attemptSelectiveSave(document, this.originalBuffer, {
         changedParaIds,
-        structuralChange,
-        hasUntrackedChanges: untrackedChanges,
+        structuralChange: false,
+        hasUntrackedChanges: false,
       });
     } catch {
       return null;
@@ -1517,12 +1576,15 @@ export class FolioDocxReviewer {
     return normalizeFolioAIBlockText(state?.doc.textContent ?? sourceText);
   }
 
-  private mergeEditedSecondaryStories(document: Document): void {
+  private mergeEditedSecondaryStories(
+    document: Document,
+    secondaryStoryStates: Iterable<FolioSecondaryStoryState> = this.secondaryStoryStates.values(),
+  ): void {
     let headers: Map<string, HeaderFooter> | undefined;
     let footers: Map<string, HeaderFooter> | undefined;
     let footnotes: Footnote[] | undefined;
     let endnotes: Endnote[] | undefined;
-    for (const entry of this.secondaryStoryStates.values()) {
+    for (const entry of secondaryStoryStates) {
       if (entry.state === entry.initialState) {
         continue;
       }
@@ -1595,12 +1657,15 @@ export class FolioDocxReviewer {
   }
 
   /** Apply any {@link resolveComment} overrides recorded for these comments. */
-  private withResolvedOverrides(comments: readonly Comment[]): Comment[] {
-    if (this.resolvedOverrides.size === 0) {
+  private withResolvedOverrides(
+    comments: readonly Comment[],
+    resolvedOverrides: ReadonlyMap<number, boolean> = this.resolvedOverrides,
+  ): Comment[] {
+    if (resolvedOverrides.size === 0) {
       return [...comments];
     }
     return comments.map((comment) => {
-      const override = this.resolvedOverrides.get(comment.id);
+      const override = resolvedOverrides.get(comment.id);
       return override === undefined ? comment : { ...comment, done: override };
     });
   }

--- a/packages/core/src/compare/sectionBoundary.test.ts
+++ b/packages/core/src/compare/sectionBoundary.test.ts
@@ -1,0 +1,320 @@
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import { FolioDocxReviewer } from "../ai-edits/headless";
+import { createDocx } from "../docx/rezip";
+import type { Document, Paragraph, SectionProperties, Table } from "../types/document";
+import { createEmptyDocument } from "../utils/createDocument";
+import { compareDocx } from "./compare";
+
+const OPTIONS = {
+  author: "Section reviewer",
+  timestamp: "2026-09-09T12:00:00.000Z",
+} as const;
+
+const SECTION_A = {
+  sectionStart: "nextPage",
+  pageWidth: 10_000,
+  pageHeight: 14_000,
+  marginLeft: 720,
+} as const satisfies SectionProperties;
+
+const SECTION_B = {
+  sectionStart: "oddPage",
+  pageWidth: 11_000,
+  pageHeight: 15_000,
+  columnCount: 2,
+  columnSpace: 500,
+} as const satisfies SectionProperties;
+
+const FOLLOWING_SECTION = {
+  sectionStart: "continuous",
+  pageWidth: 12_000,
+  pageHeight: 16_000,
+  marginRight: 900,
+  titlePg: true,
+} as const satisfies SectionProperties;
+
+const paragraph = (
+  paraId: string,
+  text: string,
+  sectionProperties?: SectionProperties,
+): Paragraph => ({
+  type: "paragraph",
+  paraId,
+  textId: paraId,
+  content: [{ type: "run", content: [{ type: "text", text }] }],
+  ...(sectionProperties === undefined ? {} : { sectionProperties }),
+});
+
+const table = (text: string): Table => ({
+  type: "table",
+  rows: [
+    {
+      type: "tableRow",
+      cells: [
+        {
+          type: "tableCell",
+          content: [paragraph("10000001", text)],
+        },
+      ],
+    },
+  ],
+});
+
+const documentWith = (content: Document["package"]["document"]["content"]): Document => {
+  const document = createEmptyDocument();
+  return {
+    ...document,
+    package: {
+      ...document.package,
+      document: { ...document.package.document, content },
+    },
+  };
+};
+
+const paragraphSectionProjection = (reviewer: FolioDocxReviewer) =>
+  reviewer
+    .toDocument()
+    .package.document.content.filter((block): block is Paragraph => block.type === "paragraph")
+    .map(({ paraId, sectionProperties }) => ({
+      paraId,
+      sectionProperties:
+        sectionProperties === undefined
+          ? null
+          : Object.fromEntries(Object.entries(sectionProperties)),
+    }));
+
+const storyProjection = (reviewer: FolioDocxReviewer) => ({
+  blocks: reviewer.snapshot().blocks.map(({ id, kind, text }) => ({ id, kind, text })),
+  sections: paragraphSectionProjection(reviewer),
+  topLevelKinds: reviewer.toDocument().package.document.content.map(({ type }) => type),
+});
+
+const reopenResolved = async (
+  buffer: ArrayBuffer,
+  mode: "accept" | "reject",
+): Promise<FolioDocxReviewer> => {
+  const reviewer = await FolioDocxReviewer.fromBuffer(buffer);
+  if (mode === "accept") {
+    reviewer.acceptAll();
+  } else {
+    reviewer.rejectAll();
+  }
+  const first = await reviewer.toBuffer();
+  const second = await reviewer.toBuffer();
+  const [concurrentFirst, concurrentSecond] = await Promise.all([
+    reviewer.toBuffer(),
+    reviewer.toBuffer(),
+  ]);
+  const documentXml = async (saved: ArrayBuffer) =>
+    (await JSZip.loadAsync(saved)).file("word/document.xml")?.async("text");
+  const expectedXml = await documentXml(first);
+  expect(await documentXml(second)).toBe(expectedXml);
+  expect(await documentXml(concurrentFirst)).toBe(expectedXml);
+  expect(await documentXml(concurrentSecond)).toBe(expectedXml);
+  const [reopenedFirst, reopenedSecond, reopenedConcurrentFirst, reopenedConcurrentSecond] =
+    await Promise.all([
+      FolioDocxReviewer.fromBuffer(first),
+      FolioDocxReviewer.fromBuffer(second),
+      FolioDocxReviewer.fromBuffer(concurrentFirst),
+      FolioDocxReviewer.fromBuffer(concurrentSecond),
+    ]);
+  const expectedProjection = storyProjection(reopenedFirst);
+  expect(storyProjection(reopenedSecond)).toEqual(expectedProjection);
+  expect(storyProjection(reopenedConcurrentFirst)).toEqual(expectedProjection);
+  expect(storyProjection(reopenedConcurrentSecond)).toEqual(expectedProjection);
+  return reopenedFirst;
+};
+
+const expectResolvedTerminals = async (baseDocument: Document, targetDocument: Document) => {
+  const [base, target] = await Promise.all([createDocx(baseDocument), createDocx(targetDocument)]);
+  const [baseReviewer, targetReviewer] = await Promise.all([
+    FolioDocxReviewer.fromBuffer(base),
+    FolioDocxReviewer.fromBuffer(target),
+  ]);
+  const result = await compareDocx(base, target, OPTIONS);
+  if (result.isErr()) {
+    throw result.error;
+  }
+  expect(result.value.verification).toEqual({ status: "verified" });
+  const pendingXml = await (
+    await JSZip.loadAsync(result.value.buffer)
+  )
+    .file("word/document.xml")
+    ?.async("text");
+  expect(pendingXml).toMatch(/<w:rPr><w:del\b[^>]*\/><\/w:rPr><w:sectPr>/u);
+
+  const [accepted, rejected] = await Promise.all([
+    reopenResolved(result.value.buffer, "accept"),
+    reopenResolved(result.value.buffer, "reject"),
+  ]);
+  expect(storyProjection(accepted)).toEqual(storyProjection(targetReviewer));
+  expect(storyProjection(rejected)).toEqual(storyProjection(baseReviewer));
+  return { baseReviewer, targetReviewer };
+};
+
+const expectPendingTerminals = async ({
+  pendingDocument,
+  acceptedDocument,
+  rejectedDocument,
+}: {
+  pendingDocument: Document;
+  acceptedDocument: Document;
+  rejectedDocument: Document;
+}) => {
+  const [pending, accepted, rejected] = await Promise.all([
+    createDocx(pendingDocument),
+    createDocx(acceptedDocument),
+    createDocx(rejectedDocument),
+  ]);
+  const [pendingZip, acceptedReviewer, rejectedReviewer] = await Promise.all([
+    JSZip.loadAsync(pending),
+    FolioDocxReviewer.fromBuffer(accepted),
+    FolioDocxReviewer.fromBuffer(rejected),
+  ]);
+  const pendingXml = await pendingZip.file("word/document.xml")?.async("text");
+  expect(pendingXml).toMatch(/<w:pPr><w:rPr><w:ins\b[^>]*\/><\/w:rPr><w:sectPr>/u);
+
+  const [resolvedAccepted, resolvedRejected] = await Promise.all([
+    reopenResolved(pending, "accept"),
+    reopenResolved(pending, "reject"),
+  ]);
+  expect(storyProjection(resolvedAccepted)).toEqual(storyProjection(acceptedReviewer));
+  expect(storyProjection(resolvedRejected)).toEqual(storyProjection(rejectedReviewer));
+};
+
+describe("tracked section-boundary ownership", () => {
+  test("accept removes a source endpoint before an ordinary paragraph", async () => {
+    await expectResolvedTerminals(
+      documentWith([paragraph("00000001", "Alpha", SECTION_A), paragraph("00000002", "Beta")]),
+      documentWith([paragraph("00000001", "AlphaBeta")]),
+    );
+  });
+
+  test("reject removes an inserted endpoint and restores the source paragraph", async () => {
+    const insertedMark = {
+      kind: "ins" as const,
+      info: { id: 1, author: "Section reviewer", date: OPTIONS.timestamp },
+    };
+    await expectPendingTerminals({
+      pendingDocument: documentWith([
+        { ...paragraph("00000001", "Alpha", SECTION_A), pPrMark: insertedMark },
+        paragraph("00000002", "Beta", FOLLOWING_SECTION),
+      ]),
+      acceptedDocument: documentWith([
+        paragraph("00000001", "Alpha", SECTION_A),
+        paragraph("00000002", "Beta", FOLLOWING_SECTION),
+      ]),
+      rejectedDocument: documentWith([paragraph("00000001", "AlphaBeta", FOLLOWING_SECTION)]),
+    });
+  });
+
+  test("accept removes consecutive source section endpoints and reject restores them", async () => {
+    const baseDocument = documentWith([
+      paragraph("00000001", "Keep"),
+      paragraph("00000002", "Delete section A", SECTION_A),
+      paragraph("00000003", "Delete section B", SECTION_B),
+      paragraph("00000004", "Tail", FOLLOWING_SECTION),
+    ]);
+    const targetDocument = documentWith([
+      paragraph("00000001", "Keep"),
+      paragraph("00000004", "Tail", FOLLOWING_SECTION),
+    ]);
+    const expectedBase = [
+      { paraId: "00000001", sectionProperties: null },
+      { paraId: "00000002", sectionProperties: SECTION_A },
+      { paraId: "00000003", sectionProperties: SECTION_B },
+      { paraId: "00000004", sectionProperties: FOLLOWING_SECTION },
+    ];
+    const expectedTarget = [
+      { paraId: "00000001", sectionProperties: null },
+      { paraId: "00000004", sectionProperties: FOLLOWING_SECTION },
+    ];
+
+    const { baseReviewer, targetReviewer } = await expectResolvedTerminals(
+      baseDocument,
+      targetDocument,
+    );
+    expect(paragraphSectionProjection(baseReviewer)).toEqual(expectedBase);
+    expect(paragraphSectionProjection(targetReviewer)).toEqual(expectedTarget);
+  });
+
+  test("accept-all removes one section endpoint alongside ordinary deleted paragraphs", async () => {
+    await expectResolvedTerminals(
+      documentWith([
+        paragraph("00000001", "Keep"),
+        paragraph("00000002", "Remove section", SECTION_A),
+        paragraph("00000003", "Remove ordinary"),
+        paragraph("00000004", "Tail", FOLLOWING_SECTION),
+      ]),
+      documentWith([
+        paragraph("00000001", "Keep"),
+        paragraph("00000004", "Tail", FOLLOWING_SECTION),
+      ]),
+    );
+  });
+
+  test("an overlapping resolution cannot change the state captured by an in-flight save", async () => {
+    const pending = await createDocx(
+      documentWith([
+        {
+          ...paragraph("00000001", "Alpha", SECTION_A),
+          pPrMark: {
+            kind: "del",
+            info: { id: 1, author: OPTIONS.author, date: OPTIONS.timestamp },
+          },
+        },
+        {
+          ...paragraph("00000002", "Beta", SECTION_B),
+          pPrMark: {
+            kind: "del",
+            info: { id: 2, author: OPTIONS.author, date: OPTIONS.timestamp },
+          },
+        },
+        paragraph("00000003", "Tail", FOLLOWING_SECTION),
+      ]),
+    );
+    const reviewer = await FolioDocxReviewer.fromBuffer(pending);
+
+    expect(reviewer.acceptChange(1)).toBe(true);
+    const firstSave = reviewer.toBuffer();
+    expect(reviewer.acceptChange(2)).toBe(true);
+    const secondSave = reviewer.toBuffer();
+
+    const [first, second] = await Promise.all([firstSave, secondSave]);
+    const [reopenedFirst, reopenedSecond] = await Promise.all([
+      FolioDocxReviewer.fromBuffer(first),
+      FolioDocxReviewer.fromBuffer(second),
+    ]);
+    expect(storyProjection(reopenedFirst)).toEqual({
+      blocks: [
+        { id: "00000001", kind: "paragraph", text: "AlphaBeta" },
+        { id: "00000003", kind: "paragraph", text: "Tail" },
+      ],
+      sections: [
+        { paraId: "00000001", sectionProperties: SECTION_B },
+        { paraId: "00000003", sectionProperties: FOLLOWING_SECTION },
+      ],
+      topLevelKinds: ["paragraph", "paragraph"],
+    });
+    expect(reopenedFirst.getChanges()).toHaveLength(1);
+    expect(storyProjection(reopenedSecond)).toEqual({
+      blocks: [{ id: "00000001", kind: "paragraph", text: "AlphaBetaTail" }],
+      sections: [{ paraId: "00000001", sectionProperties: FOLLOWING_SECTION }],
+      topLevelKinds: ["paragraph"],
+    });
+    expect(reopenedSecond.getChanges()).toHaveLength(0);
+  });
+
+  test("accept removes an emptied endpoint before a table and reject restores it", async () => {
+    await expectResolvedTerminals(
+      documentWith([
+        paragraph("00000001", "Remove", SECTION_B),
+        table("Cell"),
+        paragraph("00000002", "Tail", FOLLOWING_SECTION),
+      ]),
+      documentWith([table("Cell"), paragraph("00000002", "Tail", FOLLOWING_SECTION)]),
+    );
+  });
+});

--- a/packages/core/src/docx/rezip.test.ts
+++ b/packages/core/src/docx/rezip.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import JSZip from "jszip";
 
+import {
+  type TrackedSectionEndpointRemoval,
+  withTrackedSectionEndpointRemoval,
+} from "../internal/sectionEndpointResolution";
 import type { Document, Image } from "../types/document";
 import { parseDocx } from "./parser";
 import { RELATIONSHIP_TYPES } from "./relsParser";
@@ -14,6 +18,19 @@ const ONE_PIXEL_PNG_DATA_URL =
 
 const URI_ENCODED_SVG =
   '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"/></svg>';
+
+const repackAfterTrackedSectionEndpointRemoval = ({
+  document,
+  resolution,
+}: {
+  document: Document;
+  resolution: TrackedSectionEndpointRemoval;
+}): Promise<ArrayBuffer> =>
+  withTrackedSectionEndpointRemoval({
+    document,
+    resolution,
+    repack: () => repackDocx(document, { updateModifiedDate: false }),
+  });
 
 async function createHeaderFixture(): Promise<ArrayBuffer> {
   const zip = new JSZip();
@@ -705,6 +722,158 @@ describe("repackDocx", () => {
     }
 
     throw new Error("Expected repackDocx to reject");
+  });
+
+  test("permits only a reference owned by the exactly resolved section endpoint", async () => {
+    const originalBuffer = await createMultiSectionFirstHeaderImageFixture();
+    const doc = await parseDocx(originalBuffer, { preloadFonts: false });
+    const firstParagraph = doc.package.document.content.find(
+      (block) => block.type === "paragraph" && block.sectionProperties,
+    );
+    if (!firstParagraph || firstParagraph.type !== "paragraph") {
+      throw new Error("Expected a section-ending paragraph");
+    }
+    delete firstParagraph.sectionProperties;
+
+    const resolution = {
+      type: "tracked-section-endpoint-removal",
+      sourceParagraphEndpointCount: 1,
+      expectedParagraphEndpointCount: 0,
+      sourceEndpointFingerprint: "source-endpoints",
+      expectedEndpointFingerprint: "resolved-endpoints",
+      removedReferences: [{ part: "header", type: "first", relationshipId: "rId11" }],
+    } as const satisfies TrackedSectionEndpointRemoval;
+    const saved = await repackAfterTrackedSectionEndpointRemoval({
+      document: doc,
+      resolution,
+    });
+    const savedZip = await JSZip.loadAsync(saved);
+    const savedXml = await savedZip.file("word/document.xml")?.async("text");
+
+    expect(savedXml).not.toContain("rId11");
+    expect(savedZip.file("word/header1.xml")).not.toBeNull();
+  });
+
+  test("consumes an internal section-removal allowance in one repack call", async () => {
+    const originalBuffer = await createMultiSectionFirstHeaderImageFixture();
+    const doc = await parseDocx(originalBuffer, { preloadFonts: false });
+    const firstParagraph = doc.package.document.content.find(
+      (block) => block.type === "paragraph" && block.sectionProperties,
+    );
+    if (!firstParagraph || firstParagraph.type !== "paragraph") {
+      throw new Error("Expected a section-ending paragraph");
+    }
+    delete firstParagraph.sectionProperties;
+
+    await expect(
+      withTrackedSectionEndpointRemoval({
+        document: doc,
+        resolution: {
+          type: "tracked-section-endpoint-removal",
+          sourceParagraphEndpointCount: 1,
+          expectedParagraphEndpointCount: 0,
+          sourceEndpointFingerprint: "source-endpoints",
+          expectedEndpointFingerprint: "resolved-endpoints",
+          removedReferences: [{ part: "header", type: "first", relationshipId: "rId11" }],
+        },
+        repack: async () => {
+          await repackDocx(doc, { updateModifiedDate: false });
+          return repackDocx(doc, { updateModifiedDate: false });
+        },
+      }),
+    ).rejects.toBeInstanceOf(DocxPackageFidelityError);
+
+    // The failed scope must not leave an allowance behind for an ordinary
+    // public repack of the same document object.
+    await expect(repackDocx(doc, { updateModifiedDate: false })).rejects.toBeInstanceOf(
+      DocxPackageFidelityError,
+    );
+
+    // Stable tracker evidence may authorize a later save, but that save gets a
+    // fresh one-call scope rather than reusing state from the failed call.
+    await expect(
+      repackAfterTrackedSectionEndpointRemoval({
+        document: doc,
+        resolution: {
+          type: "tracked-section-endpoint-removal",
+          sourceParagraphEndpointCount: 1,
+          expectedParagraphEndpointCount: 0,
+          sourceEndpointFingerprint: "source-endpoints",
+          expectedEndpointFingerprint: "resolved-endpoints",
+          removedReferences: [{ part: "header", type: "first", relationshipId: "rId11" }],
+        },
+      }),
+    ).resolves.toBeInstanceOf(ArrayBuffer);
+  });
+
+  test("fails closed when serialized section loss exceeds a tracked-resolution allowance", async () => {
+    const originalBuffer = await createMultiSectionFirstHeaderImageFixture();
+    const doc = await parseDocx(originalBuffer, { preloadFonts: false });
+    const firstParagraph = doc.package.document.content.find(
+      (block) => block.type === "paragraph" && block.sectionProperties,
+    );
+    if (!firstParagraph || firstParagraph.type !== "paragraph") {
+      throw new Error("Expected a section-ending paragraph");
+    }
+    delete firstParagraph.sectionProperties;
+    delete doc.package.document.finalSectionProperties;
+
+    await expect(
+      repackAfterTrackedSectionEndpointRemoval({
+        document: doc,
+        resolution: {
+          type: "tracked-section-endpoint-removal",
+          sourceParagraphEndpointCount: 1,
+          expectedParagraphEndpointCount: 0,
+          sourceEndpointFingerprint: "source-endpoints",
+          expectedEndpointFingerprint: "resolved-endpoints",
+          removedReferences: [{ part: "header", type: "first", relationshipId: "rId11" }],
+        },
+      }),
+    ).rejects.toBeInstanceOf(DocxPackageFidelityError);
+  });
+
+  test("does not let one removed endpoint excuse a shared reference on a surviving endpoint", async () => {
+    const originalBuffer = await createMultiSectionFirstHeaderImageFixture();
+    const originalZip = await JSZip.loadAsync(originalBuffer);
+    const originalXml = await originalZip.file("word/document.xml")?.async("text");
+    if (!originalXml) {
+      throw new Error("Expected document XML");
+    }
+    originalZip.file(
+      "word/document.xml",
+      originalXml.replace(
+        '<w:headerReference w:type="default" r:id="rId12"/>',
+        '<w:headerReference w:type="first" r:id="rId11"/>',
+      ),
+    );
+    const sharedReferenceBuffer = await originalZip.generateAsync({ type: "arraybuffer" });
+    const doc = await parseDocx(sharedReferenceBuffer, { preloadFonts: false });
+    const firstParagraph = doc.package.document.content.find(
+      (block) => block.type === "paragraph" && block.sectionProperties,
+    );
+    if (!firstParagraph || firstParagraph.type !== "paragraph") {
+      throw new Error("Expected a section-ending paragraph");
+    }
+    delete firstParagraph.sectionProperties;
+    if (!doc.package.document.finalSectionProperties) {
+      throw new Error("Expected final section properties");
+    }
+    delete doc.package.document.finalSectionProperties.headerReferences;
+
+    await expect(
+      repackAfterTrackedSectionEndpointRemoval({
+        document: doc,
+        resolution: {
+          type: "tracked-section-endpoint-removal",
+          sourceParagraphEndpointCount: 1,
+          expectedParagraphEndpointCount: 0,
+          sourceEndpointFingerprint: "source-endpoints",
+          expectedEndpointFingerprint: "resolved-endpoints",
+          removedReferences: [{ part: "header", type: "first", relationshipId: "rId11" }],
+        },
+      }),
+    ).rejects.toBeInstanceOf(DocxPackageFidelityError);
   });
 
   test("selective save preserves first-section header image references", async () => {

--- a/packages/core/src/docx/rezip.ts
+++ b/packages/core/src/docx/rezip.ts
@@ -33,6 +33,10 @@ import { validateDocxPackage } from "@stll/docx-core";
 import { panic } from "better-result";
 import JSZip from "jszip";
 
+import {
+  consumeTrackedSectionEndpointRemoval,
+  type TrackedSectionEndpointRemoval,
+} from "../internal/sectionEndpointResolution";
 import type {
   BlockContent,
   Comment,
@@ -183,29 +187,68 @@ const hasParsedHeaderFooterPart = (doc: Document, ref: HeaderFooterReference): b
   return map?.has(ref.rId) ?? false;
 };
 
+const headerFooterReferenceKey = ({ element, type, rId }: HeaderFooterReference): string =>
+  `${element}:${type}:${rId}`;
+
+const incrementReferenceCount = (counts: Map<string, number>, key: string): void => {
+  counts.set(key, (counts.get(key) ?? 0) + 1);
+};
+
+const consumeReferenceCount = (counts: Map<string, number>, key: string): boolean => {
+  const count = counts.get(key) ?? 0;
+  if (count === 0) {
+    return false;
+  }
+  counts.set(key, count - 1);
+  return true;
+};
+
 function assertDocumentPackageFidelity(
   originalDocumentXml: string,
   serializedDocumentXml: string,
   doc: Document,
+  sectionEndpointRemoval?: TrackedSectionEndpointRemoval,
 ): void {
   const originalSectionCount = countDocumentSections(originalDocumentXml);
   const serializedSectionCount = countDocumentSections(serializedDocumentXml);
-  if (serializedSectionCount < originalSectionCount) {
+  const trackedRemovedSectionCount = sectionEndpointRemoval
+    ? sectionEndpointRemoval.sourceParagraphEndpointCount -
+      sectionEndpointRemoval.expectedParagraphEndpointCount
+    : 0;
+  const exactTrackedSectionRemoval =
+    trackedRemovedSectionCount > 0 &&
+    originalSectionCount - trackedRemovedSectionCount === serializedSectionCount &&
+    serializedSectionCount < originalSectionCount;
+  if (serializedSectionCount < originalSectionCount && !exactTrackedSectionRemoval) {
     throw new DocxPackageFidelityError(
       "Full DOCX repack would drop section properties. Use selective patching instead.",
     );
   }
 
-  const serializedRefs = new Set(
-    extractHeaderFooterReferences(serializedDocumentXml).map(
-      (ref) => `${ref.element}:${ref.type}:${ref.rId}`,
-    ),
-  );
-  const missingRefs = extractHeaderFooterReferences(originalDocumentXml).filter(
-    (ref) =>
-      hasParsedHeaderFooterPart(doc, ref) &&
-      !serializedRefs.has(`${ref.element}:${ref.type}:${ref.rId}`),
-  );
+  const serializedReferenceCounts = new Map<string, number>();
+  for (const reference of extractHeaderFooterReferences(serializedDocumentXml)) {
+    incrementReferenceCount(serializedReferenceCounts, headerFooterReferenceKey(reference));
+  }
+  const removedReferenceCounts = new Map<string, number>();
+  if (exactTrackedSectionRemoval && sectionEndpointRemoval) {
+    for (const { part, type, relationshipId } of sectionEndpointRemoval.removedReferences) {
+      incrementReferenceCount(removedReferenceCounts, `${part}Reference:${type}:${relationshipId}`);
+    }
+  }
+  const missingRefs: HeaderFooterReference[] = [];
+  for (const reference of extractHeaderFooterReferences(originalDocumentXml)) {
+    if (!hasParsedHeaderFooterPart(doc, reference)) {
+      continue;
+    }
+    const key = headerFooterReferenceKey(reference);
+    if (
+      consumeReferenceCount(serializedReferenceCounts, key) ||
+      consumeReferenceCount(removedReferenceCounts, key)
+    ) {
+      continue;
+    }
+    missingRefs.push(reference);
+  }
   if (missingRefs.length > 0) {
     throw new DocxPackageFidelityError(
       "Full DOCX repack would drop header/footer references. Use selective patching instead.",
@@ -897,6 +940,7 @@ type FinishRepackOptions = {
   updateModifiedDate: boolean;
   modifiedBy?: string;
   changedNoteParaIds?: ReadonlySet<string>;
+  sectionEndpointRemoval?: TrackedSectionEndpointRemoval;
 };
 
 const finishRepack = async ({
@@ -909,6 +953,7 @@ const finishRepack = async ({
   updateModifiedDate,
   modifiedBy,
   changedNoteParaIds,
+  sectionEndpointRemoval,
 }: FinishRepackOptions): Promise<ArrayBuffer> => {
   await materializeNewHeaderFooterParts(document, outputZip, compressionLevel);
 
@@ -925,7 +970,12 @@ const finishRepack = async ({
     originalDocumentXml === undefined ? undefined : readRootNamespaceBindings(originalDocumentXml),
   );
   if (originalDocumentXml) {
-    assertDocumentPackageFidelity(originalDocumentXml, documentXml, document);
+    assertDocumentPackageFidelity(
+      originalDocumentXml,
+      documentXml,
+      document,
+      sectionEndpointRemoval,
+    );
   }
   outputZip.file("word/document.xml", documentXml, {
     compression: "DEFLATE",
@@ -974,7 +1024,17 @@ const finishRepack = async ({
  * @returns Promise resolving to DOCX as ArrayBuffer
  * @throws {Error} if document has no original buffer for round-trip
  */
-export async function repackDocx(doc: Document, options: RepackOptions = {}): Promise<ArrayBuffer> {
+type RepackDocxInternalOptions = {
+  document: Document;
+  options: RepackOptions;
+  sectionEndpointRemoval?: TrackedSectionEndpointRemoval;
+};
+
+async function repackDocxWithSectionEndpointRemoval({
+  document: doc,
+  options,
+  sectionEndpointRemoval,
+}: RepackDocxInternalOptions): Promise<ArrayBuffer> {
   // Validate we have an original buffer to base on
   if (!doc.originalBuffer) {
     panic(
@@ -1011,6 +1071,16 @@ export async function repackDocx(doc: Document, options: RepackOptions = {}): Pr
     updateModifiedDate,
     ...(modifiedBy !== undefined ? { modifiedBy } : {}),
     ...(changedNoteParaIds !== undefined ? { changedNoteParaIds } : {}),
+    ...(sectionEndpointRemoval !== undefined ? { sectionEndpointRemoval } : {}),
+  });
+}
+
+export function repackDocx(doc: Document, options: RepackOptions = {}): Promise<ArrayBuffer> {
+  const sectionEndpointRemoval = consumeTrackedSectionEndpointRemoval(doc);
+  return repackDocxWithSectionEndpointRemoval({
+    document: doc,
+    options,
+    ...(sectionEndpointRemoval ? { sectionEndpointRemoval } : {}),
   });
 }
 

--- a/packages/core/src/internal/sectionEndpointResolution.ts
+++ b/packages/core/src/internal/sectionEndpointResolution.ts
@@ -1,0 +1,81 @@
+import { panic } from "better-result";
+
+import type { Document, HeaderFooterType } from "../types/document";
+
+export type RemovedSectionReference = {
+  part: "header" | "footer";
+  type: HeaderFooterType;
+  relationshipId: string;
+};
+
+/**
+ * Exact resolution evidence produced when tracked-change resolution removes
+ * section endpoints. The tracker binds this count transition to exact endpoint
+ * fingerprints; removed references bind the only relationship losses that the
+ * same resolution may legitimately cause during package serialization.
+ */
+export type TrackedSectionEndpointRemoval = {
+  type: "tracked-section-endpoint-removal";
+  sourceParagraphEndpointCount: number;
+  expectedParagraphEndpointCount: number;
+  sourceEndpointFingerprint: string;
+  expectedEndpointFingerprint: string;
+  removedReferences: readonly RemovedSectionReference[];
+};
+
+type ActiveSectionEndpointRepack =
+  | { status: "available"; authorization: TrackedSectionEndpointRemoval }
+  | { status: "consumed"; authorization: TrackedSectionEndpointRemoval };
+const activeSectionEndpointRepacks = new WeakMap<Document, ActiveSectionEndpointRepack>();
+
+const snapshotAuthorization = (
+  authorization: TrackedSectionEndpointRemoval,
+): TrackedSectionEndpointRemoval => {
+  const removedReferences = Object.freeze(
+    authorization.removedReferences.map((reference) => Object.freeze({ ...reference })),
+  );
+  return Object.freeze({ ...authorization, removedReferences });
+};
+
+type WithTrackedSectionEndpointRemovalOptions<T> = {
+  document: Document;
+  resolution: TrackedSectionEndpointRemoval;
+  repack: () => Promise<T>;
+};
+
+/** Run one repack with an exact authorization that no public save API accepts. */
+export const withTrackedSectionEndpointRemoval = async <T>({
+  document,
+  resolution,
+  repack,
+}: WithTrackedSectionEndpointRemovalOptions<T>): Promise<T> => {
+  if (activeSectionEndpointRepacks.has(document)) {
+    panic("A tracked section-endpoint repack is already active for this document");
+  }
+  const snapshot = snapshotAuthorization(resolution);
+  activeSectionEndpointRepacks.set(document, { status: "available", authorization: snapshot });
+  try {
+    const result = await repack();
+    if (activeSectionEndpointRepacks.get(document)?.status !== "consumed") {
+      panic("Tracked section-endpoint repack did not consume its authorization");
+    }
+    return result;
+  } finally {
+    activeSectionEndpointRepacks.delete(document);
+  }
+};
+
+/** @internal Consume the active authorization once for the exact document object. */
+export const consumeTrackedSectionEndpointRemoval = (
+  document: Document,
+): TrackedSectionEndpointRemoval | null => {
+  const active = activeSectionEndpointRepacks.get(document);
+  if (!active || active.status === "consumed") {
+    return null;
+  }
+  activeSectionEndpointRepacks.set(document, {
+    status: "consumed",
+    authorization: active.authorization,
+  });
+  return active.authorization;
+};

--- a/packages/core/src/prosemirror/commands/comments.ts
+++ b/packages/core/src/prosemirror/commands/comments.ts
@@ -13,6 +13,7 @@ import {
   type HeadlessInlineChangeTracking,
 } from "../../internal/headlessRevisionResolution";
 import { stateAllowsHeadlessRevisionResolution } from "../../internal/headlessRevisionResolutionGuard";
+import type { RemovedSectionReference } from "../../internal/sectionEndpointResolution";
 import type {
   ParagraphFormatting,
   RunPropertyChange,
@@ -33,6 +34,7 @@ import { textFormattingToMarks } from "../conversion/toProseDoc";
 import {
   markChangedParagraphRanges,
   markStructuralChange,
+  markTrackedSectionEndpointRemoval,
 } from "../extensions/features/ParagraphChangeTrackerExtension";
 import { getDocumentStyleResolver } from "../plugins/documentStyles";
 import { holdsNoContent } from "../zeroWidthAnchors";
@@ -163,6 +165,8 @@ function resolveChange(
       const tableCellStructuralOps: TableCellStructuralOp[] = [];
       const deferredRunPropertyChanges: ResolveRunPropertyChangeOptions[] = [];
       let bulkInlineCarrierCount = 0;
+      let removedSectionEndpointCount = 0;
+      const removedSectionReferences: RemovedSectionReference[] = [];
 
       state.doc.nodesBetween(from, to, (node, pos): boolean => {
         if (node.type.name === "paragraph") {
@@ -426,9 +430,7 @@ function resolveChange(
         }
         const joinPos = mappedPos + paragraph.nodeSize;
         const nextNode = joinPos < tr.doc.content.size ? tr.doc.nodeAt(joinPos) : null;
-        const joinable =
-          nextNode?.type.name === paragraph.type.name &&
-          !(carriesSection(paragraph) && carriesSection(nextNode));
+        const joinable = nextNode?.type.name === paragraph.type.name;
         if (!joinable) {
           // Nothing to join with: the next sibling is a table, or the paragraph
           // ends its container — a body, a cell, a header, a note or a text box
@@ -452,32 +454,16 @@ function resolveChange(
           // A container must contain a paragraph either way, so its parent's
           // only child stays blank whatever its mark says.
           //
-          // A section's properties live on a paragraph mark, so the paragraph
-          // is where its section ENDS. It can still go, but the section cannot
-          // go with it: the content before it is still in that section, which
-          // now ends one paragraph earlier. There is no next paragraph here to
-          // hand the properties to, so they move back to the previous one —
-          // unless that paragraph ends a section of its own, in which case
-          // there is nowhere to put them and the paragraph stays.
+          // Section properties belong to the paragraph mark being resolved.
+          // Removing that mark removes its section endpoint; transferring the
+          // properties backward would retain the section the revision deleted.
           const resolved = tr.doc.resolve(mappedPos);
-          const previous = resolved.nodeBefore;
-          const sectionCanMoveBack =
-            !carriesSection(paragraph) ||
-            (previous?.type.name === paragraph.type.name && !carriesSection(previous));
           const endsItsContainer = paragraphEndsItsContainer(resolved, paragraph.type.name);
           const canGo = op.markWasAdded || !endsItsContainer;
-          if (
-            sectionCanMoveBack &&
-            holdsNoContent(paragraph) &&
-            canGo &&
-            resolved.parent.childCount > 1
-          ) {
-            if (carriesSection(paragraph) && previous) {
-              tr.setNodeMarkup(mappedPos - previous.nodeSize, undefined, {
-                ...previous.attrs,
-                sectionBreakType: paragraph.attrs["sectionBreakType"],
-                _sectionProperties: paragraph.attrs["_sectionProperties"],
-              });
+          if (holdsNoContent(paragraph) && canGo && resolved.parent.childCount > 1) {
+            if (ownsSectionEndpoint(paragraph)) {
+              removedSectionEndpointCount++;
+              removedSectionReferences.push(...sectionReferencesOf(paragraph));
             }
             tr.delete(mappedPos, mappedPos + paragraph.nodeSize);
             continue;
@@ -497,23 +483,23 @@ function resolveChange(
         // The next paragraph's own `pPrMark` travels with its attrs: it is a
         // different revision, and resolving this one must not resolve it.
         //
-        // A section's properties are the exception to "the next paragraph's
-        // properties win". They are not formatting the resolved paragraph
-        // owned; they are where a section ENDS, and the paragraph the join
-        // leaves behind is now that end. Dropping them merges two sections
-        // into one and takes the dropped one's page size, margins and
-        // header and footer references with it.
+        // Section properties live on the paragraph mark. Resolving that mark
+        // away removes its section endpoint, so the joined paragraph keeps
+        // only a section endpoint already owned by the following paragraph.
         const formattingOwner = emptyFirstParagraph ? nextNode : paragraph;
-        const sectionOwner = carriesSection(paragraph) ? paragraph : nextNode;
         const joinedAttrs = {
           ...formattingOwner.attrs,
           pPrMark: nextNode.attrs["pPrMark"],
-          sectionBreakType: sectionOwner.attrs["sectionBreakType"],
-          _sectionProperties: sectionOwner.attrs["_sectionProperties"],
+          sectionBreakType: nextNode.attrs["sectionBreakType"],
+          _sectionProperties: nextNode.attrs["_sectionProperties"],
         };
         try {
           tr.join(joinPos);
           tr.setNodeMarkup(mappedPos, undefined, joinedAttrs);
+          if (ownsSectionEndpoint(paragraph)) {
+            removedSectionEndpointCount++;
+            removedSectionReferences.push(...sectionReferencesOf(paragraph));
+          }
         } catch {
           // PM rejects the join if the two blocks aren't structurally
           // compatible (e.g. paragraph followed by a table). Leaving the
@@ -588,6 +574,14 @@ function resolveChange(
 
       if (bulkInlineChangeTracking) {
         markChangedParagraphRanges(tr, bulkInlineChangeTracking);
+      }
+
+      if (removedSectionEndpointCount > 0) {
+        markTrackedSectionEndpointRemoval(tr, {
+          sourceDoc: state.doc,
+          removedEndpointCount: removedSectionEndpointCount,
+          removedReferences: removedSectionReferences,
+        });
       }
 
       if (tr.steps.length > 0) {
@@ -1095,19 +1089,32 @@ function isPPrMarkAttr(value: unknown): value is {
 const paragraphMarkWasAdded = (kind: ParagraphMarkChangeKind): boolean =>
   kind === "ins" || kind === "moveTo";
 
+const ownsSectionEndpoint = (paragraph: PMNode): boolean => {
+  const attrs = expectParagraphAttrs(paragraph);
+  return attrs._sectionProperties !== undefined || attrs.sectionBreakType !== undefined;
+};
+
+const sectionReferencesOf = (paragraph: PMNode): RemovedSectionReference[] => {
+  const sectionProperties = expectParagraphAttrs(paragraph)._sectionProperties;
+  if (!sectionProperties) {
+    return [];
+  }
+  return [
+    ...(sectionProperties.headerReferences ?? []).map(({ type, rId }) => ({
+      part: "header" as const,
+      type,
+      relationshipId: rId,
+    })),
+    ...(sectionProperties.footerReferences ?? []).map(({ type, rId }) => ({
+      part: "footer" as const,
+      type,
+      relationshipId: rId,
+    })),
+  ];
+};
+
 const isAddedPPrMarkAttr = (value: unknown): value is AddedParagraphMark =>
   isPPrMarkAttr(value) && (value.kind === "ins" || value.kind === "moveTo");
-
-/**
- * Whether the paragraph's mark carries a section's properties.
- *
- * A section break lives on a paragraph mark, so the paragraph is where the
- * section ends. Removing it removes the section: a document that had two ends
- * up with one, and every setting the dropped section carried — page size,
- * margins, its header and footer references — goes with it.
- */
-const carriesSection = (paragraph: PMNode): boolean =>
-  paragraph.attrs["sectionBreakType"] != null || paragraph.attrs["_sectionProperties"] != null;
 
 function readRevisionInfo(info: RevisionInfoAttrs | undefined): {
   author?: string;

--- a/packages/core/src/prosemirror/commands/pPrMark-accept-reject.test.ts
+++ b/packages/core/src/prosemirror/commands/pPrMark-accept-reject.test.ts
@@ -3,7 +3,17 @@ import { Schema } from "prosemirror-model";
 import { EditorState } from "prosemirror-state";
 import type { Transaction } from "prosemirror-state";
 
-import { acceptAllChanges, acceptChange, rejectAllChanges, rejectChange } from "./comments";
+import {
+  getTrackedSectionEndpointRemoval,
+  ParagraphChangeTrackerExtension,
+} from "../extensions/features/ParagraphChangeTrackerExtension";
+import {
+  acceptAIEditRevision,
+  acceptAllChanges,
+  acceptChange,
+  rejectAllChanges,
+  rejectChange,
+} from "./comments";
 
 const schema = new Schema({
   nodes: {
@@ -50,6 +60,15 @@ const dispatcher = (state: EditorState) => {
   };
   return view;
 };
+
+const trackerRuntime = ParagraphChangeTrackerExtension().onSchemaReady({ schema });
+const trackerPlugin = trackerRuntime.plugins?.at(0);
+if (!trackerPlugin) {
+  throw new Error("Expected paragraph change tracker plugin");
+}
+
+const trackedState = (doc: EditorState["doc"]) =>
+  EditorState.create({ schema, doc, plugins: [trackerPlugin] });
 
 const insMark = (info: { id: number; author?: string }) => ({
   kind: "ins" as const,
@@ -271,14 +290,13 @@ describe("pPrMark accept / reject — paragraph-mark resolution", () => {
   }
 
   // A section break lives on a paragraph mark, so the paragraph is where the
-  // section ends. Resolving the mark away must not take the section with it:
-  // the dropped section's page size, margins and header and footer references
-  // would go too, and a document that had two would end up with one.
+  // section ends. Resolving that mark away removes the endpoint with it; the
+  // following paragraph's mark owns the section that survives the join.
   describe("a section on the resolved paragraph's mark", () => {
     const deletion = () => schema.marks["deletion"]!;
     const revision = { revisionId: 1, author: "Alice", date: "2026-05-01" };
 
-    test("travels to the paragraph the join leaves behind", () => {
+    test("is removed when an ordinary following paragraph survives", () => {
       const state = EditorState.create({
         schema,
         doc: schema.node("doc", null, [
@@ -296,10 +314,10 @@ describe("pPrMark accept / reject — paragraph-mark resolution", () => {
 
       expect(view.state.doc.childCount).toBe(1);
       expect(view.state.doc.child(0).textContent).toBe("next");
-      expect(view.state.doc.child(0).attrs["sectionBreakType"]).toBe("nextPage");
+      expect(view.state.doc.child(0).attrs["sectionBreakType"]).toBeNull();
     });
 
-    test("keeps both paragraphs when the next one ends a section of its own", () => {
+    test("removes only the source endpoint when the next paragraph owns one", () => {
       const state = EditorState.create({
         schema,
         doc: schema.node("doc", null, [
@@ -319,10 +337,10 @@ describe("pPrMark accept / reject — paragraph-mark resolution", () => {
 
       acceptAllChanges()(view.state, view.dispatch);
 
-      expect(view.state.doc.childCount).toBe(2);
-      expect(view.state.doc.child(0).attrs["sectionBreakType"]).toBe("nextPage");
+      expect(view.state.doc.childCount).toBe(1);
+      expect(view.state.doc.child(0).textContent).toBe("first sectionsecond section");
+      expect(view.state.doc.child(0).attrs["sectionBreakType"]).toBe("continuous");
       expect(view.state.doc.child(0).attrs["pPrMark"]).toBeNull();
-      expect(view.state.doc.child(1).attrs["sectionBreakType"]).toBe("continuous");
     });
 
     test("keeps the next paragraph's section when surviving content is joined", () => {
@@ -384,7 +402,7 @@ describe("pPrMark accept / reject — paragraph-mark resolution", () => {
       expect(view.state.doc.child(0).attrs["pPrMark"]).toEqual(insMark({ id: 3 }));
     });
 
-    test("moves back a paragraph when there is nothing to join it with", () => {
+    test("is removed with an emptied paragraph before a nonjoinable sibling", () => {
       const state = EditorState.create({
         schema,
         doc: schema.node("doc", null, [
@@ -402,14 +420,12 @@ describe("pPrMark accept / reject — paragraph-mark resolution", () => {
 
       acceptAllChanges()(view.state, view.dispatch);
 
-      // The section now ends one paragraph earlier; the content before it is
-      // still in that section.
       expect(view.state.doc.childCount).toBe(3);
       expect(view.state.doc.child(0).textContent).toBe("first");
-      expect(view.state.doc.child(0).attrs["sectionBreakType"]).toBe("nextPage");
+      expect(view.state.doc.child(0).attrs["sectionBreakType"]).toBeNull();
     });
 
-    test("keeps the paragraph when the one before it ends a section of its own", () => {
+    test("leaves a preceding section endpoint unchanged before a nonjoinable sibling", () => {
       const state = EditorState.create({
         schema,
         doc: schema.node("doc", null, [
@@ -427,10 +443,280 @@ describe("pPrMark accept / reject — paragraph-mark resolution", () => {
 
       acceptAllChanges()(view.state, view.dispatch);
 
-      expect(view.state.doc.childCount).toBe(4);
+      expect(view.state.doc.childCount).toBe(3);
       expect(view.state.doc.child(0).attrs["sectionBreakType"]).toBe("continuous");
-      expect(view.state.doc.child(1).attrs["sectionBreakType"]).toBe("nextPage");
-      expect(view.state.doc.child(1).attrs["pPrMark"]).toBeNull();
+      expect(view.state.doc.child(1).type.name).toBe("table");
+    });
+
+    test("reject keeps a deleted endpoint on its original paragraph", () => {
+      const state = EditorState.create({
+        schema,
+        doc: schema.node("doc", null, [
+          schema.node(
+            "paragraph",
+            {
+              pPrMark: delMark({ id: 2 }),
+              sectionBreakType: "nextPage",
+              _sectionProperties: { columns: 2 },
+            },
+            schema.text("source section"),
+          ),
+          schema.node("paragraph", null, schema.text("following section")),
+        ]),
+      });
+      const view = dispatcher(state);
+
+      rejectAllChanges()(view.state, view.dispatch);
+
+      expect(view.state.doc.childCount).toBe(2);
+      expect(view.state.doc.child(0).attrs["pPrMark"]).toBeNull();
+      expect(view.state.doc.child(0).attrs["sectionBreakType"]).toBe("nextPage");
+      expect(view.state.doc.child(0).attrs["_sectionProperties"]).toEqual({ columns: 2 });
+    });
+
+    test("reject removes an inserted endpoint and retains the following paragraph", () => {
+      const state = EditorState.create({
+        schema,
+        doc: schema.node("doc", null, [
+          schema.node(
+            "paragraph",
+            {
+              pPrMark: insMark({ id: 2 }),
+              sectionBreakType: "nextPage",
+              _sectionProperties: { columns: 2 },
+            },
+            schema.text("inserted section"),
+          ),
+          schema.node("paragraph", null, schema.text("following section")),
+        ]),
+      });
+      const view = dispatcher(state);
+
+      rejectAllChanges()(view.state, view.dispatch);
+
+      expect(view.state.doc.childCount).toBe(1);
+      expect(view.state.doc.child(0).textContent).toBe("inserted sectionfollowing section");
+      expect(view.state.doc.child(0).attrs["sectionBreakType"]).toBeNull();
+    });
+
+    test("authorizes only the exact endpoint-removal direction", () => {
+      const sectionParagraph = () =>
+        schema.node(
+          "paragraph",
+          {
+            pPrMark: delMark({ id: 2 }),
+            sectionBreakType: "nextPage",
+            _sectionProperties: {
+              columns: 2,
+              headerReferences: [{ type: "first", rId: "rId7" }],
+            },
+          },
+          schema.text("source section"),
+        );
+      const followingParagraph = () =>
+        schema.node("paragraph", null, schema.text("following section"));
+      const source = schema.node("doc", null, [sectionParagraph(), followingParagraph()]);
+      const accepting = dispatcher(trackedState(source));
+      const rejecting = dispatcher(trackedState(source));
+
+      acceptAllChanges()(accepting.state, accepting.dispatch);
+      rejectAllChanges()(rejecting.state, rejecting.dispatch);
+
+      const authorization = getTrackedSectionEndpointRemoval(accepting.state);
+      expect(authorization).toMatchObject({
+        type: "tracked-section-endpoint-removal",
+        sourceParagraphEndpointCount: 1,
+        expectedParagraphEndpointCount: 0,
+        removedReferences: [{ part: "header", type: "first", relationshipId: "rId7" }],
+      });
+      expect(authorization?.sourceEndpointFingerprint).not.toBe(
+        authorization?.expectedEndpointFingerprint,
+      );
+      expect(getTrackedSectionEndpointRemoval(rejecting.state)).toBeNull();
+
+      const nonSection = dispatcher(trackedState(twoParagraphs(delMark({ id: 2 })).doc));
+      acceptAllChanges()(nonSection.state, nonSection.dispatch);
+      expect(getTrackedSectionEndpointRemoval(nonSection.state)).toBeNull();
+    });
+
+    test("counts only section-owning marks in a mixed accept-all batch", () => {
+      const state = trackedState(
+        schema.node("doc", null, [
+          schema.node(
+            "paragraph",
+            {
+              pPrMark: delMark({ id: 2 }),
+              sectionBreakType: "nextPage",
+              _sectionProperties: { columns: 2 },
+            },
+            schema.text("section paragraph"),
+          ),
+          schema.node(
+            "paragraph",
+            { pPrMark: delMark({ id: 3 }) },
+            schema.text("ordinary paragraph"),
+          ),
+          schema.node("paragraph", null, schema.text("following paragraph")),
+        ]),
+      );
+      const view = dispatcher(state);
+
+      acceptAllChanges()(view.state, view.dispatch);
+
+      expect(getTrackedSectionEndpointRemoval(view.state)).toMatchObject({
+        sourceParagraphEndpointCount: 1,
+        expectedParagraphEndpointCount: 0,
+      });
+    });
+
+    test("invalidates an authorization after a later untracked endpoint removal", () => {
+      const state = trackedState(
+        schema.node("doc", null, [
+          schema.node(
+            "paragraph",
+            {
+              pPrMark: delMark({ id: 2 }),
+              sectionBreakType: "nextPage",
+              _sectionProperties: { columns: 2 },
+            },
+            schema.text("removed endpoint"),
+          ),
+          schema.node(
+            "paragraph",
+            {
+              sectionBreakType: "continuous",
+              _sectionProperties: { columns: 3 },
+            },
+            schema.text("surviving endpoint"),
+          ),
+        ]),
+      );
+      const view = dispatcher(state);
+      acceptAllChanges()(view.state, view.dispatch);
+      expect(getTrackedSectionEndpointRemoval(view.state)).toMatchObject({
+        sourceParagraphEndpointCount: 2,
+        expectedParagraphEndpointCount: 1,
+      });
+
+      view.dispatch(
+        view.state.tr
+          .setNodeAttribute(0, "sectionBreakType", null)
+          .setNodeAttribute(0, "_sectionProperties", null),
+      );
+
+      expect(getTrackedSectionEndpointRemoval(view.state)).toBeNull();
+    });
+
+    test("invalidates an authorization after a count-neutral endpoint property change", () => {
+      const state = trackedState(
+        schema.node("doc", null, [
+          schema.node(
+            "paragraph",
+            {
+              pPrMark: delMark({ id: 2 }),
+              sectionBreakType: "nextPage",
+              _sectionProperties: { columns: 2 },
+            },
+            schema.text("removed endpoint"),
+          ),
+          schema.node(
+            "paragraph",
+            {
+              sectionBreakType: "continuous",
+              _sectionProperties: { columns: 3 },
+            },
+            schema.text("surviving endpoint"),
+          ),
+        ]),
+      );
+      const view = dispatcher(state);
+      acceptAllChanges()(view.state, view.dispatch);
+      expect(getTrackedSectionEndpointRemoval(view.state)).not.toBeNull();
+
+      view.dispatch(view.state.tr.setNodeAttribute(0, "_sectionProperties", { columns: 4 }));
+
+      expect(getTrackedSectionEndpointRemoval(view.state)).toBeNull();
+    });
+
+    test("invalidates an authorization after a count-neutral endpoint move", () => {
+      const state = trackedState(
+        schema.node("doc", null, [
+          schema.node(
+            "paragraph",
+            {
+              pPrMark: delMark({ id: 2 }),
+              sectionBreakType: "nextPage",
+              _sectionProperties: { columns: 2 },
+            },
+            schema.text("removed endpoint"),
+          ),
+          schema.node(
+            "paragraph",
+            {
+              sectionBreakType: "continuous",
+              _sectionProperties: { columns: 3 },
+            },
+            schema.text("surviving endpoint"),
+          ),
+          schema.node("paragraph", null, schema.text("ordinary paragraph")),
+        ]),
+      );
+      const view = dispatcher(state);
+      acceptAllChanges()(view.state, view.dispatch);
+      expect(getTrackedSectionEndpointRemoval(view.state)).not.toBeNull();
+      const firstParagraphSize = view.state.doc.child(0).nodeSize;
+
+      view.dispatch(
+        view.state.tr
+          .setNodeAttribute(0, "sectionBreakType", null)
+          .setNodeAttribute(0, "_sectionProperties", null)
+          .setNodeAttribute(firstParagraphSize, "sectionBreakType", "continuous")
+          .setNodeAttribute(firstParagraphSize, "_sectionProperties", { columns: 3 }),
+      );
+
+      expect(getTrackedSectionEndpointRemoval(view.state)).toBeNull();
+    });
+
+    test("accumulates exact endpoint removals across scoped resolutions", () => {
+      const state = trackedState(
+        schema.node("doc", null, [
+          schema.node(
+            "paragraph",
+            {
+              pPrMark: delMark({ id: 2 }),
+              sectionBreakType: "nextPage",
+              _sectionProperties: { columns: 2 },
+            },
+            schema.text("first section"),
+          ),
+          schema.node(
+            "paragraph",
+            {
+              pPrMark: delMark({ id: 3 }),
+              sectionBreakType: "oddPage",
+              _sectionProperties: { columns: 3 },
+            },
+            schema.text("second section"),
+          ),
+          schema.node(
+            "paragraph",
+            {
+              sectionBreakType: "continuous",
+              _sectionProperties: { columns: 4 },
+            },
+            schema.text("following section"),
+          ),
+        ]),
+      );
+      const view = dispatcher(state);
+
+      acceptAIEditRevision(2)(view.state, view.dispatch);
+      acceptAIEditRevision(3)(view.state, view.dispatch);
+
+      expect(getTrackedSectionEndpointRemoval(view.state)).toMatchObject({
+        sourceParagraphEndpointCount: 3,
+        expectedParagraphEndpointCount: 1,
+      });
     });
   });
 

--- a/packages/core/src/prosemirror/extensions/features/ParagraphChangeTrackerExtension.ts
+++ b/packages/core/src/prosemirror/extensions/features/ParagraphChangeTrackerExtension.ts
@@ -6,6 +6,7 @@
  * Used by the selective save system to patch only changed paragraphs in document.xml.
  */
 
+import type { Node as PMNode } from "prosemirror-model";
 import { Plugin, PluginKey } from "prosemirror-state";
 import type { EditorState, Transaction } from "prosemirror-state";
 import {
@@ -17,6 +18,11 @@ import {
 } from "prosemirror-transform";
 import type { Mapping } from "prosemirror-transform";
 
+import type {
+  RemovedSectionReference,
+  TrackedSectionEndpointRemoval,
+} from "../../../internal/sectionEndpointResolution";
+import { canonicalJson } from "../../../utils/canonicalJson";
 import { createExtension } from "../create";
 import type { ExtensionRuntime } from "../types";
 
@@ -28,6 +34,7 @@ const CLEAR_META = "clear";
 const IGNORE_META = "ignore";
 const STRUCTURAL_META = "structural";
 const CHANGED_PARAGRAPH_RANGES_META = "folioChangedParagraphRanges";
+const SECTION_ENDPOINT_REMOVAL_META = "folioSectionEndpointRemoval";
 
 type ChangedParagraphRangeBatch = {
   ranges: readonly { from: number; to: number }[];
@@ -45,6 +52,52 @@ const isChangedParagraphRangesMeta = (value: unknown): value is ChangedParagraph
   "type" in value &&
   value.type === "changed-paragraph-ranges";
 
+const isRemovedSectionReference = (value: unknown): value is RemovedSectionReference =>
+  typeof value === "object" &&
+  value !== null &&
+  "part" in value &&
+  (value.part === "header" || value.part === "footer") &&
+  "type" in value &&
+  (value.type === "default" || value.type === "first" || value.type === "even") &&
+  "relationshipId" in value &&
+  typeof value.relationshipId === "string";
+
+const isTrackedSectionEndpointRemoval = (value: unknown): value is TrackedSectionEndpointRemoval =>
+  typeof value === "object" &&
+  value !== null &&
+  "type" in value &&
+  value.type === "tracked-section-endpoint-removal" &&
+  "sourceParagraphEndpointCount" in value &&
+  typeof value.sourceParagraphEndpointCount === "number" &&
+  Number.isSafeInteger(value.sourceParagraphEndpointCount) &&
+  "expectedParagraphEndpointCount" in value &&
+  typeof value.expectedParagraphEndpointCount === "number" &&
+  Number.isSafeInteger(value.expectedParagraphEndpointCount) &&
+  value.sourceParagraphEndpointCount > value.expectedParagraphEndpointCount &&
+  value.expectedParagraphEndpointCount >= 0 &&
+  "sourceEndpointFingerprint" in value &&
+  typeof value.sourceEndpointFingerprint === "string" &&
+  "expectedEndpointFingerprint" in value &&
+  typeof value.expectedEndpointFingerprint === "string" &&
+  "removedReferences" in value &&
+  Array.isArray(value.removedReferences) &&
+  value.removedReferences.every(isRemovedSectionReference);
+
+type TrackedSectionEndpointRemovalMeta = {
+  type: "tracked-section-endpoint-removal-meta";
+  authorization: TrackedSectionEndpointRemoval;
+};
+
+const isTrackedSectionEndpointRemovalMeta = (
+  value: unknown,
+): value is TrackedSectionEndpointRemovalMeta =>
+  typeof value === "object" &&
+  value !== null &&
+  "type" in value &&
+  value.type === "tracked-section-endpoint-removal-meta" &&
+  "authorization" in value &&
+  isTrackedSectionEndpointRemoval(value.authorization);
+
 export type ParagraphChangeTrackerState = {
   /** Set of paraIds that were modified since last clear */
   changedParaIds: Set<string>;
@@ -54,19 +107,57 @@ export type ParagraphChangeTrackerState = {
   hasUntrackedChanges: boolean;
   /** Cached paragraph count to avoid full doc traversal on every transaction */
   paragraphCount: number;
+  /** Cached section-endpoint count used to invalidate stale save authorization. */
+  sectionEndpointCount: number;
+  /** Exact endpoint owners and properties used to invalidate count-neutral changes. */
+  sectionEndpointFingerprint: string;
+  /** Exact tracked-resolution transition that may reduce the saved section count. */
+  sectionEndpointRemoval: TrackedSectionEndpointRemoval | null;
 };
 
-/**
- * Count paragraph nodes in a ProseMirror document
- */
-function countParagraphs(doc: EditorState["doc"]): number {
-  let count = 0;
-  doc.descendants((node) => {
-    if (node.type.name === "paragraph") {
-      count++;
-    }
-  });
-  return count;
+type DocumentStructureCounts = {
+  paragraphs: number;
+  sectionEndpoints: number;
+  sectionEndpointFingerprint: string;
+};
+
+/** Count the structural values the tracker compares for every transaction. */
+function countDocumentStructure(doc: PMNode): DocumentStructureCounts {
+  let paragraphs = 0;
+  let sectionEndpoints = 0;
+  const endpointRecords: {
+    path: string;
+    paraId: unknown;
+    sectionBreakType: unknown;
+    sectionProperties: unknown;
+  }[] = [];
+  const visit = (parent: PMNode, parentPath: string): void => {
+    parent.forEach((node, _offset, index) => {
+      if (node.type.name === "paragraph") {
+        paragraphs++;
+        if (node.attrs["_sectionProperties"] != null || node.attrs["sectionBreakType"] != null) {
+          sectionEndpoints++;
+          endpointRecords.push({
+            path: parentPath.length === 0 ? `${index}` : `${parentPath}.${index}`,
+            paraId: node.attrs["paraId"] ?? null,
+            sectionBreakType: node.attrs["sectionBreakType"] ?? null,
+            sectionProperties: node.attrs["_sectionProperties"] ?? null,
+          });
+        }
+        return;
+      }
+      if (node.childCount > 0) {
+        const path = parentPath.length === 0 ? `${index}` : `${parentPath}.${index}`;
+        visit(node, path);
+      }
+    });
+  };
+  visit(doc, "");
+  return {
+    paragraphs,
+    sectionEndpoints,
+    sectionEndpointFingerprint: canonicalJson(endpointRecords),
+  };
 }
 
 /**
@@ -142,30 +233,52 @@ function createParagraphChangeTrackerPlugin(): Plugin<ParagraphChangeTrackerStat
     key: paragraphChangeTrackerKey,
     state: {
       init(_config, state): ParagraphChangeTrackerState {
+        const counts = countDocumentStructure(state.doc);
         return {
           changedParaIds: new Set(),
           structuralChange: false,
           hasUntrackedChanges: false,
-          paragraphCount: countParagraphs(state.doc),
+          paragraphCount: counts.paragraphs,
+          sectionEndpointCount: counts.sectionEndpoints,
+          sectionEndpointFingerprint: counts.sectionEndpointFingerprint,
+          sectionEndpointRemoval: null,
         };
       },
       apply(tr: Transaction, prevState: ParagraphChangeTrackerState): ParagraphChangeTrackerState {
         const meta = tr.getMeta(paragraphChangeTrackerKey);
         const changedParagraphRangesMeta = tr.getMeta(CHANGED_PARAGRAPH_RANGES_META);
+        const sectionEndpointRemovalMeta = tr.getMeta(SECTION_ENDPOINT_REMOVAL_META);
         // Check for explicit clear meta
         if (meta === CLEAR_META) {
+          const counts = countDocumentStructure(tr.doc);
           return {
             changedParaIds: new Set(),
             structuralChange: false,
             hasUntrackedChanges: false,
-            paragraphCount: prevState.paragraphCount,
+            paragraphCount: counts.paragraphs,
+            sectionEndpointCount: counts.sectionEndpoints,
+            sectionEndpointFingerprint: counts.sectionEndpointFingerprint,
+            sectionEndpointRemoval: null,
           };
         }
 
         if (meta === IGNORE_META) {
+          const counts = tr.docChanged
+            ? countDocumentStructure(tr.doc)
+            : {
+                paragraphs: prevState.paragraphCount,
+                sectionEndpoints: prevState.sectionEndpointCount,
+                sectionEndpointFingerprint: prevState.sectionEndpointFingerprint,
+              };
           return {
             ...prevState,
-            paragraphCount: tr.docChanged ? countParagraphs(tr.doc) : prevState.paragraphCount,
+            paragraphCount: counts.paragraphs,
+            sectionEndpointCount: counts.sectionEndpoints,
+            sectionEndpointRemoval:
+              counts.sectionEndpointFingerprint === prevState.sectionEndpointFingerprint
+                ? prevState.sectionEndpointRemoval
+                : null,
+            sectionEndpointFingerprint: counts.sectionEndpointFingerprint,
           };
         }
 
@@ -175,7 +288,49 @@ function createParagraphChangeTrackerPlugin(): Plugin<ParagraphChangeTrackerStat
         }
 
         // Count paragraphs in new doc only (use cached count for old doc)
-        const newCount = countParagraphs(tr.doc);
+        const counts = countDocumentStructure(tr.doc);
+        const newCount = counts.paragraphs;
+        let sectionEndpointRemoval = prevState.sectionEndpointRemoval;
+        if (counts.sectionEndpointFingerprint !== prevState.sectionEndpointFingerprint) {
+          if (
+            isTrackedSectionEndpointRemovalMeta(sectionEndpointRemovalMeta) &&
+            sectionEndpointRemovalMeta.authorization.sourceEndpointFingerprint ===
+              prevState.sectionEndpointFingerprint &&
+            sectionEndpointRemovalMeta.authorization.expectedEndpointFingerprint ===
+              counts.sectionEndpointFingerprint &&
+            sectionEndpointRemovalMeta.authorization.sourceParagraphEndpointCount ===
+              prevState.sectionEndpointCount &&
+            sectionEndpointRemovalMeta.authorization.expectedParagraphEndpointCount ===
+              counts.sectionEndpoints &&
+            counts.sectionEndpoints < prevState.sectionEndpointCount
+          ) {
+            const authorization = sectionEndpointRemovalMeta.authorization;
+            sectionEndpointRemoval = {
+              type: "tracked-section-endpoint-removal",
+              sourceParagraphEndpointCount:
+                prevState.sectionEndpointRemoval?.expectedParagraphEndpointCount ===
+                authorization.sourceParagraphEndpointCount
+                  ? prevState.sectionEndpointRemoval.sourceParagraphEndpointCount
+                  : authorization.sourceParagraphEndpointCount,
+              expectedParagraphEndpointCount: authorization.expectedParagraphEndpointCount,
+              sourceEndpointFingerprint:
+                prevState.sectionEndpointRemoval?.expectedParagraphEndpointCount ===
+                authorization.sourceParagraphEndpointCount
+                  ? prevState.sectionEndpointRemoval.sourceEndpointFingerprint
+                  : authorization.sourceEndpointFingerprint,
+              expectedEndpointFingerprint: authorization.expectedEndpointFingerprint,
+              removedReferences: [
+                ...(prevState.sectionEndpointRemoval?.expectedParagraphEndpointCount ===
+                authorization.sourceParagraphEndpointCount
+                  ? prevState.sectionEndpointRemoval.removedReferences
+                  : []),
+                ...authorization.removedReferences,
+              ],
+            };
+          } else {
+            sectionEndpointRemoval = null;
+          }
+        }
 
         // Clone previous state
         const newState: ParagraphChangeTrackerState = {
@@ -183,6 +338,9 @@ function createParagraphChangeTrackerPlugin(): Plugin<ParagraphChangeTrackerStat
           structuralChange: prevState.structuralChange || meta === STRUCTURAL_META,
           hasUntrackedChanges: prevState.hasUntrackedChanges,
           paragraphCount: newCount,
+          sectionEndpointCount: counts.sectionEndpoints,
+          sectionEndpointFingerprint: counts.sectionEndpointFingerprint,
+          sectionEndpointRemoval,
         };
 
         if (isChangedParagraphRangesMeta(changedParagraphRangesMeta)) {
@@ -316,6 +474,44 @@ export function hasStructuralChanges(state: EditorState): boolean {
 export function hasUntrackedChanges(state: EditorState): boolean {
   const trackerState = getChangeTrackerState(state);
   return trackerState?.hasUntrackedChanges ?? false;
+}
+
+/** Exact section-count transition authorized by tracked paragraph-mark resolution. */
+export function getTrackedSectionEndpointRemoval(
+  state: EditorState,
+): TrackedSectionEndpointRemoval | null {
+  return getChangeTrackerState(state)?.sectionEndpointRemoval ?? null;
+}
+
+type MarkTrackedSectionEndpointRemovalOptions = {
+  sourceDoc: PMNode;
+  removedEndpointCount: number;
+  removedReferences: readonly RemovedSectionReference[];
+};
+
+/** Record only a complete, internally consistent endpoint-removal transition. */
+export function markTrackedSectionEndpointRemoval(
+  tr: Transaction,
+  { sourceDoc, removedEndpointCount, removedReferences }: MarkTrackedSectionEndpointRemovalOptions,
+): Transaction {
+  const sourceStructure = countDocumentStructure(sourceDoc);
+  const sourceParagraphEndpointCount = sourceStructure.sectionEndpoints;
+  const expectedStructure = countDocumentStructure(tr.doc);
+  const expectedParagraphEndpointCount = expectedStructure.sectionEndpoints;
+  if (sourceParagraphEndpointCount - expectedParagraphEndpointCount !== removedEndpointCount) {
+    return tr;
+  }
+  return tr.setMeta(SECTION_ENDPOINT_REMOVAL_META, {
+    type: "tracked-section-endpoint-removal-meta",
+    authorization: {
+      type: "tracked-section-endpoint-removal",
+      sourceParagraphEndpointCount,
+      expectedParagraphEndpointCount,
+      sourceEndpointFingerprint: sourceStructure.sectionEndpointFingerprint,
+      expectedEndpointFingerprint: expectedStructure.sectionEndpointFingerprint,
+      removedReferences,
+    },
+  } satisfies TrackedSectionEndpointRemovalMeta);
 }
 
 /**


### PR DESCRIPTION
## Summary

- resolve section properties with the paragraph mark that owns them
- authorize full repack only for the exact tracked endpoint and header/footer references removed by resolution
- capture immutable save inputs so repeated and concurrent serialization use one coherent reviewer state
- cover accepted and rejected section-boundary revisions through DOCX save and reopen

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of section breaks when accepting or rejecting tracked paragraph changes.
  * Preserved the correct header and footer references when section breaks are removed.
  * Ensured saved and reopened documents retain consistent section structure and formatting.
  * Improved reliability when saving documents while tracked changes are being resolved concurrently.

* **Tests**
  * Added comprehensive coverage for section-break resolution, document repacking, and save consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->