### PR TITLE
feat: add synthetic reference layout matrix

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "bench:cross-language": "bun benchmarks/cross-language/run.ts",
     "parity": "bun parity/cli.ts",
     "parity:line-endpoints": "bun parity/lineEndpointsCli.ts",
+    "parity:layout-matrix": "bun parity/layoutMatrixCli.ts",
     "parity:build-line-endpoint-fixtures": "bun parity/fixtures/build-word-line-endpoint-fixtures.ts",
     "parity:build-layout-corpus": "bun parity/fixtures/build-layout-corpus.ts",
     "parity:check-layout-corpus": "bun parity/fixtures/build-layout-corpus.ts --check",

--- a/parity/README.md
+++ b/parity/README.md
@@ -26,6 +26,26 @@ bun parity/cli.ts some/dir --json
 bun parity/cli.ts --refresh-reference
 ```
 
+### Synthetic reference layout matrix
+
+Run every generated strength-two interaction case as its own document against
+an explicit reference renderer, then inspect the case-level JSON and visual report:
+
+```sh
+bun run parity:layout-matrix --reference libreoffice
+bun run parity:layout-matrix --reference word --refresh-reference
+```
+
+The command attributes required failures to axis pairs such as
+`section=continuous|anchorFrame=page`. It fails on missing pages, page-size
+mismatches, and reliable pagination or line-flow divergences. Direct raster
+differences and geometric drift remain advisory because glyph antialiasing and
+font environments can vary. Exports are cached by the deterministic fixture
+hash, so repeat runs reuse the reference render. The generated JSON is written
+to `parity/report/layout-matrix-<reference>.json`; the existing HTML report
+contains side-by-side pages and highlighted image diffs. Both outputs contain
+synthetic fixture data only and remain local.
+
 Requirements:
 
 - `libreoffice`: a local LibreOffice installation plus `mutool`; the adapter

--- a/parity/__tests__/layoutCorpusFixture.test.ts
+++ b/parity/__tests__/layoutCorpusFixture.test.ts
@@ -5,6 +5,7 @@ import JSZip from "jszip";
 
 import {
   buildLayoutCorpus,
+  buildLayoutInteractionCaseFixture,
   layoutInteractionMatrixManifest,
 } from "../fixtures/build-layout-corpus";
 import { buildLayoutInteractionMatrix } from "../fixtures/layout-interaction-matrix";
@@ -90,5 +91,20 @@ describe("synthetic layout corpus", () => {
     expect(kitchenDocument).toContain("<w:bidi/>");
     expect(kitchenDocument).toContain("<w:cols");
     expect(kitchenSink.file("word/footnotes.xml")).not.toBeNull();
+  });
+
+  test("isolates every matrix case with an observable section boundary", async () => {
+    for (const scenario of buildLayoutInteractionMatrix()) {
+      // oxlint-disable-next-line no-await-in-loop -- validates each bounded generated case independently
+      const zip = await JSZip.loadAsync(await buildLayoutInteractionCaseFixture(scenario));
+      // oxlint-disable-next-line no-await-in-loop -- JSZip exposes async part reads
+      const document = await zip.file("word/document.xml")!.async("text");
+      expect(document).toContain(`${scenario.id} post-boundary sentinel.`);
+      if (scenario.section === "single") {
+        expect(document).not.toContain("Section boundary");
+      } else {
+        expect(document).toContain("Section boundary");
+      }
+    }
   });
 });

--- a/parity/__tests__/layoutMatrix.test.ts
+++ b/parity/__tests__/layoutMatrix.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildLayoutInteractionMatrix } from "../fixtures/layout-interaction-matrix";
+import { summarizeLayoutMatrix } from "../layoutMatrix";
+import type { CorpusReport, Divergence, FeatureAttributedResult } from "../types";
+
+const scenarios = buildLayoutInteractionMatrix().slice(0, 2);
+
+const resultFor = (
+  id: string,
+  divergences: Divergence[] = [],
+  rasterStatus: "match" | "difference" | "dimension-mismatch" = "match",
+): FeatureAttributedResult => ({
+  file: `/synthetic/${id}.docx`,
+  score: divergences.length === 0 ? 1 : 0.5,
+  referencePages: 1,
+  folioPages: 1,
+  totalReferenceLines: 1,
+  matchedLines: divergences.length === 0 ? 1 : 0,
+  medianYOffsetPt: 0,
+  divergences,
+  attributed: [],
+  docFeatures: [],
+  fontEnvironment: { status: "native", tags: [], comparedLines: 1, matchingLines: 1 },
+  rasterComparison: {
+    status: "compared",
+    score: rasterStatus === "match" ? 1 : 0.9,
+    diffPixels: rasterStatus === "match" ? 0 : 10,
+    totalPixels: 100,
+    pages: [
+      rasterStatus === "dimension-mismatch"
+        ? {
+            status: "dimension-mismatch",
+            page: 1,
+            referenceWidthPx: 100,
+            referenceHeightPx: 100,
+            folioWidthPx: 90,
+            folioHeightPx: 100,
+            diffPixels: 10,
+            totalPixels: 100,
+            similarity: 0.9,
+          }
+        : {
+            status: rasterStatus,
+            page: 1,
+            widthPx: 100,
+            heightPx: 100,
+            diffPixels: rasterStatus === "match" ? 0 : 10,
+            totalPixels: 100,
+            similarity: rasterStatus === "match" ? 1 : 0.9,
+          },
+    ],
+  },
+});
+
+const reportFor = (
+  results: FeatureAttributedResult[],
+  reference: "word" | "libreoffice" = "word",
+) =>
+  ({
+    generatedAt: "2026-09-09T00:00:00.000Z",
+    reference: { id: reference, displayName: reference },
+    results,
+    clusters: [],
+  }) satisfies CorpusReport;
+
+describe("reference layout matrix summary", () => {
+  test("separates required structural failures from advisory raster differences", () => {
+    const first = scenarios.at(0)!;
+    const second = scenarios.at(1)!;
+    const report = summarizeLayoutMatrix(
+      reportFor([
+        resultFor(first.id, [
+          { kind: "pagination", text: "Synthetic", referencePage: 1, folioPage: 2 },
+        ]),
+        resultFor(second.id, [], "difference"),
+      ]),
+      scenarios,
+    );
+
+    expect(report.summary).toEqual({ total: 2, pass: 0, advisory: 1, fail: 1 });
+    expect(report.cases.at(0)?.requiredDivergences).toEqual({ pagination: 1 });
+    expect(report.requiredInteractionClusters.length).toBeGreaterThan(0);
+    expect(
+      report.requiredInteractionClusters.every(({ caseIds }) => caseIds.includes(first.id)),
+    ).toBeTrue();
+  });
+
+  test("makes page-raster shape failures required", () => {
+    const first = scenarios.at(0)!;
+    const report = summarizeLayoutMatrix(
+      reportFor([resultFor(first.id, [], "dimension-mismatch")]),
+      [first],
+    );
+
+    expect(report.summary.fail).toBe(1);
+    expect(report.cases.at(0)?.requiredRasterFailures).toBe(1);
+  });
+
+  test("does not gate line flow when font geometry is unverified", () => {
+    const first = scenarios.at(0)!;
+    const result = resultFor(first.id, [
+      { kind: "line-break", page: 1, referenceTexts: ["A"], folioTexts: ["A", "B"] },
+    ]);
+    result.fontEnvironment = { status: "mismatch", tags: [], comparedLines: 1, matchingLines: 0 };
+    const report = summarizeLayoutMatrix(reportFor([result]), [first]);
+
+    expect(report.summary).toEqual({ total: 1, pass: 0, advisory: 1, fail: 0 });
+  });
+
+  test("supports each reference and rejects incomplete case sets", () => {
+    const first = scenarios.at(0)!;
+    expect(
+      summarizeLayoutMatrix(reportFor([resultFor(first.id)], "libreoffice"), [first]).reference.id,
+    ).toBe("libreoffice");
+    expect(() => summarizeLayoutMatrix(reportFor([]), [first])).toThrow(
+      `Missing matrix result: ${first.id}`,
+    );
+  });
+});

--- a/parity/__tests__/layoutMatrixCli.test.ts
+++ b/parity/__tests__/layoutMatrixCli.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import type { LayoutInteractionCase } from "../fixtures/layout-interaction-matrix";
+import { LayoutMatrixError, type ReferenceLayoutMatrixReport } from "../layoutMatrix";
+import { parseLayoutMatrixCliArgs, writeLayoutMatrixArtifacts } from "../layoutMatrixCli";
+
+describe("reference layout matrix CLI", () => {
+  test("defaults to a cached headless run", () => {
+    expect(parseLayoutMatrixCliArgs([])).toMatchObject({
+      type: "run",
+      refreshReference: false,
+      referenceId: "libreoffice",
+      headed: false,
+      reuseServer: false,
+    });
+  });
+
+  test("parses run controls", () => {
+    expect(
+      parseLayoutMatrixCliArgs([
+        "--reference",
+        "word",
+        "--refresh-reference",
+        "--headed",
+        "--reuse-server",
+        "--output",
+        "/tmp/matrix.json",
+      ]),
+    ).toEqual({
+      type: "run",
+      refreshReference: true,
+      referenceId: "word",
+      headed: true,
+      reuseServer: true,
+      outputPath: "/tmp/matrix.json",
+    });
+  });
+
+  test("supports help and rejects incomplete flags", () => {
+    expect(parseLayoutMatrixCliArgs(["--help"])).toEqual({ type: "help" });
+    expect(() => parseLayoutMatrixCliArgs(["--output"])).toThrow(LayoutMatrixError);
+    expect(() => parseLayoutMatrixCliArgs(["--reference", "pages"])).toThrow(
+      "Unknown reference renderer: pages",
+    );
+  });
+
+  test("writes JSON after the visual report recreates its directory", async () => {
+    const outputDirectory = await mkdtemp(path.join(tmpdir(), "layout-matrix-cli-test-"));
+    const outputPath = path.join(outputDirectory, "layout-matrix.json");
+    try {
+      const scenario = {
+        id: "mx-synthetic",
+        section: "single",
+        anchorFrame: "inline",
+        wrap: "inline",
+        flow: "normal",
+        table: "none",
+        typography: "latin",
+      } satisfies LayoutInteractionCase;
+      const report = {
+        schema: "folio.reference-layout-matrix",
+        version: 1,
+        generatedAt: "2026-09-09T00:00:00.000Z",
+        reference: { id: "word", displayName: "Word" },
+        summary: { total: 1, pass: 1, advisory: 0, fail: 0 },
+        cases: [
+          {
+            scenario,
+            status: "pass",
+            geometryReliable: true,
+            referencePages: 1,
+            folioPages: 1,
+            requiredDivergences: {},
+            diagnosticDivergences: {},
+            requiredRasterFailures: 0,
+          },
+        ],
+        requiredInteractionClusters: [],
+      } satisfies ReferenceLayoutMatrixReport;
+      await writeLayoutMatrixArtifacts({
+        report,
+        outputPath,
+        writeVisualReport: async () => {
+          await rm(outputDirectory, { recursive: true, force: true });
+          await mkdir(outputDirectory, { recursive: true });
+          return path.join(outputDirectory, "index.html");
+        },
+      });
+
+      expect(await Bun.file(outputPath).exists()).toBeTrue();
+    } finally {
+      await rm(outputDirectory, { recursive: true, force: true });
+    }
+  });
+});

--- a/parity/cli.ts
+++ b/parity/cli.ts
@@ -93,6 +93,11 @@ type CliFlags = {
   paths: string[];
 };
 
+export type RunPipelineOptions = Pick<
+  CliFlags,
+  "refreshReference" | "referenceId" | "headed" | "reuseServer" | "maxPages"
+>;
+
 export const parseArgs = (argv: string[]): CliFlags => {
   const flags: CliFlags = {
     help: false,
@@ -226,10 +231,10 @@ const resolveCorpus = async (inputPaths: string[]): Promise<string[]> => {
 };
 
 /** Per-doc pipeline failure: any throw during reference/folio/compare/features. */
-type DocFailure = { file: string; error: Error };
+export type DocFailure = { file: string; error: Error };
 
 /** Result of running the full per-doc pipeline over the corpus. */
-type PipelineOutcome = {
+export type PipelineOutcome = {
   results: FeatureAttributedResult[];
   paragraphsByDoc: ParagraphFeatures[][];
   assets: Map<string, DocAssets>;
@@ -242,9 +247,9 @@ type PipelineOutcome = {
  * applications and the folio extractor shares one browser page, so documents
  * cannot be processed concurrently.
  */
-const runPipeline = async (
+export const runPipeline = async (
   docs: string[],
-  flags: CliFlags,
+  flags: RunPipelineOptions,
   referenceRenderer: ReferenceRenderer,
 ): Promise<PipelineOutcome> => {
   const results: FeatureAttributedResult[] = [];

--- a/parity/fixtures/README.md
+++ b/parity/fixtures/README.md
@@ -25,7 +25,13 @@ floating anchors pair only with floating wrap modes.
 ```sh
 bun run parity:build-layout-corpus
 bun run parity:check-layout-corpus
