### PR TITLE
fix: persist style-numbered list exits

### DIFF
--- a/.changeset/tidy-style-list-exits.md
+++ b/.changeset/tidy-style-list-exits.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep list removal effective for paragraphs whose numbering comes from a style.

--- a/packages/core/src/prosemirror/extensions/features/ListExtension-enter.test.ts
+++ b/packages/core/src/prosemirror/extensions/features/ListExtension-enter.test.ts
@@ -8,6 +8,7 @@ import { applyFolioAIEditOperations } from "../../../ai-edits/apply";
 import { createFolioAIEditSnapshot } from "../../../ai-edits/snapshot";
 import { toFlowBlocks } from "../../../layout-bridge/convert/toFlowBlocks";
 import type { Document } from "../../../types/document";
+import { fromProseDoc } from "../../conversion/fromProseDoc";
 import { toProseDoc } from "../../conversion/toProseDoc";
 import { LIST_RENDERING_ATTR_KEYS } from "../../listMarker";
 import { createDocumentNumberingPlugin } from "../../plugins/documentNumbering";
@@ -98,6 +99,35 @@ const multilevelState = (level: number): EditorState =>
     plugins: [createDocumentNumberingPlugin(MULTILEVEL_NUMBERING.definitions)],
   });
 
+const styleNumberedDocument = (): Document => ({
+  package: {
+    numbering: MULTILEVEL_NUMBERING.definitions,
+    styles: {
+      styles: [
+        {
+          styleId: "SyntheticClause",
+          type: "paragraph",
+          pPr: { numPr: { numId: 23, ilvl: 1 } },
+        },
+      ],
+    },
+    document: {
+      content: [
+        {
+          type: "paragraph",
+          formatting: { styleId: "SyntheticClause" },
+          content: [
+            {
+              type: "run",
+              content: [{ type: "text", text: "Synthetic styled clause" }],
+            },
+          ],
+        },
+      ],
+    },
+  },
+});
+
 const listMarkers = (state: EditorState): string[] =>
   toFlowBlocks(state.doc).flatMap((block) =>
     block.kind === "paragraph" && block.attrs?.listMarker ? [block.attrs.listMarker] : [],
@@ -128,6 +158,40 @@ describe("ListExtension Enter numbering", () => {
     expect(listMarkers(state)).toEqual(["(a)", "(b)"]);
     expect(state.selection.$from.parent).toBe(state.doc.lastChild);
     expect(state.selection.$from.parentOffset).toBe(0);
+  });
+
+  test("Backspace keeps a style-numbered list exit after the document model refreshes", () => {
+    const document = styleNumberedDocument();
+    let state = EditorState.create({
+      doc: toProseDoc(document, { styles: document.package.styles }),
+      plugins: [createDocumentNumberingPlugin(MULTILEVEL_NUMBERING.definitions)],
+    });
+    const runtime = ListExtension().onSchemaReady({ schema });
+    const enter = runtime.keyboardShortcuts?.["Enter"];
+    const backspace = runtime.keyboardShortcuts?.["Backspace"];
+    if (!enter || !backspace) {
+      return panic("List extension did not register Enter and Backspace");
+    }
+    const first = state.doc.firstChild;
+    if (!first) {
+      return panic("Synthetic document did not contain its paragraph");
+    }
+    state = state.apply(state.tr.setSelection(TextSelection.create(state.doc, first.nodeSize - 1)));
+    enter(state, (transaction) => {
+      state = state.apply(transaction);
+    });
+    backspace(state, (transaction) => {
+      state = state.apply(transaction);
+    });
+
+    const refreshedDocument = fromProseDoc(state.doc, document);
+    const refreshedState = EditorState.create({
+      doc: toProseDoc(refreshedDocument, { styles: refreshedDocument.package.styles }),
+      plugins: [createDocumentNumberingPlugin(MULTILEVEL_NUMBERING.definitions)],
+    });
+
+    expect(listMarkers(refreshedState)).toHaveLength(1);
+    expect(refreshedState.doc.lastChild?.attrs["numPr"]).toEqual({ numId: 0, ilvl: 1 });
   });
 
   test("does not retain an imported template after replacing the list", () => {

--- a/packages/core/src/prosemirror/extensions/features/ListExtension.ts
+++ b/packages/core/src/prosemirror/extensions/features/ListExtension.ts
@@ -82,6 +82,20 @@ function getPreviousListFormatting(attrs: Record<string, unknown>): Record<strin
   return previousFormatting;
 }
 
+function clearListAttrs(attrs: ParagraphAttrs): Record<string, unknown> {
+  const styleNumPr = attrs.numPrFromStyle;
+  const numPr =
+    styleNumPr?.numId !== undefined && styleNumPr.numId !== 0
+      ? { numId: 0, ilvl: attrs.numPr?.ilvl ?? styleNumPr.ilvl ?? 0 }
+      : null;
+
+  return {
+    ...attrs,
+    numPr,
+    ...CLEARED_LIST_RENDERING_ATTRS,
+  };
+}
+
 // ============================================================================
 // LIST COMMANDS
 // ============================================================================
@@ -130,11 +144,7 @@ function toggleList(numId: number): Command {
         let nextAttrs: Record<string, unknown>;
 
         if (isInSameList) {
-          nextAttrs = {
-            ...node.attrs,
-            numPr: null,
-            ...CLEARED_LIST_RENDERING_ATTRS,
-          };
+          nextAttrs = clearListAttrs(expectParagraphAttrs(node));
         } else {
           const isBullet = numId === 1;
           nextAttrs = {
@@ -244,9 +254,7 @@ const decreaseListLevel: Command = (state, dispatch) => {
     dispatch(
       state.tr
         .setNodeMarkup(paragraphPos, undefined, {
-          ...paragraph.attrs,
-          numPr: null,
-          ...CLEARED_LIST_RENDERING_ATTRS,
+          ...clearListAttrs(expectParagraphAttrs(paragraph)),
           indentLeft: null,
           indentFirstLine: null,
           hangingIndent: null,
@@ -279,11 +287,7 @@ const removeList: Command = (state, dispatch) => {
   state.doc.nodesBetween($from.pos, $to.pos, (node, pos) => {
     if (node.type.name === "paragraph" && node.attrs["numPr"] && !seen.has(pos)) {
       seen.add(pos);
-      tr = tr.setNodeMarkup(pos, undefined, {
-        ...node.attrs,
-        numPr: null,
-        ...CLEARED_LIST_RENDERING_ATTRS,
-      });
+      tr = tr.setNodeMarkup(pos, undefined, clearListAttrs(expectParagraphAttrs(node)));
     }
   });
 
@@ -348,11 +352,11 @@ function exitListOnEmptyEnter(): Command {
     }
 
     if (dispatch) {
-      const tr = state.tr.setNodeMarkup($from.before(), undefined, {
-        ...paragraph.attrs,
-        numPr: null,
-        ...CLEARED_LIST_RENDERING_ATTRS,
-      });
+      const tr = state.tr.setNodeMarkup(
+        $from.before(),
+        undefined,
+        clearListAttrs(expectParagraphAttrs(paragraph)),
+      );
       dispatch(tr);
     }
     return true;
@@ -415,11 +419,11 @@ function backspaceExitList(): Command {
     }
 
     if (dispatch) {
-      const tr = state.tr.setNodeMarkup($from.before(), undefined, {
-        ...paragraph.attrs,
-        numPr: null,
-        ...CLEARED_LIST_RENDERING_ATTRS,
-      });
+      const tr = state.tr.setNodeMarkup(
+        $from.before(),
+        undefined,
+        clearListAttrs(expectParagraphAttrs(paragraph)),
+      );
       dispatch(tr);
     }
     return true;
@@ -483,9 +487,7 @@ function decreaseListIndent(): Command {
         const currentLevel = attrs.numPr?.ilvl ?? 0;
         if (currentLevel <= 0) {
           tr = tr.setNodeMarkup(pos, undefined, {
-            ...attrs,
-            numPr: null,
-            ...CLEARED_LIST_RENDERING_ATTRS,
+            ...clearListAttrs(attrs),
             indentLeft: null,
             indentFirstLine: null,
             hangingIndent: null,


### PR DESCRIPTION
## Summary

- preserve explicit list removal when numbering is inherited from a paragraph style
- use one canonical list-exit transformation across keyboard and toolbar commands
- verify the edit remains unnumbered after document-model refresh with synthetic content