### PR TITLE
fix: keep deletion state and rendering synchronized

### DIFF
--- a/.changeset/calm-list-backspace.md
+++ b/.changeset/calm-list-backspace.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Allow deletion to continue after exiting style-inherited numbering.

--- a/.changeset/calm-list-backspace.md
+++ b/.changeset/calm-list-backspace.md
@@ -4,4 +4,4 @@
 "@stll/folio-vue": patch
 ---
 
-Keep list deletion, paired inline metadata, and rendered updates synchronized.
+Keep list deletion, paired inline metadata, markerless indentation, and rendered updates synchronized.

--- a/.changeset/calm-list-backspace.md
+++ b/.changeset/calm-list-backspace.md
@@ -1,5 +1,7 @@
 ---
 "@stll/folio-core": patch
+"@stll/folio-react": patch
+"@stll/folio-vue": patch
 ---
 
-Allow deletion to continue after exiting style-inherited numbering.
+Keep list deletion, paired inline metadata, and rendered updates synchronized.

--- a/packages/core/src/controller/hiddenEditorManager.test.ts
+++ b/packages/core/src/controller/hiddenEditorManager.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { EditorState, Transaction } from "prosemirror-state";
+import type { EditorState } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
 
 import {
@@ -46,7 +46,7 @@ const makeDeps = (
     getReadOnly: () => false,
     getDocumentIdentity: () => "0",
     getDocumentContext: () => null,
-    onTransaction: (_transaction: Transaction, _newState: EditorState) => {
+    onTransaction: () => {
       spies["onTransaction"].calls += 1;
     },
     onSelectionChange: (_state: EditorState) => {

--- a/packages/core/src/controller/hiddenEditorManager.ts
+++ b/packages/core/src/controller/hiddenEditorManager.ts
@@ -362,7 +362,7 @@ export type HiddenEditorManagerDeps = {
   getDocumentIdentity: () => string;
   /** Document context for the API's `getDocument` (PM state -> Document). */
   getDocumentContext: () => Document | null;
-  onTransaction: (transaction: Transaction, newState: EditorState) => void;
+  onTransaction: (update: HiddenEditorTransactionUpdate) => void;
   onSelectionChange: (state: EditorState) => void;
   onKeyDown: (view: EditorView, event: KeyboardEvent) => boolean;
   onCopy?: () => void;
@@ -372,6 +372,12 @@ export type HiddenEditorManagerDeps = {
   onEditorViewReady: (view: EditorView) => void;
   onEditorViewDestroy: () => void;
   onRemoteSelectionsChange: (selections: HiddenProseMirrorRemoteSelection[]) => void;
+};
+
+export type HiddenEditorTransactionUpdate = {
+  transactions: readonly Transaction[];
+  newState: EditorState;
+  docChanged: boolean;
 };
 
 type PreventableDomEvent = { preventDefault: () => void };
@@ -480,15 +486,26 @@ export const createHiddenEditorManager = (deps: HiddenEditorManagerDeps): Hidden
           return;
         }
 
-        const newState = view.state.apply(transaction);
-        view.updateState(newState);
+        const applied = view.state.applyTransaction(transaction);
+        view.updateState(applied.state);
+
+        const docChanged = applied.transactions.some(
+          (appliedTransaction) => appliedTransaction.docChanged,
+        );
+        const selectionChanged = applied.transactions.some(
+          (appliedTransaction) => appliedTransaction.selectionSet || appliedTransaction.docChanged,
+        );
 
         // Notify about transaction.
-        deps.onTransaction(transaction, newState);
+        deps.onTransaction({
+          transactions: applied.transactions,
+          newState: applied.state,
+          docChanged,
+        });
 
         // Notify about selection changes.
-        if (transaction.selectionSet || transaction.docChanged) {
-          deps.onSelectionChange(newState);
+        if (selectionChanged) {
+          deps.onSelectionChange(applied.state);
         }
 
         const currentCollaboration = deps.getCollaboration();
@@ -496,7 +513,7 @@ export const createHiddenEditorManager = (deps: HiddenEditorManagerDeps): Hidden
         if (currentCollaboration?.awareness && currentCollaborationModules) {
           deps.onRemoteSelectionsChange(
             collectRemoteSelections(
-              newState,
+              applied.state,
               currentCollaboration.awareness,
               currentCollaborationModules,
             ),

--- a/packages/core/src/docx/numberingParser.ts
+++ b/packages/core/src/docx/numberingParser.ts
@@ -989,3 +989,7 @@ export function getBulletCharacter(level: ListLevel): string {
 export function isBulletLevel(level: ListLevel): boolean {
   return level.numFmt === "bullet" || level.numFmt === "none";
 }
+
+/** Whether a numbering level reserves horizontal space for a visible marker. */
+export const numberingLevelHasMarkerSlot = (level: Pick<ListLevel, "numFmt">): boolean =>
+  level.numFmt !== "none";

--- a/packages/core/src/docx/paragraphParser-numbering-indent.test.ts
+++ b/packages/core/src/docx/paragraphParser-numbering-indent.test.ts
@@ -21,6 +21,19 @@ const NUMBERING_WITH_HANGING = `<?xml version="1.0" encoding="UTF-8" standalone=
   <w:num w:numId="1"><w:abstractNumId w:val="0"/></w:num>
 </w:numbering>`;
 
+const NUMBERING_WITHOUT_MARKER = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:abstractNum w:abstractNumId="4">
+    <w:lvl w:ilvl="0">
+      <w:start w:val="1"/>
+      <w:numFmt w:val="none"/>
+      <w:lvlText w:val=""/>
+      <w:pPr><w:ind w:left="700" w:hanging="700"/></w:pPr>
+    </w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="5"><w:abstractNumId w:val="4"/></w:num>
+</w:numbering>`;
+
 function parseParagraphXml(xml: string, numbering: ReturnType<typeof parseNumbering>) {
   const root = parseXmlDocument(xml) as XmlElement | null;
   if (!root) {
@@ -93,6 +106,41 @@ describe("paragraphParser direct ind vs numbering level indent", () => {
           <w:ind w:hanging="180"/>
         </w:pPr>
         <w:r><w:t>Item</w:t></w:r>
+      </w:p>`,
+      numbering,
+    );
+
+    expect(paragraph.formatting?.indentFirstLine).toBe(-180);
+    expect(paragraph.formatting?.hangingIndent).toBe(true);
+  });
+});
+
+describe("markerless numbering indentation", () => {
+  const numbering = parseNumbering(NUMBERING_WITHOUT_MARKER);
+
+  test("keeps the level left indent without creating an empty hanging slot", () => {
+    const paragraph = parseParagraphXml(
+      `<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="5"/></w:numPr></w:pPr>
+        <w:r><w:t>Synthetic paragraph content.</w:t></w:r>
+      </w:p>`,
+      numbering,
+    );
+
+    expect(paragraph.listRendering?.numFmt).toBe("none");
+    expect(paragraph.formatting?.indentLeft).toBe(700);
+    expect(paragraph.formatting?.indentFirstLine).toBeUndefined();
+    expect(paragraph.formatting?.hangingIndent).toBeUndefined();
+  });
+
+  test("preserves an explicitly authored hanging indent", () => {
+    const paragraph = parseParagraphXml(
+      `<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:pPr>
+          <w:numPr><w:ilvl w:val="0"/><w:numId w:val="5"/></w:numPr>
+          <w:ind w:hanging="180"/>
+        </w:pPr>
+        <w:r><w:t>Synthetic paragraph content.</w:t></w:r>
       </w:p>`,
       numbering,
     );

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -49,7 +49,7 @@ import {
 } from "./bookmarkParser";
 import { parseFieldType } from "./fieldParser";
 import { parseHyperlinkChild, parseHyperlink as parseHyperlinkFromModule } from "./hyperlinkParser";
-import { markerFormattingFromLevel } from "./numberingParser";
+import { markerFormattingFromLevel, numberingLevelHasMarkerSlot } from "./numberingParser";
 import type { NumberingMap } from "./numberingParser";
 import {
   BorderStyleSchema,
@@ -2256,7 +2256,11 @@ export function parseParagraph(
           if (!hasDirectLeft && !chainInd.left && level.pPr.indentLeft !== undefined) {
             paragraph.formatting.indentLeft = level.pPr.indentLeft;
           }
-          if (!hasDirectFirstLineOrHanging && !chainInd.firstLine) {
+          if (
+            !hasDirectFirstLineOrHanging &&
+            !chainInd.firstLine &&
+            numberingLevelHasMarkerSlot(level)
+          ) {
             if (level.pPr.indentFirstLine !== undefined) {
               paragraph.formatting.indentFirstLine = level.pPr.indentFirstLine;
             }

--- a/packages/core/src/paged-layout/transactionDirtyRange.test.ts
+++ b/packages/core/src/paged-layout/transactionDirtyRange.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { EditorState } from "prosemirror-state";
 
 import { schema } from "../prosemirror/schema";
-import { getTransactionDirtyRange } from "./transactionDirtyRange";
+import { getTransactionDirtyRange, getTransactionsDirtyRange } from "./transactionDirtyRange";
 
 describe("getTransactionDirtyRange", () => {
   test("maps changed ranges from multi-step transactions into final document coordinates", () => {
@@ -52,5 +52,22 @@ describe("getTransactionDirtyRange", () => {
     const dirtyRange = getTransactionDirtyRange(transaction);
 
     expect(dirtyRange).toEqual({ from: 2, to: 7 });
+  });
+});
+
+describe("getTransactionsDirtyRange", () => {
+  test("includes appended transactions and maps every range into final coordinates", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text("abcdefghijklmnopqrstuvwxyz".repeat(6))]),
+    ]);
+    const state = EditorState.create({ doc });
+    const firstTransaction = state.tr.insertText("A", 100);
+    const intermediateState = state.apply(firstTransaction);
+    const appendedTransaction = intermediateState.tr.insertText("prefix", 2);
+
+    expect(getTransactionsDirtyRange([firstTransaction, appendedTransaction])).toEqual({
+      from: 2,
+      to: 107,
+    });
   });
 });

--- a/packages/core/src/paged-layout/transactionDirtyRange.ts
+++ b/packages/core/src/paged-layout/transactionDirtyRange.ts
@@ -1,7 +1,7 @@
 import type { Transaction } from "prosemirror-state";
 import { AddMarkStep, RemoveMarkStep } from "prosemirror-transform";
 
-import type { DirtyRange } from "./incrementalMeasure";
+import { mergeDirtyRanges, type DirtyRange } from "./incrementalMeasure";
 
 type DirtyRangeAccumulator = {
   from: number;
@@ -23,6 +23,34 @@ export function getTransactionDirtyRange(transaction: Transaction): DirtyRange |
   }
 
   return dirtyRange;
+}
+
+/** Collect every transaction in an applied batch in the final document's coordinates. */
+export function getTransactionsDirtyRange(transactions: readonly Transaction[]): DirtyRange | null {
+  let combinedRange: DirtyRange | null = null;
+
+  for (let index = 0; index < transactions.length; index += 1) {
+    const transaction = transactions[index];
+    if (!transaction) {
+      continue;
+    }
+    const range = getTransactionDirtyRange(transaction);
+    if (!range) {
+      continue;
+    }
+
+    let from = range.from;
+    let to = range.to;
+    for (const followingTransaction of transactions.slice(index + 1)) {
+      // oxlint-disable-next-line unicorn/no-array-method-this-argument -- ProseMirror Mapping.map(pos, assoc) API
+      from = followingTransaction.mapping.map(from, -1);
+      // oxlint-disable-next-line unicorn/no-array-method-this-argument -- ProseMirror Mapping.map(pos, assoc) API
+      to = followingTransaction.mapping.map(to, 1);
+    }
+    combinedRange = mergeDirtyRanges(combinedRange, { from, to });
+  }
+
+  return combinedRange;
 }
 
 function includeStepDirtyRange(

--- a/packages/core/src/prosemirror/bookmarkBoundaryIntegrity.ts
+++ b/packages/core/src/prosemirror/bookmarkBoundaryIntegrity.ts
@@ -1,0 +1,47 @@
+export type BookmarkBoundaryOccurrence = {
+  id: number;
+  type: "start" | "end";
+  position: number;
+};
+
+type BoundarySummary = {
+  startPositions: number[];
+  endPositions: number[];
+};
+
+export const findInvalidBookmarkBoundaryIds = (
+  occurrences: readonly BookmarkBoundaryOccurrence[],
+  reservedIds: ReadonlySet<number> = new Set(),
+): ReadonlySet<number> => {
+  const summaries = new Map<number, BoundarySummary>();
+
+  for (const occurrence of occurrences) {
+    const summary = summaries.get(occurrence.id) ?? {
+      startPositions: [],
+      endPositions: [],
+    };
+    if (occurrence.type === "start") {
+      summary.startPositions.push(occurrence.position);
+    } else {
+      summary.endPositions.push(occurrence.position);
+    }
+    summaries.set(occurrence.id, summary);
+  }
+
+  const invalidIds = new Set<number>();
+  for (const [id, summary] of summaries) {
+    const start = summary.startPositions.at(0);
+    const end = summary.endPositions.at(0);
+    if (
+      reservedIds.has(id) ||
+      summary.startPositions.length !== 1 ||
+      summary.endPositions.length !== 1 ||
+      start === undefined ||
+      end === undefined ||
+      start >= end
+    ) {
+      invalidIds.add(id);
+    }
+  }
+  return invalidIds;
+};

--- a/packages/core/src/prosemirror/extensions/features/ListExtension-enter.test.ts
+++ b/packages/core/src/prosemirror/extensions/features/ListExtension-enter.test.ts
@@ -185,13 +185,27 @@ describe("ListExtension Enter numbering", () => {
     });
 
     const refreshedDocument = fromProseDoc(state.doc, document);
-    const refreshedState = EditorState.create({
+    let refreshedState = EditorState.create({
       doc: toProseDoc(refreshedDocument, { styles: refreshedDocument.package.styles }),
       plugins: [createDocumentNumberingPlugin(MULTILEVEL_NUMBERING.definitions)],
     });
 
     expect(listMarkers(refreshedState)).toHaveLength(1);
     expect(refreshedState.doc.lastChild?.attrs["numPr"]).toEqual({ numId: 0, ilvl: 1 });
+    const lastParagraphStart = refreshedState.doc.firstChild?.nodeSize;
+    if (lastParagraphStart === undefined) {
+      return panic("Synthetic document lost its first paragraph");
+    }
+    refreshedState = refreshedState.apply(
+      refreshedState.tr.setSelection(
+        TextSelection.create(refreshedState.doc, lastParagraphStart + 1),
+      ),
+    );
+    expect(
+      backspace(refreshedState, (transaction) => {
+        refreshedState = refreshedState.apply(transaction);
+      }),
+    ).toBe(false);
   });
 
   test("does not retain an imported template after replacing the list", () => {

--- a/packages/core/src/prosemirror/extensions/features/ListExtension.ts
+++ b/packages/core/src/prosemirror/extensions/features/ListExtension.ts
@@ -96,6 +96,14 @@ function clearListAttrs(attrs: ParagraphAttrs): Record<string, unknown> {
   };
 }
 
+type ActiveListParagraphAttrs = ParagraphAttrs & {
+  numPr: NonNullable<ParagraphAttrs["numPr"]> & { numId: number };
+};
+
+function hasActiveListNumbering(attrs: ParagraphAttrs): attrs is ActiveListParagraphAttrs {
+  return attrs.numPr?.numId !== undefined && attrs.numPr.numId !== 0;
+}
+
 // ============================================================================
 // LIST COMMANDS
 // ============================================================================
@@ -188,13 +196,16 @@ const attrsForListLevel = (
   attrs: ParagraphAttrs,
   level: number,
 ): Record<string, unknown> => {
-  const numPr = attrs.numPr;
-  if (numPr?.numId === undefined) {
+  if (!hasActiveListNumbering(attrs)) {
     panic("Cannot change the level of a list without a numbering id");
   }
   return {
     ...attrs,
-    ...listLevelAttrPatch(attrs, { numId: numPr.numId, ilvl: level }, getDocumentNumbering(state)),
+    ...listLevelAttrPatch(
+      attrs,
+      { numId: attrs.numPr.numId, ilvl: level },
+      getDocumentNumbering(state),
+    ),
   };
 };
 
@@ -205,11 +216,12 @@ const increaseListLevel: Command = (state, dispatch) => {
   if (paragraph.type.name !== "paragraph") {
     return false;
   }
-  if (!paragraph.attrs["numPr"]) {
+  const attrs = expectParagraphAttrs(paragraph);
+  if (!hasActiveListNumbering(attrs)) {
     return false;
   }
 
-  const currentLevel = paragraph.attrs["numPr"].ilvl || 0;
+  const currentLevel = attrs.numPr.ilvl || 0;
   if (currentLevel >= 8) {
     return false;
   }
@@ -223,7 +235,7 @@ const increaseListLevel: Command = (state, dispatch) => {
   dispatch(
     state.tr
       .setNodeMarkup(paragraphPos, undefined, {
-        ...attrsForListLevel(state, expectParagraphAttrs(paragraph), currentLevel + 1),
+        ...attrsForListLevel(state, attrs, currentLevel + 1),
       })
       .scrollIntoView(),
   );
@@ -238,11 +250,12 @@ const decreaseListLevel: Command = (state, dispatch) => {
   if (paragraph.type.name !== "paragraph") {
     return false;
   }
-  if (!paragraph.attrs["numPr"]) {
+  const attrs = expectParagraphAttrs(paragraph);
+  if (!hasActiveListNumbering(attrs)) {
     return false;
   }
 
-  const currentLevel = paragraph.attrs["numPr"].ilvl || 0;
+  const currentLevel = attrs.numPr.ilvl || 0;
 
   if (!dispatch) {
     return true;
@@ -254,7 +267,7 @@ const decreaseListLevel: Command = (state, dispatch) => {
     dispatch(
       state.tr
         .setNodeMarkup(paragraphPos, undefined, {
-          ...clearListAttrs(expectParagraphAttrs(paragraph)),
+          ...clearListAttrs(attrs),
           indentLeft: null,
           indentFirstLine: null,
           hangingIndent: null,
@@ -265,7 +278,7 @@ const decreaseListLevel: Command = (state, dispatch) => {
     dispatch(
       state.tr
         .setNodeMarkup(paragraphPos, undefined, {
-          ...attrsForListLevel(state, expectParagraphAttrs(paragraph), currentLevel - 1),
+          ...attrsForListLevel(state, attrs, currentLevel - 1),
         })
         .scrollIntoView(),
     );
@@ -285,7 +298,11 @@ const removeList: Command = (state, dispatch) => {
   const seen = new Set<number>();
 
   state.doc.nodesBetween($from.pos, $to.pos, (node, pos) => {
-    if (node.type.name === "paragraph" && node.attrs["numPr"] && !seen.has(pos)) {
+    if (
+      node.type.name === "paragraph" &&
+      hasActiveListNumbering(expectParagraphAttrs(node)) &&
+      !seen.has(pos)
+    ) {
       seen.add(pos);
       tr = tr.setNodeMarkup(pos, undefined, clearListAttrs(expectParagraphAttrs(node)));
     }
@@ -306,7 +323,7 @@ export function isInList(state: EditorState): boolean {
   if (paragraph.type.name !== "paragraph") {
     return false;
   }
-  return !!paragraph.attrs["numPr"]?.numId;
+  return hasActiveListNumbering(expectParagraphAttrs(paragraph));
 }
 
 export function getListInfo(state: EditorState): { numId: number; ilvl: number } | null {
@@ -316,13 +333,14 @@ export function getListInfo(state: EditorState): { numId: number; ilvl: number }
   if (paragraph.type.name !== "paragraph") {
     return null;
   }
-  if (!paragraph.attrs["numPr"]?.numId) {
+  const attrs = expectParagraphAttrs(paragraph);
+  if (!hasActiveListNumbering(attrs)) {
     return null;
   }
 
   return {
-    numId: paragraph.attrs["numPr"].numId,
-    ilvl: paragraph.attrs["numPr"].ilvl || 0,
+    numId: attrs.numPr.numId,
+    ilvl: attrs.numPr.ilvl || 0,
   };
 }
 
@@ -342,8 +360,8 @@ function exitListOnEmptyEnter(): Command {
       return false;
     }
 
-    const numPr = paragraph.attrs["numPr"];
-    if (!numPr) {
+    const attrs = expectParagraphAttrs(paragraph);
+    if (!hasActiveListNumbering(attrs)) {
       return false;
     }
 
@@ -352,11 +370,7 @@ function exitListOnEmptyEnter(): Command {
     }
 
     if (dispatch) {
-      const tr = state.tr.setNodeMarkup(
-        $from.before(),
-        undefined,
-        clearListAttrs(expectParagraphAttrs(paragraph)),
-      );
+      const tr = state.tr.setNodeMarkup($from.before(), undefined, clearListAttrs(attrs));
       dispatch(tr);
     }
     return true;
@@ -375,8 +389,8 @@ function splitListItem(): Command {
       return false;
     }
 
-    const numPr = paragraph.attrs["numPr"];
-    if (!numPr) {
+    const attrs = expectParagraphAttrs(paragraph);
+    if (!hasActiveListNumbering(attrs)) {
       return false;
     }
 
@@ -413,17 +427,13 @@ function backspaceExitList(): Command {
       return false;
     }
 
-    const numPr = paragraph.attrs["numPr"];
-    if (!numPr) {
+    const attrs = expectParagraphAttrs(paragraph);
+    if (!hasActiveListNumbering(attrs)) {
       return false;
     }
 
     if (dispatch) {
-      const tr = state.tr.setNodeMarkup(
-        $from.before(),
-        undefined,
-        clearListAttrs(expectParagraphAttrs(paragraph)),
-      );
+      const tr = state.tr.setNodeMarkup($from.before(), undefined, clearListAttrs(attrs));
       dispatch(tr);
     }
     return true;
@@ -437,8 +447,11 @@ function increaseListIndent(): Command {
     // Collect all list paragraphs in the selection range
     const positions: { pos: number; attrs: ParagraphAttrs }[] = [];
     state.doc.nodesBetween($from.pos, $to.pos, (node, pos) => {
-      if (node.type.name === "paragraph" && node.attrs["numPr"]) {
+      if (node.type.name === "paragraph") {
         const attrs = expectParagraphAttrs(node);
+        if (!hasActiveListNumbering(attrs)) {
+          return;
+        }
         const currentLevel = attrs.numPr?.ilvl ?? 0;
         if (currentLevel < 8) {
           positions.push({ pos, attrs });
@@ -472,8 +485,11 @@ function decreaseListIndent(): Command {
     // Collect all list paragraphs in the selection range
     const positions: { pos: number; attrs: ParagraphAttrs }[] = [];
     state.doc.nodesBetween($from.pos, $to.pos, (node, pos) => {
-      if (node.type.name === "paragraph" && node.attrs["numPr"]) {
-        positions.push({ pos, attrs: expectParagraphAttrs(node) });
+      if (node.type.name === "paragraph") {
+        const attrs = expectParagraphAttrs(node);
+        if (hasActiveListNumbering(attrs)) {
+          positions.push({ pos, attrs });
+        }
       }
     });
 

--- a/packages/core/src/prosemirror/extensions/features/pasteCleanup.ts
+++ b/packages/core/src/prosemirror/extensions/features/pasteCleanup.ts
@@ -23,6 +23,10 @@ import { Fragment, Slice, type Node as PMNode } from "prosemirror-model";
 import { htmlCommentEnd } from "../../../utils/htmlComments";
 import { stripXmlDeclarations } from "../../../utils/stripXmlDeclarations";
 import { readBookmarkBoundaryAttrs } from "../../bookmarkBoundaryAttrs";
+import {
+  findInvalidBookmarkBoundaryIds,
+  type BookmarkBoundaryOccurrence,
+} from "../../bookmarkBoundaryIntegrity";
 
 /**
  * Remove every HTML comment, including downlevel conditional comments
@@ -290,16 +294,9 @@ export function cleanPastedHtml(html: string, options: CleanPastedHtmlOptions = 
   }
 }
 
-type BoundaryCounts = {
-  starts: number;
-  ends: number;
-  firstStart?: number;
-  firstEnd?: number;
-};
-
 /** Remove incomplete or duplicate bookmark pairs at copied slice edges. */
 export function removeUnpairedBookmarkBoundaries(slice: Slice): Slice {
-  const counts = new Map<number, BoundaryCounts>();
+  const boundaries: BookmarkBoundaryOccurrence[] = [];
   let boundaryIndex = 0;
   slice.content.descendants((node) => {
     if (node.type.name !== "bookmarkBoundary") {
@@ -310,29 +307,11 @@ export function removeUnpairedBookmarkBoundaries(slice: Slice): Slice {
       return false;
     }
     const attrs = result.value;
-    const count = counts.get(attrs.id) ?? { starts: 0, ends: 0 };
-    if (attrs.type === "start") {
-      count.starts += 1;
-      count.firstStart ??= boundaryIndex;
-    } else {
-      count.ends += 1;
-      count.firstEnd ??= boundaryIndex;
-    }
+    boundaries.push({ id: attrs.id, type: attrs.type, position: boundaryIndex });
     boundaryIndex += 1;
-    counts.set(attrs.id, count);
     return false;
   });
-  const pairedIds = new Set(
-    [...counts].flatMap(([id, count]) =>
-      count.starts === 1 &&
-      count.ends === 1 &&
-      count.firstStart !== undefined &&
-      count.firstEnd !== undefined &&
-      count.firstStart < count.firstEnd
-        ? [id]
-        : [],
-    ),
-  );
+  const invalidIds = findInvalidBookmarkBoundaryIds(boundaries);
 
   const filterFragment = (fragment: Fragment): Fragment => {
     const children: PMNode[] = [];
@@ -340,7 +319,7 @@ export function removeUnpairedBookmarkBoundaries(slice: Slice): Slice {
     fragment.forEach((node) => {
       if (node.type.name === "bookmarkBoundary") {
         const result = readBookmarkBoundaryAttrs(node);
-        if (result.ok && pairedIds.has(result.value.id)) {
+        if (result.ok && !invalidIds.has(result.value.id)) {
           children.push(node);
         }
         return;

--- a/packages/core/src/prosemirror/extensions/nodes/BookmarkBoundaryExtension.test.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/BookmarkBoundaryExtension.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+import { EditorState, type Plugin } from "prosemirror-state";
 
 import { schema } from "../../schema";
+import { validateProseMirrorDocument } from "../../validation";
+import { BookmarkBoundaryExtension } from "./BookmarkBoundaryExtension";
 
 class FakeHTMLElement {
   constructor(private readonly attrs: Readonly<Record<string, string>>) {}
@@ -16,6 +20,32 @@ const parseBookmarkBoundary = (attrs: Readonly<Record<string, string>>) => {
     throw new Error("BookmarkBoundaryExtension must define parseDOM[0].getAttrs");
   }
   return getAttrs(new FakeHTMLElement(attrs) as unknown as HTMLElement);
+};
+
+const getBoundaryIntegrityPlugin = (): Plugin => {
+  const plugin = BookmarkBoundaryExtension().onSchemaReady({ schema }).plugins?.at(0);
+  if (!plugin) {
+    throw new Error("BookmarkBoundaryExtension must enforce boundary integrity");
+  }
+  return plugin;
+};
+
+const createBoundaryDocument = () =>
+  schema.node("doc", null, [
+    schema.node("paragraph", null, [
+      schema.node("bookmarkBoundary", { type: "start", id: 101, name: "range-a" }),
+      schema.text("alpha"),
+      schema.node("bookmarkBoundary", { type: "start", id: 202, name: "range-b" }),
+      schema.text("beta"),
+      schema.node("bookmarkBoundary", { type: "end", id: 101 }),
+      schema.text("gamma"),
+      schema.node("bookmarkBoundary", { type: "end", id: 202 }),
+    ]),
+  ]);
+
+const expectValidBoundaryStructure = (state: EditorState): void => {
+  const result = validateProseMirrorDocument(state.doc);
+  expect(result.issues.filter(({ message }) => message.includes("Bookmark"))).toEqual([]);
 };
 
 describe("BookmarkBoundaryExtension DOM round-trip", () => {
@@ -91,6 +121,92 @@ describe("BookmarkBoundaryExtension DOM round-trip", () => {
     expect(boundaryDom[1]["data-docx-internal-clipboard"]).toBeTruthy();
     expect(anchorDom[1]["data-docx-internal-clipboard"]).toBe(
       boundaryDom[1]["data-docx-internal-clipboard"],
+    );
+  });
+});
+
+describe("BookmarkBoundaryExtension editing integrity", () => {
+  test("removes the surviving endpoint when an edit deletes its pair", () => {
+    const state = EditorState.create({
+      doc: createBoundaryDocument(),
+      plugins: [getBoundaryIntegrityPlugin()],
+    });
+
+    const applied = state.applyTransaction(state.tr.delete(1, 2));
+
+    expect(applied.transactions).toHaveLength(2);
+    expectValidBoundaryStructure(applied.state);
+    expect(applied.state.doc.textContent).toBe("alphabetagamma");
+  });
+
+  test("preserves complete crossing pairs after ordinary text edits", () => {
+    const state = EditorState.create({
+      doc: createBoundaryDocument(),
+      plugins: [getBoundaryIntegrityPlugin()],
+    });
+
+    const applied = state.applyTransaction(state.tr.insertText("x", 3));
+
+    expect(applied.transactions).toHaveLength(1);
+    expectValidBoundaryStructure(applied.state);
+    let boundaryCount = 0;
+    applied.state.doc.descendants((node) => {
+      if (node.type.name === "bookmarkBoundary") {
+        boundaryCount += 1;
+      }
+      return true;
+    });
+    expect(boundaryCount).toBe(4);
+  });
+
+  test("removes ambiguous node pairs that collide with paragraph bookmark ids", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", { bookmarks: [{ id: 303, name: "paragraph-range" }] }, [
+        schema.node("bookmarkBoundary", { type: "start", id: 303, name: "node-range" }),
+        schema.text("synthetic"),
+        schema.node("bookmarkBoundary", { type: "end", id: 303 }),
+      ]),
+    ]);
+    const state = EditorState.create({ doc, plugins: [getBoundaryIntegrityPlugin()] });
+
+    const applied = state.applyTransaction(state.tr.insertText("x", 3));
+
+    expect(applied.transactions).toHaveLength(2);
+    expectValidBoundaryStructure(applied.state);
+    let boundaryCount = 0;
+    applied.state.doc.descendants((node) => {
+      if (node.type.name === "bookmarkBoundary") {
+        boundaryCount += 1;
+      }
+      return true;
+    });
+    expect(boundaryCount).toBe(0);
+  });
+
+  test("preserves paired-boundary validity under arbitrary deletion sequences", () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.tuple(fc.nat(), fc.nat()), { minLength: 1, maxLength: 20 }),
+        (deletions) => {
+          let state = EditorState.create({
+            doc: createBoundaryDocument(),
+            plugins: [getBoundaryIntegrityPlugin()],
+          });
+
+          for (const [first, second] of deletions) {
+            const paragraph = state.doc.firstChild;
+            if (!paragraph) {
+              throw new Error("Synthetic document must retain its paragraph");
+            }
+            const boundary = paragraph.content.size + 1;
+            const from = 1 + (Math.min(first, second) % boundary);
+            const to = 1 + (Math.max(first, second) % boundary);
+            const applied = state.applyTransaction(state.tr.delete(from, to));
+            state = applied.state;
+            expectValidBoundaryStructure(state);
+          }
+        },
+      ),
     );
   });
 });

--- a/packages/core/src/prosemirror/extensions/nodes/BookmarkBoundaryExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/BookmarkBoundaryExtension.ts
@@ -1,6 +1,17 @@
 /** Zero-width bookmark boundary that preserves its position through ProseMirror edits. */
 
-import { expectBookmarkBoundaryAttrs } from "../../bookmarkBoundaryAttrs";
+import type { Node as PMNode } from "prosemirror-model";
+import { Plugin } from "prosemirror-state";
+
+import { readParagraphAttrs } from "../../attrs";
+import {
+  expectBookmarkBoundaryAttrs,
+  readBookmarkBoundaryAttrs,
+} from "../../bookmarkBoundaryAttrs";
+import {
+  findInvalidBookmarkBoundaryIds,
+  type BookmarkBoundaryOccurrence,
+} from "../../bookmarkBoundaryIntegrity";
 import { createNodeExtension } from "../create";
 
 type BookmarkBoundaryOptions = {
@@ -22,6 +33,46 @@ function readOptionalColumn(dom: HTMLElement, attribute: string): number | undef
 
 /** The node name, for callers asking whether a paragraph holds any content. */
 export const BOOKMARK_BOUNDARY_NODE_NAME = "bookmarkBoundary";
+
+type PositionedNode = {
+  position: number;
+  node: PMNode;
+};
+
+type PositionedBoundary = BookmarkBoundaryOccurrence & PositionedNode;
+
+const collectInvalidBoundaries = (doc: PMNode): PositionedNode[] => {
+  const boundaries: PositionedBoundary[] = [];
+  const malformedBoundaries: PositionedNode[] = [];
+  const paragraphBookmarkIds = new Set<number>();
+
+  doc.descendants((node, position) => {
+    if (node.type.name === "paragraph") {
+      const attrs = readParagraphAttrs(node);
+      if (attrs.ok) {
+        for (const bookmark of attrs.value.bookmarks ?? []) {
+          paragraphBookmarkIds.add(bookmark.id);
+        }
+      }
+    }
+    if (node.type.name !== BOOKMARK_BOUNDARY_NODE_NAME) {
+      return true;
+    }
+
+    const result = readBookmarkBoundaryAttrs(node);
+    if (!result.ok) {
+      malformedBoundaries.push({ position, node });
+      return false;
+    }
+    const attrs = result.value;
+    const boundary = { id: attrs.id, type: attrs.type, position, node };
+    boundaries.push(boundary);
+    return false;
+  });
+
+  const invalidIds = findInvalidBookmarkBoundaryIds(boundaries, paragraphBookmarkIds);
+  return [...boundaries.filter(({ id }) => invalidIds.has(id)), ...malformedBoundaries];
+};
 
 export const BookmarkBoundaryExtension = createNodeExtension<BookmarkBoundaryOptions>({
   name: BOOKMARK_BOUNDARY_NODE_NAME,
@@ -90,5 +141,29 @@ export const BookmarkBoundaryExtension = createNodeExtension<BookmarkBoundaryOpt
         },
       ];
     },
+  }),
+  onSchemaReady: () => ({
+    plugins: [
+      new Plugin({
+        appendTransaction(transactions, _oldState, newState) {
+          if (!transactions.some(({ docChanged }) => docChanged)) {
+            return null;
+          }
+
+          const invalidBoundaries = collectInvalidBoundaries(newState.doc);
+          if (invalidBoundaries.length === 0) {
+            return null;
+          }
+
+          const transaction = newState.tr;
+          for (const { node, position } of invalidBoundaries.toSorted(
+            (first, second) => second.position - first.position,
+          )) {
+            transaction.delete(position, position + node.nodeSize);
+          }
+          return transaction;
+        },
+      }),
+    ],
   }),
 });

--- a/packages/core/src/prosemirror/styles/resolvedStyleAttrs-list.test.ts
+++ b/packages/core/src/prosemirror/styles/resolvedStyleAttrs-list.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { createNumberingMap, parseNumbering } from "../../docx/numberingParser";
-import { listAttrsFromResolvedStyle } from "./resolvedStyleAttrs";
+import { listAttrsFromResolvedStyle, listLevelAttrPatch } from "./resolvedStyleAttrs";
 
 const W = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
 const MC = 'xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"';
@@ -31,8 +31,17 @@ const NUMBERING_CUSTOM = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?
       <w:pPr><w:ind w:left="360" w:hanging="360"/></w:pPr>
     </w:lvl>
   </w:abstractNum>
+  <w:abstractNum w:abstractNumId="11">
+    <w:lvl w:ilvl="0">
+      <w:start w:val="1"/>
+      <w:numFmt w:val="none"/>
+      <w:lvlText w:val=""/>
+      <w:pPr><w:ind w:left="700" w:hanging="700"/></w:pPr>
+    </w:lvl>
+  </w:abstractNum>
   <w:num w:numId="1"><w:abstractNumId w:val="6"/></w:num>
   <w:num w:numId="2"><w:abstractNumId w:val="10"/></w:num>
+  <w:num w:numId="3"><w:abstractNumId w:val="11"/></w:num>
 </w:numbering>`;
 
 describe("listAttrsFromResolvedStyle (#765 applyStyle)", () => {
@@ -87,5 +96,22 @@ describe("listAttrsFromResolvedStyle (#765 applyStyle)", () => {
     );
     expect(attrs?.["numPr"]).toEqual({ numId: 2, ilvl: 0 });
     expect(attrs?.["listMarker"]).toBeNull();
+  });
+
+  test("keeps markerless level indentation without an empty hanging slot", () => {
+    const attrs = listAttrsFromResolvedStyle({ paragraphFormatting: { numPr: { numId: 3 } } }, map);
+
+    expect(attrs?.["listNumFmt"]).toBe("none");
+    expect(attrs?.["indentLeft"]).toBe(700);
+    expect(attrs?.["indentFirstLine"]).toBeUndefined();
+    expect(attrs?.["hangingIndent"]).toBeUndefined();
+  });
+
+  test("clears the hanging slot when a list command targets a markerless level", () => {
+    const attrs = listLevelAttrPatch({}, { numId: 3, ilvl: 0 }, map);
+
+    expect(attrs["indentLeft"]).toBe(700);
+    expect(attrs["indentFirstLine"]).toBeNull();
+    expect(attrs["hangingIndent"]).toBeNull();
   });
 });

--- a/packages/core/src/prosemirror/styles/resolvedStyleAttrs.ts
+++ b/packages/core/src/prosemirror/styles/resolvedStyleAttrs.ts
@@ -9,7 +9,11 @@
  * identical paragraph attrs.
  */
 
-import { computeListRendering, type NumberingMap } from "../../docx/numberingParser";
+import {
+  computeListRendering,
+  numberingLevelHasMarkerSlot,
+  type NumberingMap,
+} from "../../docx/numberingParser";
 import { tableOfContentsStyleLevel } from "../../utils/tableOfContentsStyle";
 import { setAutospacingBaseValue } from "../autospacingBase";
 import { CLEARED_LIST_RENDERING_ATTRS } from "../listMarker";
@@ -123,7 +127,7 @@ export function listAttrsFromResolvedStyle(
     }
     const styleHasFirstLine =
       ppr?.indentFirstLine !== undefined || ppr?.hangingIndent !== undefined;
-    if (!styleHasFirstLine) {
+    if (!styleHasFirstLine && numberingLevelHasMarkerSlot(level)) {
       if (level.pPr.indentFirstLine !== undefined) {
         attrs["indentFirstLine"] = level.pPr.indentFirstLine;
       }
@@ -170,13 +174,14 @@ export function listLevelAttrPatch(
   numbering: NumberingMap | null | undefined,
 ): Record<string, unknown> {
   const level = numbering?.getLevel(numPr.numId, numPr.ilvl);
+  const hasMarkerSlot = level ? numberingLevelHasMarkerSlot(level) : false;
   return {
     ...listAttrsFromNumbering(numPr, numbering),
     // Inline LISTNUM fields still belong to this paragraph after a level
     // change; their relative child-level advance moves with it.
     listImplicitChildLevelAdvances: attrs.listImplicitChildLevelAdvances ?? null,
     indentLeft: level?.pPr?.indentLeft ?? null,
-    indentFirstLine: level?.pPr?.indentFirstLine ?? null,
-    hangingIndent: level?.pPr?.hangingIndent ?? null,
+    indentFirstLine: hasMarkerSlot ? (level?.pPr?.indentFirstLine ?? null) : null,
+    hangingIndent: hasMarkerSlot ? (level?.pPr?.hangingIndent ?? null) : null,
   };
 }

--- a/packages/react/src/paged-editor/HiddenProseMirror.tsx
+++ b/packages/react/src/paged-editor/HiddenProseMirror.tsx
@@ -35,6 +35,7 @@ import {
   createHiddenEditorManager,
   type CollaborationModules,
   type HiddenEditorManager,
+  type HiddenEditorTransactionUpdate,
   type HiddenProseMirrorCollaboration,
   type HiddenProseMirrorRemoteSelection,
 } from "@stll/folio-core/controller/hiddenEditorManager";
@@ -75,7 +76,7 @@ export type HiddenProseMirrorProps = {
   /** Whether the editor is read-only */
   readOnly?: boolean;
   /** Callback when document changes via transaction */
-  onTransaction?: (transaction: Transaction, newState: EditorState) => void;
+  onTransaction?: (update: HiddenEditorTransactionUpdate) => void;
   /** Callback when selection changes */
   onSelectionChange?: (state: EditorState) => void;
   /** External ProseMirror plugins */
@@ -289,7 +290,7 @@ export const HiddenProseMirror = forwardRef<HiddenProseMirrorRef, HiddenProseMir
         getReadOnly: () => readOnlyRef.current,
         getDocumentIdentity: () => documentIdentityRef.current,
         getDocumentContext: () => documentRef.current,
-        onTransaction: (transaction, newState) => onTransactionRef.current?.(transaction, newState),
+        onTransaction: (update) => onTransactionRef.current?.(update),
         onSelectionChange: (state) => onSelectionChangeRef.current?.(state),
         onKeyDown: (view, event) => onKeyDownRef.current?.(view, event) ?? false,
         onCopy: () => onCopyRef.current?.(),

--- a/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/packages/react/src/paged-editor/PagedEditor.tsx
@@ -44,6 +44,7 @@ import { createFolioAIEditSnapshot } from "@stll/folio-core/ai-edits/snapshot";
 import { createFolioEditor } from "@stll/folio-core/controller/folioEditor";
 import type { FolioEditor, FolioEditorDocumentIO } from "@stll/folio-core/controller/folioEditor";
 import { createFolioEditorEmitter } from "@stll/folio-core/controller/folioEditorEvents";
+import type { HiddenEditorTransactionUpdate } from "@stll/folio-core/controller/hiddenEditorManager";
 import { resolveActiveEditorStory } from "@stll/folio-core/controller/activeEditorStory";
 import { suggestionModeKey } from "@stll/folio-core/prosemirror/plugins/suggestionMode";
 import { createLatestRequestGate } from "@stll/folio-core/controller/latestRequestGate";
@@ -167,7 +168,7 @@ import {
 } from "@stll/folio-core/paged-layout/sectionGeometry";
 import { resizeColumnPair } from "@stll/folio-core/paged-layout/tableColumnResize";
 import { tableInsertButtonOffset } from "@stll/folio-core/paged-layout/tableInsertButtonGeometry";
-import { getTransactionDirtyRange } from "@stll/folio-core/paged-layout/transactionDirtyRange";
+import { getTransactionsDirtyRange } from "@stll/folio-core/paged-layout/transactionDirtyRange";
 // Table commands (for quick-action insert buttons)
 import { addRowBelow, addColumnRight } from "@stll/folio-core/prosemirror";
 import { findStartPosForParaId } from "@stll/folio-core/prosemirror/utils/findParagraphByParaId";
@@ -2751,7 +2752,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
      * Handle PM transaction - re-layout on content/selection change.
      */
     const handleTransaction = useCallback(
-      (transaction: Transaction, newState: EditorState) => {
+      ({ transactions, newState, docChanged }: HiddenEditorTransactionUpdate) => {
         // Keep the anonymization match list mirrored in a ref so the
         // overlay recompute reads the latest set without depending on
         // a state setter inside its useCallback closure. We pull off
@@ -2786,7 +2787,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
           // the settled layout — the same deferral the selection overlay uses.
           // Only project inline when ranges change without a doc change (no
           // reflow pending, so the current layout is already correct).
-          if (!transaction.docChanged) {
+          if (!docChanged) {
             updateDirectivesOverlay();
           }
         }
@@ -2809,7 +2810,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
             entries: nextPreviewEntries,
             mode: nextPreviewMode,
           };
-          if (!transaction.docChanged) {
+          if (!docChanged) {
             if (nextPreviewMode !== previousPreview.mode) {
               scheduleLayout(newState, null);
             } else {
@@ -2837,12 +2838,12 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
             suggestions: nextAiSuggestions,
             focusedId: nextAiFocusedId,
           };
-          if (!transaction.docChanged) {
+          if (!docChanged) {
             updateAISuggestionsOverlay();
           }
         }
 
-        if (transaction.docChanged) {
+        if (docChanged) {
           // Increment state sequence to signal document changed
           syncCoordinator.incrementStateSeq();
 
@@ -2858,7 +2859,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
           hideSelectionOverlayDuringInput(newState);
 
           // Content changed - schedule layout (coalesced via rAF)
-          scheduleLayout(newState, getTransactionDirtyRange(transaction));
+          scheduleLayout(newState, getTransactionsDirtyRange(transactions));
 
           // Convert back to the Folio document model off the keypress path.
           scheduleDocumentChangeNotification();
@@ -2871,7 +2872,7 @@ export const PagedEditor = forwardRef<PagedEditorRef, PagedEditorProps>(
         // (e.g. arrow keys, clicks). For doc changes, the overlay will be updated
         // after layout completes via the useEffect([layout]) hook, avoiding cursor
         // flicker from stale DOM positions.
-        if (!transaction.docChanged) {
+        if (!docChanged) {
           updateSelectionOverlay(newState);
         }
       },

--- a/packages/vue/src/composables/useDocxEditor.ts
+++ b/packages/vue/src/composables/useDocxEditor.ts
@@ -27,7 +27,7 @@
 import { onScopeDispose, ref, shallowRef, toValue, watch } from "vue";
 import type { MaybeRefOrGetter, Ref } from "vue";
 
-import type { EditorState, Plugin, Transaction } from "prosemirror-state";
+import type { EditorState, Plugin } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
 
 import {
@@ -58,6 +58,7 @@ import {
 import type {
   CollaborationModules,
   HiddenEditorManager,
+  HiddenEditorTransactionUpdate,
   HiddenProseMirrorCollaboration,
   HiddenProseMirrorRemoteSelection,
 } from "@stll/folio-core/controller/hiddenEditorManager";
@@ -94,7 +95,7 @@ import {
   getPageSize,
   twipsToPixels,
 } from "@stll/folio-core/paged-layout/sectionGeometry";
-import { getTransactionDirtyRange } from "@stll/folio-core/paged-layout/transactionDirtyRange";
+import { getTransactionsDirtyRange } from "@stll/folio-core/paged-layout/transactionDirtyRange";
 import { fromProseDoc } from "@stll/folio-core/prosemirror/conversion/fromProseDoc";
 import { ExtensionManager } from "@stll/folio-core/prosemirror/extensions/ExtensionManager";
 import {
@@ -895,12 +896,16 @@ export function useDocxEditor(options: UseDocxEditorOptions): UseDocxEditorRetur
     { flush: "post" },
   );
 
-  function handleTransaction(transaction: Transaction, newState: EditorState): void {
+  function handleTransaction({
+    transactions,
+    newState,
+    docChanged,
+  }: HiddenEditorTransactionUpdate): void {
     editorState.value = newState;
-    if (transaction.docChanged) {
+    if (docChanged) {
       isDirty.value = true;
       syncCoordinator.incrementStateSeq();
-      scheduler.schedule(newState, getTransactionDirtyRange(transaction));
+      scheduler.schedule(newState, getTransactionsDirtyRange(transactions));
       scheduleDocumentChangeNotification();
     }
     syncCoordinator.requestRender();

--- a/tests/visual/editing-flows.spec.ts
+++ b/tests/visual/editing-flows.spec.ts
@@ -68,6 +68,15 @@ function bodyText(page: Page): Promise<string> {
   );
 }
 
+function bodyDocumentFingerprint(page: Page): Promise<string> {
+  return page.evaluate(() =>
+    JSON.stringify(
+      globalThis.__folioPlayground?.getEditorRef()?.getEditorRef()?.getView()?.state.doc.toJSON() ??
+        null,
+    ),
+  );
+}
+
 function paintedBodyContains(page: Page, text: string): Promise<boolean> {
   return page.evaluate(
     (expected) =>
@@ -433,14 +442,23 @@ test.describe("lists", () => {
     await page.keyboard.press("Backspace");
     await expect.poll(() => caretParagraphNumId(page)).toBe(0);
 
+    // Backspace at a paragraph start may clear indentation or join a block
+    // before it reaches visible text. Every keypress must still mutate the
+    // document; none may be swallowed while those structural steps complete.
     const modelLengthBeforeDelete = (await bodyText(page)).length;
+    let deletedText = false;
     for (let index = 0; index < 6; index += 1) {
+      const documentBeforeKey = await bodyDocumentFingerprint(page);
       await page.keyboard.press("Backspace");
-      if ((await bodyText(page)).length < modelLengthBeforeDelete) {
+      await expect.poll(() => bodyDocumentFingerprint(page)).not.toBe(documentBeforeKey);
+      const currentLength = (await bodyText(page)).length;
+      if (currentLength < modelLengthBeforeDelete) {
+        expect(currentLength).toBe(modelLengthBeforeDelete - 1);
+        deletedText = true;
         break;
       }
     }
-    await expect.poll(async () => (await bodyText(page)).length).toBe(modelLengthBeforeDelete - 1);
+    expect(deletedText).toBe(true);
   });
 });
 

--- a/tests/visual/editing-flows.spec.ts
+++ b/tests/visual/editing-flows.spec.ts
@@ -68,6 +68,15 @@ function bodyText(page: Page): Promise<string> {
   );
 }
 
+function paintedBodyTextLength(page: Page): Promise<number> {
+  return page.evaluate(() =>
+    [...document.querySelectorAll(".layout-page-content")].reduce(
+      (length, element) => length + (element.textContent?.length ?? 0),
+      0,
+    ),
+  );
+}
+
 /** Count body ProseMirror nodes by type name in the live document. */
 function countNodes(page: Page, typeName: string): Promise<number> {
   return page.evaluate((name) => {
@@ -359,6 +368,34 @@ test.describe("lists", () => {
     // Clicking the already-active numbered-list button clears list formatting.
     await clickToolbarButton(page, "Numbered List");
     await expect.poll(() => caretParagraphNumId(page)).toBeNull();
+  });
+
+  test("Backspace continues into text after exiting a style-numbered paragraph", async ({
+    page,
+  }) => {
+    await mountFixture(page, "sample.docx");
+    const marker = page.locator(".layout-list-marker").first();
+    await marker.click();
+    await page.keyboard.press("End");
+    await page.keyboard.press("Enter");
+    const inserted = "Synthetic deletion target";
+    await page.keyboard.type(inserted);
+    for (let index = 0; index < inserted.length; index += 1) {
+      await page.keyboard.press("Backspace");
+    }
+    await page.keyboard.press("Backspace");
+    await expect.poll(() => caretParagraphNumId(page)).toBe(0);
+
+    const modelLengthBeforeDelete = (await bodyText(page)).length;
+    const paintedLengthBeforeDelete = await paintedBodyTextLength(page);
+    for (let index = 0; index < 6; index += 1) {
+      await page.keyboard.press("Backspace");
+      if ((await bodyText(page)).length < modelLengthBeforeDelete) {
+        break;
+      }
+    }
+    await expect.poll(async () => (await bodyText(page)).length).toBe(modelLengthBeforeDelete - 1);
+    await expect.poll(() => paintedBodyTextLength(page)).toBeLessThan(paintedLengthBeforeDelete);
   });
 });
 

--- a/tests/visual/editing-flows.spec.ts
+++ b/tests/visual/editing-flows.spec.ts
@@ -68,12 +68,13 @@ function bodyText(page: Page): Promise<string> {
   );
 }
 
-function paintedBodyTextLength(page: Page): Promise<number> {
-  return page.evaluate(() =>
-    [...document.querySelectorAll(".layout-page-content")].reduce(
-      (length, element) => length + (element.textContent?.length ?? 0),
-      0,
-    ),
+function paintedBodyContains(page: Page, text: string): Promise<boolean> {
+  return page.evaluate(
+    (expected) =>
+      [...document.querySelectorAll(".layout-page-content")].some((element) =>
+        element.textContent?.includes(expected),
+      ),
+    text,
   );
 }
 
@@ -378,16 +379,61 @@ test.describe("lists", () => {
     await marker.click();
     await page.keyboard.press("End");
     await page.keyboard.press("Enter");
-    const inserted = "Synthetic deletion target";
+    const inserted = "Synthetic paired deletion target";
     await page.keyboard.type(inserted);
-    for (let index = 0; index < inserted.length; index += 1) {
+
+    await page.evaluate((expected) => {
+      const view = globalThis.__folioPlayground?.getEditorRef()?.getEditorRef()?.getView();
+      if (!view) throw new Error("Editor view is unavailable");
+      const boundary = view.state.schema.nodes.bookmarkBoundary;
+      if (!boundary) throw new Error("Bookmark boundary node is unavailable");
+      let targetStart: number | null = null;
+      view.state.doc.descendants((node, position) => {
+        const matchIndex = node.text?.indexOf(expected) ?? -1;
+        if (matchIndex >= 0) {
+          targetStart = position + matchIndex;
+          return false;
+        }
+        return true;
+      });
+      if (targetStart === null) throw new Error("Synthetic target is unavailable");
+      const targetEnd = targetStart + expected.length;
+      const transaction = view.state.tr
+        .insert(targetEnd, boundary.create({ type: "end", id: 707 }))
+        .insert(targetStart, boundary.create({ type: "start", id: 707, name: "synthetic-range" }));
+      view.dispatch(transaction);
+      view.focus();
+    }, inserted);
+
+    // One edit removes visible text and one invisible endpoint. Its partner
+    // must disappear atomically, and paint must consume the full transaction
+    // batch rather than only the initiating edit.
+    await page.evaluate(() => {
+      const view = globalThis.__folioPlayground?.getEditorRef()?.getEditorRef()?.getView();
+      if (!view) throw new Error("Editor view is unavailable");
+      let endPosition: number | null = null;
+      view.state.doc.descendants((node, position) => {
+        if (node.type.name === "bookmarkBoundary" && node.attrs.type === "end") {
+          endPosition = position;
+          return false;
+        }
+        return true;
+      });
+      if (endPosition === null) throw new Error("Synthetic endpoint is unavailable");
+      view.dispatch(view.state.tr.delete(endPosition - 1, endPosition + 1));
+      view.focus();
+    });
+    await expect.poll(() => countNodes(page, "bookmarkBoundary")).toBe(0);
+    await expect.poll(async () => (await bodyText(page)).includes(inserted)).toBe(false);
+    await expect.poll(() => paintedBodyContains(page, inserted)).toBe(false);
+
+    for (let index = 0; index < inserted.length - 1; index += 1) {
       await page.keyboard.press("Backspace");
     }
     await page.keyboard.press("Backspace");
     await expect.poll(() => caretParagraphNumId(page)).toBe(0);
 
     const modelLengthBeforeDelete = (await bodyText(page)).length;
-    const paintedLengthBeforeDelete = await paintedBodyTextLength(page);
     for (let index = 0; index < 6; index += 1) {
       await page.keyboard.press("Backspace");
       if ((await bodyText(page)).length < modelLengthBeforeDelete) {
@@ -395,7 +441,6 @@ test.describe("lists", () => {
       }
     }
     await expect.poll(async () => (await bodyText(page)).length).toBe(modelLengthBeforeDelete - 1);
-    await expect.poll(() => paintedBodyTextLength(page)).toBeLessThan(paintedLengthBeforeDelete);
   });
 });
 


### PR DESCRIPTION
## Summary

- centralize active-list detection so numbering-off paragraphs fall through to ordinary editing commands
- enforce complete, ordered pairs for inline range metadata after every document transaction
- propagate complete applied transaction batches through React and Vue layout invalidation
- share one pair classifier between paste cleanup and live editing

## Tests

- generated deletion sequences over overlapping synthetic ranges
- transaction-batch dirty-range mapping in final document coordinates
- synthetic browser interaction covering model and painted-text convergence
- full core, property, interaction, typecheck, lint, formatting, build, and adapter parity checks