### PR TITLE
fix(core): keep structural table grids aligned

### DIFF
--- a/.changeset/clean-structural-table-grids.md
+++ b/.changeset/clean-structural-table-grids.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep table-grid widths aligned when accepting or directly applying column removals.

--- a/packages/core/src/ai-edits/aiEdits.test.ts
+++ b/packages/core/src/ai-edits/aiEdits.test.ts
@@ -47,6 +47,10 @@ const schema = new Schema({
       content: "tableRow+",
       group: "block",
       tableRole: "table",
+      attrs: {
+        columnWidths: { default: null },
+        _originalFormatting: { default: null },
+      },
     },
     tableRow: {
       content: "tableCell*",
@@ -3517,7 +3521,19 @@ describe("Folio AI edit operations", () => {
     );
     const state = EditorState.create({
       schema,
-      doc: schema.node("doc", null, [schema.node("table", null, rows)]),
+      doc: schema.node("doc", null, [
+        schema.node(
+          "table",
+          {
+            columnWidths: [1200, 1800, 2400],
+            _originalFormatting: {
+              sourceXml: "<w:tblPr/>",
+              gridSourceXml: "<w:tblGrid/>",
+            },
+          },
+          rows,
+        ),
+      ]),
     });
     const view = makeView(state);
 
@@ -3538,6 +3554,71 @@ describe("Folio AI edit operations", () => {
     ]);
     expect(TableMap.get(view.state.doc.child(0)).width).toBe(1);
     expect(view.state.doc.child(0).textContent).toBe("AD");
+    expect(view.state.doc.child(0).attrs["columnWidths"]).toEqual([1200]);
+    expect(view.state.doc.child(0).attrs["_originalFormatting"]).toEqual({
+      sourceXml: "<w:tblPr/>",
+    });
+  });
+
+  test("direct deletion splices the first, middle, or last authored grid width", () => {
+    for (const { removedIndex, expectedWidths } of [
+      { removedIndex: 0, expectedWidths: [1800, 2400] },
+      { removedIndex: 1, expectedWidths: [1200, 2400] },
+      { removedIndex: 2, expectedWidths: [1200, 1800] },
+    ]) {
+      const rows = [
+        ["A", "B", "C"],
+        ["D", "E", "F"],
+      ].map((texts, rowIndex) =>
+        schema.node(
+          "tableRow",
+          null,
+          texts.map((text, columnIndex) =>
+            schema.node("tableCell", null, [
+              schema.node("paragraph", { paraId: `grid-${rowIndex}-${columnIndex}` }, [
+                schema.text(text),
+              ]),
+            ]),
+          ),
+        ),
+      );
+      const state = EditorState.create({
+        schema,
+        doc: schema.node("doc", null, [
+          schema.node(
+            "table",
+            {
+              columnWidths: [1200, 1800, 2400],
+              _originalFormatting: {
+                sourceXml: "<w:tblPr/>",
+                gridSourceXml: "<w:tblGrid/>",
+              },
+            },
+            rows,
+          ),
+        ]),
+      });
+      const view = makeView(state);
+
+      const result = applyFolioAIEditOperations({
+        view,
+        snapshot: createFolioAIEditSnapshot(state.doc),
+        operations: [
+          {
+            id: "delete-column",
+            type: "deleteTableColumn",
+            blockId: `grid-0-${removedIndex}`,
+          },
+        ],
+        mode: "direct",
+      });
+
+      expect(result.skipped).toEqual([]);
+      expect(view.state.doc.child(0).attrs["columnWidths"]).toEqual(expectedWidths);
+      expect(view.state.doc.child(0).attrs["_originalFormatting"]).toEqual({
+        sourceXml: "<w:tblPr/>",
+      });
+    }
   });
 
   test("keeps insertion and deletion targets stable at the same column boundary", () => {

--- a/packages/core/src/ai-edits/table-cell-grid-revision.test.ts
+++ b/packages/core/src/ai-edits/table-cell-grid-revision.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import { parseDocx } from "../docx/parser";
+import { createDocx } from "../docx/rezip";
+import type { Table, TableCell, TrackedChangeInfo } from "../types/document";
+import { createEmptyDocument } from "../utils/createDocument";
+import { FolioDocxReviewer } from "./headless";
+
+const GRID_WIDTHS = [1200, 1800, 2400, 4680];
+const GRID_SOURCE =
+  '<w:tblGrid><w:gridCol w:w="1200"/><w:gridCol w:w="1800"/><w:gridCol w:w="2400"/><w:gridCol w:w="4680"/></w:tblGrid>';
+const UNCHANGED_GRID_SOURCE =
+  '<w:tblGrid><w:gridCol w:w="3000"/><w:gridCol w:w="7000"/></w:tblGrid>';
+const TABLE_SOURCE = '<w:tblPr><w:tblW w:w="0" w:type="auto"/></w:tblPr>';
+
+const revision = (id: number): TrackedChangeInfo => ({
+  id,
+  author: "Reviewer",
+  date: "2026-01-02T03:04:05Z",
+});
+
+const cell = (text: string, revisionId?: number): TableCell => ({
+  type: "tableCell",
+  ...(revisionId !== undefined && {
+    structuralChange: { type: "tableCellDeletion", info: revision(revisionId) },
+  }),
+  content: [
+    {
+      type: "paragraph",
+      content: [{ type: "run", content: [{ type: "text", text }] }],
+    },
+  ],
+});
+
+const table = ({
+  widths,
+  gridSourceXml,
+  cells,
+}: {
+  widths: number[];
+  gridSourceXml: string;
+  cells: TableCell[];
+}): Table => ({
+  type: "table",
+  columnWidths: widths,
+  formatting: { sourceXml: TABLE_SOURCE, gridSourceXml },
+  rows: [{ type: "tableRow", cells }],
+});
+
+const buildSource = (): Promise<ArrayBuffer> => {
+  const template = createEmptyDocument();
+  return createDocx({
+    ...template,
+    package: {
+      ...template.package,
+      document: {
+        ...template.package.document,
+        content: [
+          table({
+            widths: GRID_WIDTHS,
+            gridSourceXml: GRID_SOURCE,
+            cells: [cell("A", 101), cell("B", 102), cell("C", 103), cell("Survivor")],
+          }),
+          table({
+            widths: [3000, 7000],
+            gridSourceXml: UNCHANGED_GRID_SOURCE,
+            cells: [cell("Unaffected left"), cell("Unaffected right")],
+          }),
+        ],
+      },
+    },
+  });
+};
+
+const documentXml = async (buffer: ArrayBuffer): Promise<string> => {
+  const entry = (await JSZip.loadAsync(buffer)).file("word/document.xml");
+  if (!entry) {
+    throw new Error("expected word/document.xml");
+  }
+  return entry.async("string");
+};
+
+const gridsFrom = (xml: string): string[] => xml.match(/<w:tblGrid>.*?<\/w:tblGrid>/gu) ?? [];
+
+const tablesFrom = async (buffer: ArrayBuffer): Promise<Table[]> => {
+  const parsed = await parseDocx(buffer, { detectVariables: false, preloadFonts: false });
+  return parsed.package.document.content.filter((block): block is Table => block.type === "table");
+};
+
+describe("tracked table cell grid provenance", () => {
+  test("accepting cell removals is a save/reopen fixed point", async () => {
+    const reviewer = await FolioDocxReviewer.fromBuffer(await buildSource());
+
+    expect(reviewer.acceptAll()).toBe(3);
+    const once = await reviewer.toBuffer();
+    const tables = await tablesFrom(once);
+
+    expect(tables.at(0)?.columnWidths).toEqual([4680]);
+    expect(tables.at(0)?.rows.at(0)?.cells).toHaveLength(1);
+    expect(tables.at(0)?.formatting?.gridSourceXml).toBe(
+      '<w:tblGrid><w:gridCol w:w="4680"/></w:tblGrid>',
+    );
+    expect(tables.at(1)?.columnWidths).toEqual([3000, 7000]);
+    expect(tables.at(1)?.formatting?.gridSourceXml).toBe(UNCHANGED_GRID_SOURCE);
+    expect(gridsFrom(await documentXml(once))).toEqual([
+      '<w:tblGrid><w:gridCol w:w="4680"/></w:tblGrid>',
+      UNCHANGED_GRID_SOURCE,
+    ]);
+
+    const reopened = await FolioDocxReviewer.fromBuffer(once);
+    const twice = await reopened.toBuffer();
+    expect(await documentXml(twice)).toBe(await documentXml(once));
+  });
+
+  test("rejecting cell removals preserves both table grids verbatim", async () => {
+    const reviewer = await FolioDocxReviewer.fromBuffer(await buildSource());
+
+    expect(reviewer.rejectAll()).toBe(3);
+    const once = await reviewer.toBuffer();
+    const tables = await tablesFrom(once);
+
+    expect(tables.at(0)?.columnWidths).toEqual(GRID_WIDTHS);
+    expect(tables.at(0)?.rows.at(0)?.cells).toHaveLength(4);
+    expect(tables.at(0)?.formatting?.gridSourceXml).toBe(GRID_SOURCE);
+    expect(tables.at(1)?.columnWidths).toEqual([3000, 7000]);
+    expect(tables.at(1)?.formatting?.gridSourceXml).toBe(UNCHANGED_GRID_SOURCE);
+    expect(gridsFrom(await documentXml(once))).toEqual([GRID_SOURCE, UNCHANGED_GRID_SOURCE]);
+
+    const reopened = await FolioDocxReviewer.fromBuffer(once);
+    const twice = await reopened.toBuffer();
+    expect(await documentXml(twice)).toBe(await documentXml(once));
+  });
+});

--- a/packages/core/src/ai-edits/table-row-column-mutations.ts
+++ b/packages/core/src/ai-edits/table-row-column-mutations.ts
@@ -10,6 +10,7 @@ import {
 } from "prosemirror-tables";
 
 import { markStructuralChange } from "../prosemirror/extensions/features/ParagraphChangeTrackerExtension";
+import { reconcileTableGridAfterColumnRemoval } from "../prosemirror/tableGridMutation";
 import { stripBlockIdentityAttrs } from "./block-identity";
 import { tableRowFromTemplate, type TableStructureRevision } from "./table-template";
 import {
@@ -354,6 +355,12 @@ export const applyTableColumnDeletion = ({
     },
     columnIndex,
   );
+  reconcileTableGridAfterColumnRemoval({
+    tr,
+    tablePosition,
+    previousTable: table,
+    removedColumn: columnIndex,
+  });
   return applied(tr, null);
 };
 

--- a/packages/core/src/prosemirror/commands/comments.test.ts
+++ b/packages/core/src/prosemirror/commands/comments.test.ts
@@ -4,6 +4,7 @@ import { Schema } from "prosemirror-model";
 import type { Node as PMNode } from "prosemirror-model";
 import { EditorState, TextSelection } from "prosemirror-state";
 import type { Command, Transaction } from "prosemirror-state";
+import { TableMap } from "prosemirror-tables";
 
 import {
   acceptChange,
@@ -65,7 +66,15 @@ const tableSchema = new Schema({
     doc: { content: "block+" },
     paragraph: { content: "text*", group: "block" },
     text: { group: "inline" },
-    table: { content: "tableRow+", group: "block", tableRole: "table" },
+    table: {
+      content: "tableRow+",
+      group: "block",
+      tableRole: "table",
+      attrs: {
+        columnWidths: { default: null },
+        _originalFormatting: { default: null },
+      },
+    },
     tableRow: {
       content: "tableCell*",
       tableRole: "row",
@@ -105,6 +114,10 @@ const tableSchema = new Schema({
 
 const REV_A_ATTRS = { revisionId: 1, author: "AI", date: "2026-01-01" };
 const REV_B_ATTRS = { revisionId: 2, author: "AI", date: "2026-01-02" };
+const TABLE_GRID_FORMATTING = {
+  sourceXml: "<w:tblPr/>",
+  gridSourceXml: "<w:tblGrid/>",
+};
 
 const makeStateWithMarks = () => {
   // One paragraph with two NON-overlapping insertion spans —
@@ -400,12 +413,19 @@ describe("table cell structural revision resolution", () => {
     EditorState.create({
       schema: tableSchema,
       doc: tableSchema.node("doc", null, [
-        tableSchema.node("table", null, [
-          tableSchema.node("tableRow", null, [
-            cell("Original", undefined),
-            cell("Changed", marker),
-          ]),
-        ]),
+        tableSchema.node(
+          "table",
+          {
+            columnWidths: [1200, 1800],
+            _originalFormatting: TABLE_GRID_FORMATTING,
+          },
+          [
+            tableSchema.node("tableRow", null, [
+              cell("Original", undefined),
+              cell("Changed", marker),
+            ]),
+          ],
+        ),
       ]),
     });
 
@@ -420,9 +440,12 @@ describe("table cell structural revision resolution", () => {
     );
 
     expect(acceptAIEditRevision(71)(view.state, view.dispatch)).toBe(true);
-    const row = view.state.doc.firstChild?.firstChild;
+    const table = view.state.doc.firstChild;
+    const row = table?.firstChild;
     expect(row?.childCount).toBe(2);
     expect(row?.child(1).attrs["cellMarker"]).toBeNull();
+    expect(table?.attrs["columnWidths"]).toEqual([1200, 1800]);
+    expect(table?.attrs["_originalFormatting"]).toEqual(TABLE_GRID_FORMATTING);
   });
 
   test("reject removes an inserted cell without consuming another cell revision", () => {
@@ -471,13 +494,251 @@ describe("table cell structural revision resolution", () => {
     };
     const accepting = dispatcher(stateWithCells(marker));
     expect(acceptAIEditRevision(74)(accepting.state, accepting.dispatch)).toBe(true);
-    expect(accepting.state.doc.firstChild?.firstChild?.textContent).toBe("Original");
+    const acceptedTable = accepting.state.doc.firstChild;
+    expect(acceptedTable?.firstChild?.textContent).toBe("Original");
+    expect(acceptedTable?.attrs["columnWidths"]).toEqual([1200]);
+    expect(acceptedTable?.attrs["_originalFormatting"]).toEqual({ sourceXml: "<w:tblPr/>" });
 
     const rejecting = dispatcher(stateWithCells(marker));
     expect(rejectAIEditRevision(74)(rejecting.state, rejecting.dispatch)).toBe(true);
-    const row = rejecting.state.doc.firstChild?.firstChild;
+    const rejectedTable = rejecting.state.doc.firstChild;
+    const row = rejectedTable?.firstChild;
     expect(row?.textContent).toBe("OriginalChanged");
     expect(row?.child(1).attrs["cellMarker"]).toBeNull();
+    expect(rejectedTable?.attrs["columnWidths"]).toEqual([1200, 1800]);
+    expect(rejectedTable?.attrs["_originalFormatting"]).toEqual(TABLE_GRID_FORMATTING);
+    expect(TABLE_GRID_FORMATTING).toEqual({
+      sourceXml: "<w:tblPr/>",
+      gridSourceXml: "<w:tblGrid/>",
+    });
+  });
+
+  test("structural cell removal keeps the surviving column's grid provenance", () => {
+    const deletedCell = (text: string, revisionId: number) =>
+      cell(text, {
+        cellMarker: {
+          kind: "del",
+          info: { revisionId, author: "Reviewer", date: "2026-07-16" },
+        },
+      });
+    const view = dispatcher(
+      EditorState.create({
+        schema: tableSchema,
+        doc: tableSchema.node("doc", null, [
+          tableSchema.node(
+            "table",
+            {
+              columnWidths: [1200, 1800, 2400, 4680],
+              _originalFormatting: {
+                sourceXml: "<w:tblPr/>",
+                gridSourceXml: "<w:tblGrid>stale after a structural edit</w:tblGrid>",
+              },
+            },
+            [
+              tableSchema.node("tableRow", null, [
+                deletedCell("A", 81),
+                deletedCell("B", 82),
+                deletedCell("C", 83),
+                cell("Survivor", undefined),
+              ]),
+            ],
+          ),
+        ]),
+      }),
+    );
+
+    expect(acceptAllChanges()(view.state, view.dispatch)).toBe(true);
+
+    const table = view.state.doc.firstChild;
+    expect(table?.attrs["columnWidths"]).toEqual([4680]);
+    expect(table?.attrs["_originalFormatting"]).toEqual({ sourceXml: "<w:tblPr/>" });
+    expect(table?.firstChild?.textContent).toBe("Survivor");
+    expect(() => view.state.doc.check()).not.toThrow();
+  });
+
+  for (const { label, removedIndex, expectedWidths } of [
+    { label: "first", removedIndex: 0, expectedWidths: [1800, 2400] },
+    { label: "middle", removedIndex: 1, expectedWidths: [1200, 2400] },
+    { label: "last", removedIndex: 2, expectedWidths: [1200, 1800] },
+  ]) {
+    test(`removing the ${label} column splices that authored grid width`, () => {
+      const labels = ["First", "Middle", "Last"];
+      const marker = {
+        cellMarker: {
+          kind: "del" as const,
+          info: { revisionId: 84, author: "Reviewer", date: "2026-07-16" },
+        },
+      };
+      const view = dispatcher(
+        EditorState.create({
+          schema: tableSchema,
+          doc: tableSchema.node("doc", null, [
+            tableSchema.node(
+              "table",
+              {
+                columnWidths: [1200, 1800, 2400],
+                _originalFormatting: TABLE_GRID_FORMATTING,
+              },
+              [
+                tableSchema.node(
+                  "tableRow",
+                  null,
+                  labels.map((text, index) =>
+                    cell(text, index === removedIndex ? marker : undefined),
+                  ),
+                ),
+              ],
+            ),
+          ]),
+        }),
+      );
+
+      expect(acceptAIEditRevision(84)(view.state, view.dispatch)).toBe(true);
+
+      const table = view.state.doc.firstChild;
+      expect(table?.attrs["columnWidths"]).toEqual(expectedWidths);
+      expect(table?.attrs["_originalFormatting"]).toEqual({ sourceXml: "<w:tblPr/>" });
+      expect(table?.textContent).toBe(labels.filter((_, index) => index !== removedIndex).join(""));
+    });
+  }
+
+  test("an inconsistent authored grid is invalidated when topology changes", () => {
+    const view = dispatcher(
+      EditorState.create({
+        schema: tableSchema,
+        doc: tableSchema.node("doc", null, [
+          tableSchema.node(
+            "table",
+            {
+              columnWidths: [1200, 1800],
+              _originalFormatting: TABLE_GRID_FORMATTING,
+            },
+            [
+              tableSchema.node("tableRow", null, [
+                cell("First", undefined),
+                cell("Removed", {
+                  cellMarker: {
+                    kind: "del",
+                    info: { revisionId: 85, author: "Reviewer", date: "2026-07-16" },
+                  },
+                }),
+                cell("Last", undefined),
+              ]),
+            ],
+          ),
+        ]),
+      }),
+    );
+
+    expect(acceptAIEditRevision(85)(view.state, view.dispatch)).toBe(true);
+
+    const table = view.state.doc.firstChild;
+    if (!table) {
+      throw new Error("expected a table");
+    }
+    expect(table?.attrs["columnWidths"]).toBeNull();
+    expect(table?.attrs["_originalFormatting"]).toEqual({ sourceXml: "<w:tblPr/>" });
+    expect(TableMap.get(table).width).toBe(2);
+  });
+
+  test("a cell removal that leaves the table width unchanged preserves grid provenance", () => {
+    const view = dispatcher(
+      EditorState.create({
+        schema: tableSchema,
+        doc: tableSchema.node("doc", null, [
+          tableSchema.node(
+            "table",
+            {
+              columnWidths: [1200, 1800, 2400],
+              _originalFormatting: TABLE_GRID_FORMATTING,
+            },
+            [
+              tableSchema.node("tableRow", null, [
+                cell("A", undefined),
+                cell("B", undefined),
+                cell("C", undefined),
+              ]),
+              tableSchema.node("tableRow", null, [
+                cell("D", undefined),
+                cell("Removed", {
+                  cellMarker: {
+                    kind: "del",
+                    info: { revisionId: 86, author: "Reviewer", date: "2026-07-16" },
+                  },
+                }),
+                cell("F", undefined),
+              ]),
+            ],
+          ),
+        ]),
+      }),
+    );
+
+    expect(acceptAIEditRevision(86)(view.state, view.dispatch)).toBe(true);
+
+    const table = view.state.doc.firstChild;
+    if (!table) {
+      throw new Error("expected a table");
+    }
+    expect(TableMap.get(table).width).toBe(3);
+    expect(table?.attrs["columnWidths"]).toEqual([1200, 1800, 2400]);
+    expect(table?.attrs["_originalFormatting"]).toEqual(TABLE_GRID_FORMATTING);
+  });
+
+  test("nested cell removal updates only the nested table grid", () => {
+    const nestedTable = tableSchema.node(
+      "table",
+      {
+        columnWidths: [1200, 1800, 2400],
+        _originalFormatting: TABLE_GRID_FORMATTING,
+      },
+      [
+        tableSchema.node("tableRow", null, [
+          cell("Nested first", undefined),
+          cell("Nested removed", {
+            cellMarker: {
+              kind: "del",
+              info: { revisionId: 87, author: "Reviewer", date: "2026-07-16" },
+            },
+          }),
+          cell("Nested last", undefined),
+        ]),
+      ],
+    );
+    const outerFormatting = {
+      sourceXml: '<w:tblPr><w:tblStyle w:val="Outer"/></w:tblPr>',
+      gridSourceXml: '<w:tblGrid><w:gridCol w:w="9000"/></w:tblGrid>',
+    };
+    const view = dispatcher(
+      EditorState.create({
+        schema: tableSchema,
+        doc: tableSchema.node("doc", null, [
+          tableSchema.node(
+            "table",
+            { columnWidths: [9000], _originalFormatting: outerFormatting },
+            [
+              tableSchema.node("tableRow", null, [
+                tableSchema.node("tableCell", null, [
+                  tableSchema.node("paragraph", null, [tableSchema.text("Outer")]),
+                  nestedTable,
+                ]),
+              ]),
+            ],
+          ),
+        ]),
+      }),
+    );
+
+    expect(acceptAIEditRevision(87)(view.state, view.dispatch)).toBe(true);
+
+    const outerTable = view.state.doc.firstChild;
+    const resolvedNestedTable = outerTable?.firstChild?.firstChild?.child(1);
+    expect(outerTable?.attrs["columnWidths"]).toEqual([9000]);
+    expect(outerTable?.attrs["_originalFormatting"]).toEqual(outerFormatting);
+    expect(resolvedNestedTable?.attrs["columnWidths"]).toEqual([1200, 2400]);
+    expect(resolvedNestedTable?.attrs["_originalFormatting"]).toEqual({
+      sourceXml: "<w:tblPr/>",
+    });
   });
 
   test("bulk accept and reject resolve inserted cells", () => {
@@ -508,16 +769,23 @@ describe("table cell structural revision resolution", () => {
       EditorState.create({
         schema: tableSchema,
         doc: tableSchema.node("doc", null, [
-          tableSchema.node("table", null, [
-            tableSchema.node("tableRow", null, [
-              cell("First", undefined),
-              markedCell("Pending first", 78),
-            ]),
-            tableSchema.node("tableRow", null, [
-              cell("Second", undefined),
-              markedCell("Pending second", 79),
-            ]),
-          ]),
+          tableSchema.node(
+            "table",
+            {
+              columnWidths: [1200, 1800],
+              _originalFormatting: TABLE_GRID_FORMATTING,
+            },
+            [
+              tableSchema.node("tableRow", null, [
+                cell("First", undefined),
+                markedCell("Pending first", 78),
+              ]),
+              tableSchema.node("tableRow", null, [
+                cell("Second", undefined),
+                markedCell("Pending second", 79),
+              ]),
+            ],
+          ),
         ]),
       }),
     );
@@ -526,6 +794,8 @@ describe("table cell structural revision resolution", () => {
     const table = view.state.doc.firstChild;
     expect(table?.child(0).textContent).toBe("First");
     expect(table?.child(1).textContent).toBe("Second");
+    expect(table?.attrs["columnWidths"]).toEqual([1200]);
+    expect(table?.attrs["_originalFormatting"]).toEqual({ sourceXml: "<w:tblPr/>" });
     expect(() => view.state.doc.check()).not.toThrow();
   });
 

--- a/packages/core/src/prosemirror/commands/comments.test.ts
+++ b/packages/core/src/prosemirror/commands/comments.test.ts
@@ -602,6 +602,50 @@ describe("table cell structural revision resolution", () => {
     });
   }
 
+  test("removing a spanning cell splices every physical grid column it owned", () => {
+    const view = dispatcher(
+      EditorState.create({
+        schema: tableSchema,
+        doc: tableSchema.node("doc", null, [
+          tableSchema.node(
+            "table",
+            {
+              columnWidths: [900, 1100, 2400],
+              _originalFormatting: TABLE_GRID_FORMATTING,
+            },
+            [
+              tableSchema.node("tableRow", null, [
+                tableSchema.node(
+                  "tableCell",
+                  {
+                    colspan: 2,
+                    colwidth: [900, 1100],
+                    cellMarker: {
+                      kind: "del",
+                      info: { revisionId: 88, author: "Reviewer", date: "2026-07-16" },
+                    },
+                  },
+                  [tableSchema.node("paragraph", null, [tableSchema.text("Removed")])],
+                ),
+                cell("Survivor", undefined),
+              ]),
+            ],
+          ),
+        ]),
+      }),
+    );
+
+    expect(acceptAIEditRevision(88)(view.state, view.dispatch)).toBe(true);
+
+    const table = view.state.doc.firstChild;
+    if (!table) {
+      throw new Error("expected a table");
+    }
+    expect(table.attrs["columnWidths"]).toEqual([2400]);
+    expect(table.attrs["_originalFormatting"]).toEqual({ sourceXml: "<w:tblPr/>" });
+    expect(TableMap.get(table).width).toBe(1);
+  });
+
   test("an inconsistent authored grid is invalidated when topology changes", () => {
     const view = dispatcher(
       EditorState.create({

--- a/packages/core/src/prosemirror/commands/comments.test.ts
+++ b/packages/core/src/prosemirror/commands/comments.test.ts
@@ -1153,6 +1153,62 @@ describe("table cell structural revision resolution", () => {
     expect(acceptingDeletion.state.doc.firstChild?.type.name).toBe("paragraph");
     expect(() => acceptingDeletion.state.doc.check()).not.toThrow();
   });
+
+  test("removing a final table cell cannot transfer its grid onto an adjacent table", () => {
+    const adjacentFormatting = {
+      sourceXml: '<w:tblPr><w:tblStyle w:val="Adjacent"/></w:tblPr>',
+      gridSourceXml: '<w:tblGrid><w:gridCol w:w="3000"/><w:gridCol w:w="7000"/></w:tblGrid>',
+    };
+    const view = dispatcher(
+      EditorState.create({
+        schema: tableSchema,
+        doc: tableSchema.node("doc", null, [
+          tableSchema.node(
+            "table",
+            {
+              columnWidths: [900, 1000, 1100],
+              _originalFormatting: TABLE_GRID_FORMATTING,
+            },
+            [
+              tableSchema.node("tableRow", null, [
+                tableSchema.node(
+                  "tableCell",
+                  {
+                    colspan: 3,
+                    colwidth: [900, 1000, 1100],
+                    cellMarker: {
+                      kind: "del",
+                      info: { revisionId: 89, author: "Reviewer", date: "2026-07-16" },
+                    },
+                  },
+                  [tableSchema.node("paragraph", null, [tableSchema.text("Removed table")])],
+                ),
+              ]),
+            ],
+          ),
+          tableSchema.node(
+            "table",
+            { columnWidths: [3000, 7000], _originalFormatting: adjacentFormatting },
+            [
+              tableSchema.node("tableRow", null, [
+                cell("Adjacent left", undefined),
+                cell("Adjacent right", undefined),
+              ]),
+            ],
+          ),
+        ]),
+      }),
+    );
+
+    expect(acceptAIEditRevision(89)(view.state, view.dispatch)).toBe(true);
+
+    const adjacentTable = view.state.doc.firstChild;
+    expect(adjacentTable?.type.name).toBe("table");
+    expect(adjacentTable?.textContent).toBe("Adjacent leftAdjacent right");
+    expect(adjacentTable?.attrs["columnWidths"]).toEqual([3000, 7000]);
+    expect(adjacentTable?.attrs["_originalFormatting"]).toEqual(adjacentFormatting);
+    expect(() => view.state.doc.check()).not.toThrow();
+  });
 });
 
 describe("findChangeAtPosition", () => {

--- a/packages/core/src/prosemirror/commands/comments.ts
+++ b/packages/core/src/prosemirror/commands/comments.ts
@@ -45,6 +45,7 @@ import { RUN_FORMATTING_MARK_NAMES } from "../runFormattingMarkNames";
 import { setParagraphAttrsWithRebasedRunFormatting } from "../rebaseParagraphRunFormatting";
 import type { ParagraphPropertyChangeAttrs } from "../schema/nodes";
 import { getTableCellMergeChange } from "../tableCellMergeRevision";
+import { reconcileTableGridAfterColumnRemoval } from "../tableGridMutation";
 import {
   hasMatchingCollapsedTableCellMerge,
   resolveCollapsedTableCellMerge,
@@ -898,11 +899,31 @@ function deleteTableCellAt(tr: Transaction, cellPos: number): void {
   if (row.type.spec["tableRole"] !== "row") {
     return;
   }
+  const tableDepth = resolved.depth - 1;
+  const table = resolved.node(tableDepth);
+  if (table.type.spec["tableRole"] !== "table") {
+    return;
+  }
+  const tablePosition = resolved.before(tableDepth);
+  const cellOffset = cellPos - resolved.start(tableDepth);
+  const removedColumn = TableMap.get(table).findCell(cellOffset).left;
   if (row.childCount > 1) {
     tr.delete(cellPos, cellPos + cell.nodeSize);
+    reconcileTableGridAfterColumnRemoval({
+      tr,
+      tablePosition,
+      previousTable: table,
+      removedColumn,
+    });
     return;
   }
   deleteTableRowAt(tr, resolved.start() - 1);
+  reconcileTableGridAfterColumnRemoval({
+    tr,
+    tablePosition,
+    previousTable: table,
+    removedColumn,
+  });
 }
 
 function deleteTableRowAt(tr: Transaction, rowPos: number): void {

--- a/packages/core/src/prosemirror/commands/comments.ts
+++ b/packages/core/src/prosemirror/commands/comments.ts
@@ -917,6 +917,10 @@ function deleteTableCellAt(tr: Transaction, cellPos: number): void {
     });
     return;
   }
+  if (table.childCount === 1) {
+    deleteTableRowAt(tr, resolved.start() - 1);
+    return;
+  }
   deleteTableRowAt(tr, resolved.start() - 1);
   reconcileTableGridAfterColumnRemoval({
     tr,

--- a/packages/core/src/prosemirror/tableGridMutation.ts
+++ b/packages/core/src/prosemirror/tableGridMutation.ts
@@ -1,0 +1,59 @@
+import type { Node as PMNode } from "prosemirror-model";
+import type { Transaction } from "prosemirror-state";
+import { TableMap } from "prosemirror-tables";
+
+import { expectTableAttrs, mergeTableAttrs } from "./attrs";
+
+type ReconcileTableGridAfterColumnRemovalOptions = {
+  tr: Transaction;
+  tablePosition: number;
+  previousTable: PMNode;
+  removedColumn: number;
+};
+
+/**
+ * Keep the editable table grid aligned with a physical column removal.
+ *
+ * `prosemirror-tables` owns cell topology, but Folio separately retains the
+ * authored `w:tblGrid` widths and source XML on the table node. A topology
+ * edit that leaves those attrs untouched serializes a new row shape against
+ * the old grid; reopening then has to interpret surviving cells as spans.
+ */
+export const reconcileTableGridAfterColumnRemoval = ({
+  tr,
+  tablePosition,
+  previousTable,
+  removedColumn,
+}: ReconcileTableGridAfterColumnRemovalOptions): void => {
+  const previousColumnCount = TableMap.get(previousTable).width;
+  const table = tr.doc.nodeAt(tablePosition);
+  if (!table || table.type.spec["tableRole"] !== "table") {
+    return;
+  }
+
+  const columnCount = TableMap.get(table).width;
+  if (columnCount >= previousColumnCount) {
+    return;
+  }
+
+  const removedColumnCount = previousColumnCount - columnCount;
+  const previousWidths = expectTableAttrs(previousTable).columnWidths;
+  const columnWidths =
+    previousWidths?.length === previousColumnCount
+      ? previousWidths.toSpliced(removedColumn, removedColumnCount)
+      : undefined;
+  const formatting = expectTableAttrs(table)._originalFormatting;
+  const originalFormatting = formatting ? { ...formatting } : undefined;
+  if (originalFormatting) {
+    delete originalFormatting.gridSourceXml;
+  }
+
+  tr.setNodeMarkup(
+    tablePosition,
+    undefined,
+    mergeTableAttrs(table, {
+      columnWidths: columnWidths?.length === columnCount ? columnWidths : undefined,
+      _originalFormatting: originalFormatting,
+    }),
+  );
+};


### PR DESCRIPTION
## Summary

- reconcile captured table-grid widths after a physical column removal
- discard stale serialized grid XML while retaining unrelated authored table properties
- apply the invariant to direct document-operation edits and tracked cell-resolution paths
- prevent a removed table from transferring grid provenance to a sibling that shifts into its position
- cover sequential, first/middle/last, spanning, inconsistent, nested, adjacent-table, accept/reject, and save/reopen cases

## Verification

- 188 focused tests across the affected edit and revision-resolution suites
- core typecheck and build
- targeted lint and formatting checks
- API reports and API/type-cost budgets