+bun run parity:layout-matrix
 ```
+
+The matrix command generates one temporary DOCX per case. Isolating the cases
+makes failures attributable to a single axis combination and prevents a section
+transition in one case from changing a later case. The temporary documents and
+local reports contain synthetic values only.
 
 The isolated and pairwise fixtures should remain small enough to attribute a
 regression. Add a feature to the kitchen sink only after it has focused

--- a/parity/fixtures/build-layout-corpus.ts
+++ b/parity/fixtures/build-layout-corpus.ts
@@ -391,14 +391,8 @@ export const buildLayoutInteractionCaseFixture = (
 ): Promise<Uint8Array> =>
   buildFixture({
     name: "pairwise-layout-interactions.docx",
-    body: matrixCaseContent(scenario, 0),
-    sectionProperties: `${headerFooterReferences}${
-      scenario.section === "continuous" || scenario.section === "twoColumn"
-        ? '<w:type w:val="continuous"/>'
-        : ""
-    }${pageProperties(
-      scenario.section === "twoColumn" ? '<w:cols w:num="2" w:space="720"/>' : "",
-    )}`,
+    body: `${matrixCaseContent(scenario, 0)}${matrixSectionBoundary(scenario)}<w:p><w:r><w:t>${scenario.id} post-boundary sentinel.</w:t></w:r></w:p>`,
+    sectionProperties: `${headerFooterReferences}${pageProperties()}`,
     parts: PAGE_FURNITURE_PARTS,
     relationships: MATRIX_RELATIONSHIPS,
     overrides: PAGE_FURNITURE_OVERRIDES,

--- a/parity/layoutMatrix.ts
+++ b/parity/layoutMatrix.ts
@@ -1,0 +1,186 @@
+import path from "node:path";
+
+import { TaggedError } from "better-result";
+import {
+  layoutInteractionCasePairs,
+  type LayoutInteractionCase,
+} from "./fixtures/layout-interaction-matrix";
+import type {
+  CorpusReport,
+  Divergence,
+  DivergenceKind,
+  FeatureAttributedResult,
+  RasterComparison,
+  ReferenceRendererInfo,
+} from "./types";
+import { isGeometryScoreReliable } from "./types";
+
+export const LAYOUT_MATRIX_REPORT_SCHEMA = "folio.reference-layout-matrix";
+export const LAYOUT_MATRIX_REPORT_VERSION = 1;
+
+const REQUIRED_DIVERGENCE_KINDS = new Set<DivergenceKind>([
+  "page-count",
+  "pagination",
+  "line-break",
+  "missing-line",
+  "extra-line",
+  "text-mismatch",
+]);
+
+export type LayoutMatrixCaseStatus = "pass" | "advisory" | "fail";
+
+type DivergenceCounts = Partial<Record<DivergenceKind, number>>;
+
+export type LayoutMatrixCaseResult = {
+  scenario: LayoutInteractionCase;
+  status: LayoutMatrixCaseStatus;
+  geometryReliable: boolean;
+  referencePages: number;
+  folioPages: number;
+  requiredDivergences: DivergenceCounts;
+  diagnosticDivergences: DivergenceCounts;
+  requiredRasterFailures: number;
+  rasterComparison?: RasterComparison;
+};
+
+export type LayoutMatrixInteractionCluster = {
+  pair: string;
+  failingCases: number;
+  caseIds: string[];
+};
+
+export type ReferenceLayoutMatrixReport = {
+  schema: typeof LAYOUT_MATRIX_REPORT_SCHEMA;
+  version: typeof LAYOUT_MATRIX_REPORT_VERSION;
+  generatedAt: string;
+  reference: ReferenceRendererInfo;
+  summary: Record<LayoutMatrixCaseStatus | "total", number>;
+  cases: LayoutMatrixCaseResult[];
+  requiredInteractionClusters: LayoutMatrixInteractionCluster[];
+};
+
+export class LayoutMatrixError extends TaggedError("LayoutMatrixError")<{
+  message: string;
+}> {}
+
+export const layoutMatrixError = (message: string): LayoutMatrixError =>
+  new LayoutMatrixError({ message });
+
+const countDivergences = (divergences: Divergence[]): DivergenceCounts => {
+  const counts: DivergenceCounts = {};
+  for (const { kind } of divergences) counts[kind] = (counts[kind] ?? 0) + 1;
+  return counts;
+};
+
+const hasRasterDifference = (raster: RasterComparison | undefined): boolean =>
+  raster === undefined || raster.status === "empty" || raster.score < 1;
+
+const countRequiredRasterFailures = (raster: RasterComparison | undefined): number => {
+  if (raster === undefined || raster.status === "empty") return 1;
+  return raster.pages.filter(
+    ({ status }) =>
+      status === "dimension-mismatch" ||
+      status === "missing-reference" ||
+      status === "missing-folio",
+  ).length;
+};
+
+const caseStatus = (
+  hasRequiredFailure: boolean,
+  hasDiagnostic: boolean,
+): LayoutMatrixCaseStatus => {
+  if (hasRequiredFailure) return "fail";
+  if (hasDiagnostic) return "advisory";
+  return "pass";
+};
+
+const summarizeCase = (
+  scenario: LayoutInteractionCase,
+  result: FeatureAttributedResult,
+): LayoutMatrixCaseResult => {
+  const geometryReliable = isGeometryScoreReliable(result.fontEnvironment);
+  const required = result.divergences.filter(({ kind }) => REQUIRED_DIVERGENCE_KINDS.has(kind));
+  const diagnostics = result.divergences.filter(({ kind }) => !REQUIRED_DIVERGENCE_KINDS.has(kind));
+  const requiredRasterFailures = countRequiredRasterFailures(result.rasterComparison);
+  const hasRequiredFailure =
+    (geometryReliable && required.length > 0) || requiredRasterFailures > 0;
+  const hasDiagnostic =
+    required.length > 0 || diagnostics.length > 0 || hasRasterDifference(result.rasterComparison);
+  const status = caseStatus(hasRequiredFailure, hasDiagnostic);
+
+  return {
+    scenario,
+    status,
+    geometryReliable,
+    referencePages: result.referencePages,
+    folioPages: result.folioPages,
+    requiredDivergences: countDivergences(required),
+    diagnosticDivergences: countDivergences(diagnostics),
+    requiredRasterFailures,
+    ...(result.rasterComparison === undefined ? {} : { rasterComparison: result.rasterComparison }),
+  };
+};
+
+const resultCaseId = ({ file }: FeatureAttributedResult): string =>
+  path.basename(file, path.extname(file));
+
+const requireCaseResults = (
+  scenarios: readonly LayoutInteractionCase[],
+  results: FeatureAttributedResult[],
+): Map<string, FeatureAttributedResult> => {
+  const expected = new Set(scenarios.map(({ id }) => id));
+  const byId = new Map<string, FeatureAttributedResult>();
+  for (const result of results) {
+    const id = resultCaseId(result);
+    if (!expected.has(id)) throw layoutMatrixError(`Unexpected matrix result: ${id}.`);
+    if (byId.has(id)) throw layoutMatrixError(`Duplicate matrix result: ${id}.`);
+    byId.set(id, result);
+  }
+  for (const { id } of scenarios) {
+    if (!byId.has(id)) throw layoutMatrixError(`Missing matrix result: ${id}.`);
+  }
+  return byId;
+};
+
+const clusterFailures = (cases: LayoutMatrixCaseResult[]): LayoutMatrixInteractionCluster[] => {
+  const clusters = new Map<string, string[]>();
+  for (const result of cases) {
+    if (result.status !== "fail") continue;
+    for (const pair of layoutInteractionCasePairs(result.scenario)) {
+      const ids = clusters.get(pair) ?? [];
+      ids.push(result.scenario.id);
+      clusters.set(pair, ids);
+    }
+  }
+  return Array.from(clusters, ([pair, caseIds]) => ({
+    pair,
+    failingCases: caseIds.length,
+    caseIds,
+  })).toSorted(
+    (left, right) => right.failingCases - left.failingCases || left.pair.localeCompare(right.pair),
+  );
+};
+
+export const summarizeLayoutMatrix = (
+  report: CorpusReport,
+  scenarios: readonly LayoutInteractionCase[],
+): ReferenceLayoutMatrixReport => {
+  const byId = requireCaseResults(scenarios, report.results);
+  const cases = scenarios.map((scenario) => {
+    const result = byId.get(scenario.id);
+    if (!result) throw layoutMatrixError(`Missing matrix result: ${scenario.id}.`);
+    return summarizeCase(scenario, result);
+  });
+  const summary = { total: cases.length, pass: 0, advisory: 0, fail: 0 };
+  for (const result of cases) summary[result.status] += 1;
+
+  return {
+    schema: LAYOUT_MATRIX_REPORT_SCHEMA,
+    version: LAYOUT_MATRIX_REPORT_VERSION,
+    generatedAt: report.generatedAt,
+    reference: report.reference,
+    summary,
+    cases,
+    requiredInteractionClusters: clusterFailures(cases),
+  };
+};

--- a/parity/layoutMatrixCli.ts
+++ b/parity/layoutMatrixCli.ts
@@ -1,0 +1,198 @@
+#!/usr/bin/env bun
+/** Run every synthetic layout interaction case against a selected reference renderer. */
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { runPipeline, type RunPipelineOptions } from "./cli";
+import { clusterCorpus } from "./features";
+import { buildLayoutInteractionCaseFixture } from "./fixtures/build-layout-corpus";
+import { buildLayoutInteractionMatrix } from "./fixtures/layout-interaction-matrix";
+import { layoutMatrixError, summarizeLayoutMatrix } from "./layoutMatrix";
+import { REPORT_DIR } from "./config";
+import { getReferenceRenderer, isReferenceRendererId } from "./referenceRenderer";
+import { writeHtmlReport } from "./report";
+import type { CorpusReport, ReferenceRendererId } from "./types";
+
+const EXIT_OK = 0;
+const EXIT_DIVERGENT = 1;
+const EXIT_INFRA_FAILURE = 2;
+const DEFAULT_REFERENCE: ReferenceRendererId = "libreoffice";
+const TOP_CLUSTER_LIMIT = 10;
+
+export type LayoutMatrixCliCommand =
+  | { type: "help" }
+  | {
+      type: "run";
+      refreshReference: boolean;
+      referenceId: ReferenceRendererId;
+      headed: boolean;
+      reuseServer: boolean;
+      outputPath: string;
+    };
+
+const requireFlagValue = (argv: string[], index: number, flag: string): string => {
+  const value = argv[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw layoutMatrixError(`${flag} requires a path.`);
+  }
+  return value;
+};
+
+export const parseLayoutMatrixCliArgs = (argv: string[]): LayoutMatrixCliCommand => {
+  if (argv.includes("--help") || argv.includes("-h")) return { type: "help" };
+  let refreshReference = false;
+  let referenceId: ReferenceRendererId = DEFAULT_REFERENCE;
+  let headed = false;
+  let reuseServer = false;
+  let outputPath: string | undefined;
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--refresh-reference") {
+      refreshReference = true;
+    } else if (arg === "--reference") {
+      const value = requireFlagValue(argv, index, arg);
+      if (!isReferenceRendererId(value)) {
+        throw layoutMatrixError(`Unknown reference renderer: ${value}.`);
+      }
+      referenceId = value;
+      index += 1;
+    } else if (arg === "--headed") {
+      headed = true;
+    } else if (arg === "--reuse-server") {
+      reuseServer = true;
+    } else if (arg === "--output") {
+      outputPath = requireFlagValue(argv, index, arg);
+      index += 1;
+    } else {
+      throw layoutMatrixError(`Unknown option: ${String(arg)}`);
+    }
+  }
+  return {
+    type: "run",
+    refreshReference,
+    referenceId,
+    headed,
+    reuseServer,
+    outputPath: outputPath ?? path.join(REPORT_DIR, `layout-matrix-${referenceId}.json`),
+  };
+};
+
+const HELP_TEXT = `Synthetic reference-renderer layout matrix
+
+Usage:
+  bun parity/layoutMatrixCli.ts [--reference <id>] [--refresh-reference] [--headed] [--reuse-server] [--output <report.json>]
+
+Each generated case contains invented values only. Reference exports are cached
+by fixture hash; pass --refresh-reference after changing the environment. Page,
+page-size, and reliable line-flow failures make the command fail. Raw pixel
+differences and geometry drift remain advisory diagnostics.
+`;
+
+const writeCaseCorpus = async (directory: string): Promise<string[]> => {
+  const paths: string[] = [];
+  const scenarios = buildLayoutInteractionMatrix();
+  for (const scenario of scenarios) {
+    const filePath = path.join(directory, `${scenario.id}.docx`);
+    // oxlint-disable-next-line no-await-in-loop -- deterministic fixture generation is bounded to the matrix size
+    await Bun.write(filePath, await buildLayoutInteractionCaseFixture(scenario));
+    paths.push(filePath);
+  }
+  return paths;
+};
+
+const printSummary = (report: ReturnType<typeof summarizeLayoutMatrix>): void => {
+  const { summary } = report;
+  console.log(
+    `\nLayout matrix: ${summary.total} cases, ${summary.fail} required failure${summary.fail === 1 ? "" : "s"}, ${summary.advisory} advisory, ${summary.pass} exact.`,
+  );
+  if (report.requiredInteractionClusters.length === 0) return;
+  console.log("Required interaction clusters:");
+  for (const cluster of report.requiredInteractionClusters.slice(0, TOP_CLUSTER_LIMIT)) {
+    console.log(
+      `  ${cluster.pair}: ${cluster.failingCases} case${cluster.failingCases === 1 ? "" : "s"}`,
+    );
+  }
+};
+
+type WriteLayoutMatrixArtifactsOptions = {
+  report: ReturnType<typeof summarizeLayoutMatrix>;
+  outputPath: string;
+  writeVisualReport: () => Promise<string>;
+};
+
+export const writeLayoutMatrixArtifacts = async ({
+  report,
+  outputPath,
+  writeVisualReport,
+}: WriteLayoutMatrixArtifactsOptions): Promise<{ htmlPath: string; outputPath: string }> => {
+  const htmlPath = await writeVisualReport();
+  const resolvedOutputPath = path.resolve(outputPath);
+  await mkdir(path.dirname(resolvedOutputPath), { recursive: true });
+  await Bun.write(resolvedOutputPath, `${JSON.stringify(report, null, 2)}\n`);
+  return { htmlPath, outputPath: resolvedOutputPath };
+};
+
+const run = async (command: Extract<LayoutMatrixCliCommand, { type: "run" }>): Promise<number> => {
+  const renderer = getReferenceRenderer(command.referenceId);
+  if (!(await renderer.isAvailable())) {
+    throw layoutMatrixError(`${renderer.displayName} and mutool are required.`);
+  }
+  const workDirectory = await mkdtemp(path.join(tmpdir(), "folio-layout-matrix-"));
+  try {
+    const docs = await writeCaseCorpus(workDirectory);
+    const flags: RunPipelineOptions = {
+      refreshReference: command.refreshReference,
+      referenceId: command.referenceId,
+      headed: command.headed,
+      reuseServer: command.reuseServer,
+    };
+    const { results, paragraphsByDoc, assets, failures } = await runPipeline(docs, flags, renderer);
+    if (failures.length > 0) {
+      const ids = failures.map(({ file }) => path.basename(file, ".docx")).join(", ");
+      throw layoutMatrixError(`Matrix infrastructure failed for: ${ids}.`);
+    }
+    const referenceVersion = (await renderer.getVersion()) ?? undefined;
+    const corpusReport: CorpusReport = {
+      generatedAt: new Date().toISOString(),
+      reference: {
+        id: renderer.id,
+        displayName: renderer.displayName,
+        ...(referenceVersion === undefined ? {} : { version: referenceVersion }),
+      },
+      results,
+      clusters: clusterCorpus(results, paragraphsByDoc),
+    };
+    const report = summarizeLayoutMatrix(corpusReport, buildLayoutInteractionMatrix());
+    const { htmlPath, outputPath } = await writeLayoutMatrixArtifacts({
+      report,
+      outputPath: command.outputPath,
+      writeVisualReport: async () => await writeHtmlReport(corpusReport, assets),
+    });
+    printSummary(report);
+    console.log(`Matrix JSON: ${outputPath}`);
+    console.log(`Visual report: ${htmlPath}`);
+    return report.summary.fail === 0 ? EXIT_OK : EXIT_DIVERGENT;
+  } finally {
+    await rm(workDirectory, { recursive: true, force: true });
+  }
+};
+
+export const runLayoutMatrixCli = async (argv: string[]): Promise<number> => {
+  const command = parseLayoutMatrixCliArgs(argv);
+  if (command.type === "help") {
+    console.log(HELP_TEXT);
+    return EXIT_OK;
+  }
+  return await run(command);
+};
+
+if (import.meta.main) {
+  try {
+    process.exitCode = await runLayoutMatrixCli(process.argv.slice(2));
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    console.error(`Layout matrix failed: ${err.name}: ${err.message}`);
+    process.exitCode = EXIT_INFRA_FAILURE;
+  }
+}


### PR DESCRIPTION
## Summary

- run each generated pairwise layout case as an isolated deterministic document
- compare Folio with an explicitly selected reference renderer and retain case-level visual diagnostics
- gate structural page and line-flow failures while keeping environment-sensitive raster drift advisory
- aggregate failing feature pairs and persist a machine-readable local report