### PR TITLE
fix: anchor carets across unpainted positions

### DIFF
--- a/.changeset/calm-cursors-anchor.md
+++ b/.changeset/calm-cursors-anchor.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Anchor carets beside painted text when inline metadata has no visual span.

--- a/packages/core/src/layout-bridge/dom/clickToPositionDom-caret-height.test.ts
+++ b/packages/core/src/layout-bridge/dom/clickToPositionDom-caret-height.test.ts
@@ -105,8 +105,18 @@ class FakeHTMLElement {
   }
 
   private matches(selector: string): boolean {
-    if (selector.includes(".layout-page-content")) {
+    if (selector === ".layout-page-content span[data-pm-start][data-pm-end]") {
       return this.classes.has("layout-run-text");
+    }
+    if (selector === ".layout-page-content .layout-paragraph" || selector === ".layout-paragraph") {
+      return this.classes.has("layout-paragraph");
+    }
+    if (selector === "span[data-pm-start][data-pm-end]") {
+      return (
+        this.classes.has("layout-run-text") &&
+        this.dataset["pmStart"] !== undefined &&
+        this.dataset["pmEnd"] !== undefined
+      );
     }
     if (selector === ".layout-page") {
       return this.classes.has("layout-page");
@@ -241,6 +251,40 @@ const buildCollapsedLeadingSpaceContainer = (): HTMLElement => {
   return container as unknown as HTMLElement;
 };
 
+const buildUnpaintedPrefixContainer = (): HTMLElement => {
+  const container = new FakeHTMLElement();
+  const page = new FakeHTMLElement(["layout-page"]);
+  page.dataset["pageNumber"] = "1";
+  const content = new FakeHTMLElement(["layout-page-content"]);
+  const paragraph = new FakeHTMLElement(
+    ["layout-paragraph"],
+    { left: 20, top: 30, right: 180, bottom: 48, width: 160, height: 18 },
+    18,
+  );
+  paragraph.dataset["pmStart"] = "10";
+  paragraph.dataset["pmEnd"] = "14";
+  const line = new FakeHTMLElement(
+    ["layout-line"],
+    { left: 20, top: 30, right: 180, bottom: 48, width: 160, height: 18 },
+    18,
+  );
+  const emptyTextSlot = new FakeHTMLElement(
+    ["layout-run-text"],
+    { left: 70, top: 30, right: 70, bottom: 48, width: 0, height: 18 },
+    18,
+  );
+  emptyTextSlot.dataset["pmStart"] = "12";
+  emptyTextSlot.dataset["pmEnd"] = "12";
+
+  container.append(page);
+  page.append(content);
+  content.append(paragraph);
+  paragraph.append(line);
+  line.append(emptyTextSlot);
+
+  return container as unknown as HTMLElement;
+};
+
 let originalHTMLElement: unknown;
 let originalNode: unknown;
 
@@ -269,6 +313,12 @@ describe("getCaretPositionFromDom caret height", () => {
     const caret = getCaretPositionFromDom(buildContainer(), 3, rect({}));
 
     expect(caret?.height).toBe(18);
+  });
+
+  test("anchors a caret after an unpainted inline prefix to the first painted text slot", () => {
+    const caret = getCaretPositionFromDom(buildUnpaintedPrefixContainer(), 11, rect({}));
+
+    expect(caret).toEqual({ x: 70, y: 30, height: 18, pageIndex: 0 });
   });
 
   test("falls back to line height when the range reports zero height", () => {

--- a/packages/core/src/layout-bridge/dom/clickToPositionDom-caret-height.test.ts
+++ b/packages/core/src/layout-bridge/dom/clickToPositionDom-caret-height.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
+import { RenderedDomContextImpl } from "../../render-dom/RenderedDomContext";
 import { getCaretPositionFromDom } from "./clickToPositionDom";
 
 class FakeHTMLElement {
@@ -106,7 +107,11 @@ class FakeHTMLElement {
 
   private matches(selector: string): boolean {
     if (selector === ".layout-page-content span[data-pm-start][data-pm-end]") {
-      return this.classes.has("layout-run-text");
+      return (
+        this.classes.has("layout-run-text") &&
+        this.dataset["pmStart"] !== undefined &&
+        this.dataset["pmEnd"] !== undefined
+      );
     }
     if (selector === ".layout-page-content .layout-paragraph" || selector === ".layout-paragraph") {
       return this.classes.has("layout-paragraph");
@@ -251,7 +256,7 @@ const buildCollapsedLeadingSpaceContainer = (): HTMLElement => {
   return container as unknown as HTMLElement;
 };
 
-const buildUnpaintedPrefixContainer = (): HTMLElement => {
+const buildUnpaintedPrefixContainer = (target: "empty" | "tab" = "empty"): HTMLElement => {
   const container = new FakeHTMLElement();
   const page = new FakeHTMLElement(["layout-page"]);
   page.dataset["pageNumber"] = "1";
@@ -265,16 +270,15 @@ const buildUnpaintedPrefixContainer = (): HTMLElement => {
   paragraph.dataset["pmEnd"] = "14";
   const line = new FakeHTMLElement(
     ["layout-line"],
-    { left: 20, top: 30, right: 180, bottom: 48, width: 160, height: 18 },
+    { left: 20, top: 30, right: 180, bottom: 66, width: 160, height: 36 },
     18,
   );
   const emptyTextSlot = new FakeHTMLElement(
-    ["layout-run-text"],
-    { left: 70, top: 30, right: 70, bottom: 48, width: 0, height: 18 },
-    18,
+    target === "tab" ? ["layout-run-text", "layout-run-tab"] : ["layout-run-text"],
+    { left: 70, top: 30, right: 70, bottom: 30, width: 0, height: 0 },
   );
   emptyTextSlot.dataset["pmStart"] = "12";
-  emptyTextSlot.dataset["pmEnd"] = "12";
+  emptyTextSlot.dataset["pmEnd"] = target === "tab" ? "13" : "12";
 
   container.append(page);
   page.append(content);
@@ -318,8 +322,17 @@ describe("getCaretPositionFromDom caret height", () => {
   test("anchors a caret after an unpainted inline prefix to the first painted text slot", () => {
     const caret = getCaretPositionFromDom(buildUnpaintedPrefixContainer(), 11, rect({}));
 
-    expect(caret).toEqual({ x: 70, y: 30, height: 18, pageIndex: 0 });
+    expect(caret).toEqual({ x: 70, y: 30, height: 36, pageIndex: 0 });
   });
+
+  test.each(["empty", "tab"] as const)(
+    "normalizes a transformed %s anchor back into document coordinates",
+    (target) => {
+      const context = new RenderedDomContextImpl(buildUnpaintedPrefixContainer(target), 2);
+
+      expect(context.getCoordinatesForPosition(11)).toEqual({ x: 35, y: 15, height: 18 });
+    },
+  );
 
   test("falls back to line height when the range reports zero height", () => {
     rangeHeight = 0;

--- a/packages/core/src/layout-bridge/dom/clickToPositionDom.ts
+++ b/packages/core/src/layout-bridge/dom/clickToPositionDom.ts
@@ -568,6 +568,81 @@ export function findCollapsedLineEdgeCaretTarget(
   return null;
 }
 
+const getPaintedSpanCaretGeometry = (
+  span: HTMLElement,
+  pmPos: number,
+): CollapsedLineEdgeCaretGeometry => {
+  const collapsed = getCollapsedLineEdgeCaretGeometry(span, pmPos);
+  if (collapsed) return collapsed;
+
+  const spanRect = span.getBoundingClientRect();
+  const line = closestHtmlElement(span, ".layout-line");
+  const lineHeight = line?.offsetHeight || spanRect.height || 16;
+  if (span.classList.contains("layout-run-tab")) {
+    const pmEnd = Number(span.dataset["pmEnd"]);
+    return {
+      left: pmPos >= pmEnd ? spanRect.right : spanRect.left,
+      top: spanRect.top,
+      height: lineHeight,
+    };
+  }
+
+  const textNodes = descendantTextNodes(span);
+  if (textNodes.length === 0) {
+    return { left: spanRect.left, top: spanRect.top, height: lineHeight };
+  }
+
+  const pmStart = Number(span.dataset["pmStart"]);
+  const charIndex = Math.min(Math.max(0, pmPos - pmStart), totalTextLength(textNodes));
+  const boundary = textBoundaryAt(textNodes, charIndex, "start");
+  if (!boundary) {
+    return { left: spanRect.left, top: spanRect.top, height: lineHeight };
+  }
+  const range = span.ownerDocument.createRange();
+  range.setStart(boundary.node, boundary.offset);
+  range.setEnd(boundary.node, boundary.offset);
+  const rangeRect = range.getBoundingClientRect();
+  return {
+    left: rangeRect.left,
+    top: rangeRect.top,
+    height: rangeRect.height || lineHeight,
+  };
+};
+
+/**
+ * Map an unpainted inline position inside a paragraph to the nearest painted
+ * span boundary. Inline metadata and folded fields occupy ProseMirror
+ * positions without emitting glyphs; their carets belong at the adjacent text
+ * slot, not at the paragraph box's physical edge.
+ */
+export function findParagraphGapCaretTarget(
+  container: ParentNode,
+  pmPos: number,
+): CollapsedLineEdgeCaretTarget | null {
+  let best: { span: HTMLElement; boundaryPos: number; distance: number } | undefined;
+  for (const paragraph of htmlQueryAll(container, ".layout-page-content .layout-paragraph")) {
+    const paragraphStart = Number(paragraph.dataset["pmStart"]);
+    const paragraphEnd = Number(paragraph.dataset["pmEnd"]);
+    if (!(pmPos > paragraphStart && pmPos < paragraphEnd)) continue;
+
+    for (const span of htmlQueryAll(paragraph, "span[data-pm-start][data-pm-end]")) {
+      const spanStart = Number(span.dataset["pmStart"]);
+      const spanEnd = Number(span.dataset["pmEnd"]);
+      if (!Number.isFinite(spanStart) || !Number.isFinite(spanEnd)) continue;
+      const boundaryPos = pmPos < spanStart ? spanStart : spanEnd;
+      const distance = Math.abs(boundaryPos - pmPos);
+      if (!best || distance < best.distance) {
+        best = { span, boundaryPos, distance };
+      }
+    }
+  }
+  if (!best) return null;
+  return {
+    span: best.span,
+    geometry: getPaintedSpanCaretGeometry(best.span, best.boundaryPos),
+  };
+}
+
 export function getCaretPositionFromDom(
   container: HTMLElement,
   pmPos: number,
@@ -662,6 +737,18 @@ export function getCaretPositionFromDom(
         pageIndex,
       };
     }
+  }
+
+  const gapTarget = findParagraphGapCaretTarget(container, pmPos);
+  if (gapTarget) {
+    const pageEl = closestHtmlElement(gapTarget.span, ".layout-page");
+    const pageIndex = pageEl ? Number(pageEl.dataset["pageNumber"] || 1) - 1 : 0;
+    return {
+      x: gapTarget.geometry.left - overlayRect.left,
+      y: gapTarget.geometry.top - overlayRect.top,
+      height: gapTarget.geometry.height,
+      pageIndex,
+    };
   }
 
   // Check empty paragraphs

--- a/packages/core/src/layout-bridge/dom/clickToPositionDom.ts
+++ b/packages/core/src/layout-bridge/dom/clickToPositionDom.ts
@@ -577,7 +577,7 @@ const getPaintedSpanCaretGeometry = (
 
   const spanRect = span.getBoundingClientRect();
   const line = closestHtmlElement(span, ".layout-line");
-  const lineHeight = line?.offsetHeight || spanRect.height || 16;
+  const lineHeight = line?.getBoundingClientRect().height || spanRect.height || 16;
   if (span.classList.contains("layout-run-tab")) {
     const pmEnd = Number(span.dataset["pmEnd"]);
     return {

--- a/packages/core/src/prosemirror/extensions/features/ListExtension-enter.test.ts
+++ b/packages/core/src/prosemirror/extensions/features/ListExtension-enter.test.ts
@@ -126,6 +126,8 @@ describe("ListExtension Enter numbering", () => {
     ).toBe(true);
 
     expect(listMarkers(state)).toEqual(["(a)", "(b)"]);
+    expect(state.selection.$from.parent).toBe(state.doc.lastChild);
+    expect(state.selection.$from.parentOffset).toBe(0);
   });
 
   test("does not retain an imported template after replacing the list", () => {

--- a/packages/core/src/render-dom/RenderedDomContext.ts
+++ b/packages/core/src/render-dom/RenderedDomContext.ts
@@ -5,7 +5,10 @@
  */
 
 import { findBodyEmptyRuns, findBodyPmSpans } from "../layout-bridge/dom/findBodyPmSpans";
-import { findCollapsedLineEdgeCaretTarget } from "../layout-bridge/dom/clickToPositionDom";
+import {
+  findCollapsedLineEdgeCaretTarget,
+  findParagraphGapCaretTarget,
+} from "../layout-bridge/dom/clickToPositionDom";
 import {
   createTextStreamRange,
   descendantTextNodes,
@@ -96,6 +99,15 @@ export class RenderedDomContextImpl implements RenderedDomContext {
         x: (rangeRect.left - containerRect.left) / this.#zoom,
         y: (rangeRect.top - containerRect.top) / this.#zoom,
         height: lineHeightFor(span, this.#zoom),
+      };
+    }
+
+    const gapTarget = findParagraphGapCaretTarget(this.#pagesContainer, pmPos);
+    if (gapTarget) {
+      return {
+        x: (gapTarget.geometry.left - containerRect.left) / this.#zoom,
+        y: (gapTarget.geometry.top - containerRect.top) / this.#zoom,
+        height: gapTarget.geometry.height / this.#zoom,
       };
     }
 


### PR DESCRIPTION
Map editor positions carried only by non-visual inline content to the nearest painted span boundary. Share the fallback across local and framework-neutral caret projection, and preserve the list-split selection invariant with synthetic coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved caret placement beside inline metadata, folded fields, and other content without a visible text span.
  - Carets now anchor to the nearest appropriate painted text position, including paragraph gaps, empty spans, tabs, and line edges.
  - Improved coordinate calculations for clicking or navigating to these positions.
  - After pressing Enter on an imported marker, the selection now starts correctly in the newly created paragraph.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->