### PR TITLE
fix(core): preserve formatting across paragraph splits and merges

### DIFF
--- a/.changeset/curvy-plums-compare.md
+++ b/.changeset/curvy-plums-compare.md
@@ -1,0 +1,6 @@
+---
+"@stll/folio-core": patch
+"@stll/folio-agents": patch
+---
+
+Preserve paragraph formatting when a comparison splits or merges paragraphs.

--- a/api-reports/core/ai-edits.api.md
+++ b/api-reports/core/ai-edits.api.md
@@ -279,6 +279,8 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     offset: number;
     separator?: string;
     blockId: string;
+    firstParagraphProperties?: FolioAIBlockParagraphProperties;
+    secondParagraphProperties?: FolioAIBlockParagraphProperties;
 } |
 /**
 * Add a whole table next to the anchor block, its rows marked inserted in
@@ -328,6 +330,7 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     type: "mergeBlockWithNext";
     separator?: string;
     blockId: string;
+    mergedParagraphProperties?: FolioAIBlockParagraphProperties;
 } | {
     id: string;
     type: "commentOnBlock";

--- a/api-reports/core/compat-eigenpal.api.md
+++ b/api-reports/core/compat-eigenpal.api.md
@@ -935,6 +935,8 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     offset: number;
     separator?: string;
     blockId: string;
+    firstParagraphProperties?: FolioAIBlockParagraphProperties;
+    secondParagraphProperties?: FolioAIBlockParagraphProperties;
 } |
 /**
 * Add a whole table next to the anchor block, its rows marked inserted in
@@ -984,6 +986,7 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     type: "mergeBlockWithNext";
     separator?: string;
     blockId: string;
+    mergedParagraphProperties?: FolioAIBlockParagraphProperties;
 } | {
     id: string;
     type: "commentOnBlock";

--- a/api-reports/core/index.api.md
+++ b/api-reports/core/index.api.md
@@ -935,6 +935,8 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     offset: number;
     separator?: string;
     blockId: string;
+    firstParagraphProperties?: FolioAIBlockParagraphProperties;
+    secondParagraphProperties?: FolioAIBlockParagraphProperties;
 } |
 /**
 * Add a whole table next to the anchor block, its rows marked inserted in
@@ -984,6 +986,7 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     type: "mergeBlockWithNext";
     separator?: string;
     blockId: string;
+    mergedParagraphProperties?: FolioAIBlockParagraphProperties;
 } | {
     id: string;
     type: "commentOnBlock";

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -351,8 +351,8 @@ export const FOLIO_DOCUMENT_OPERATION_KEYS_BY_TYPE: Readonly<{
     readonly insertBeforeBlock: readonly ["id", "type", "blockId", "severity", "area", "precondition", "suggestionId", "text", "inheritFormatting", "alignment", "spacing", "listLevel", "moveId", "pageBreakBefore", "styleId", "comment"];
     readonly replaceBlock: readonly ["id", "type", "blockId", "severity", "area", "precondition", "suggestionId", "text", "preserveFormatting", "styleId", "comment"];
     readonly deleteBlock: readonly ["id", "type", "blockId", "severity", "area", "precondition", "suggestionId", "moveId", "comment"];
-    readonly splitBlock: readonly ["id", "type", "blockId", "severity", "area", "precondition", "suggestionId", "offset", "separator"];
-    readonly mergeBlockWithNext: readonly ["id", "type", "blockId", "severity", "area", "precondition", "suggestionId", "separator"];
+    readonly splitBlock: readonly ["id", "type", "blockId", "severity", "area", "precondition", "suggestionId", "offset", "separator", "firstParagraphProperties", "secondParagraphProperties"];
+    readonly mergeBlockWithNext: readonly ["id", "type", "blockId", "severity", "area", "precondition", "suggestionId", "separator", "mergedParagraphProperties"];
     readonly setBlockParagraphProperties: readonly ["id", "type", "blockId", "severity", "area", "precondition", "suggestionId", "properties"];
     readonly insertTable: readonly ["id", "type", "blockId", "severity", "area", "precondition", "suggestionId", "position", "rows"];
     readonly deleteTable: readonly ["id", "type", "blockId", "severity", "area", "precondition", "suggestionId"];
@@ -633,6 +633,8 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     offset: number;
     separator?: string;
     blockId: string;
+    firstParagraphProperties?: FolioAIBlockParagraphProperties;
+    secondParagraphProperties?: FolioAIBlockParagraphProperties;
 } |
 /**
 * Add a whole table next to the anchor block, its rows marked inserted in
@@ -682,6 +684,7 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
     type: "mergeBlockWithNext";
     separator?: string;
     blockId: string;
+    mergedParagraphProperties?: FolioAIBlockParagraphProperties;
 } | {
     id: string;
     type: "commentOnBlock";

--- a/packages/agents/src/operation-conformance.test.ts
+++ b/packages/agents/src/operation-conformance.test.ts
@@ -411,12 +411,27 @@ const CONTRACT_OPERATION_FIXTURES: Record<FolioDocumentOperationType, Record<str
     blockId: "0304003A",
     offset: 12,
     separator: " ",
+    firstParagraphProperties: {
+      styleId: "OpeningBody",
+      alignment: "center",
+      spacing: { spaceBefore: 240 },
+    },
+    secondParagraphProperties: {
+      styleId: "ClosingBody",
+      alignment: "right",
+      spacing: { spaceAfter: 360 },
+    },
   },
   mergeBlockWithNext: {
     id: "op-merge-block-with-next",
     type: "mergeBlockWithNext",
     blockId: "0304003A",
     separator: " ",
+    mergedParagraphProperties: {
+      styleId: "JoinedBody",
+      alignment: "both",
+      spacing: { lineSpacing: 480, lineSpacingRule: "exact" },
+    },
   },
   insertTable: {
     id: "op-insert-table",

--- a/packages/agents/src/operation-schema.ts
+++ b/packages/agents/src/operation-schema.ts
@@ -215,6 +215,22 @@ export const FOLIO_CLEARABLE_PARAGRAPH_SPACING_JSON_SCHEMA = {
     "Complete direct paragraph spacing (`w:spacing`); omitted attributes stay absent, while zero and false remain explicit. Null removes the direct spacing child and restores style inheritance.",
 } as const satisfies FolioJsonSchema;
 
+export const FOLIO_BLOCK_PARAGRAPH_PROPERTIES_JSON_SCHEMA = {
+  type: "object",
+  description: "The paragraph properties to set; at least one.",
+  properties: {
+    styleId: FOLIO_CLEARABLE_PARAGRAPH_STYLE_ID_JSON_SCHEMA,
+    listLevel: FOLIO_CLEARABLE_LIST_LEVEL_JSON_SCHEMA,
+    alignment: {
+      oneOf: [{ type: "string", enum: FOLIO_PARAGRAPH_ALIGNMENT_VALUES }, { type: "null" }],
+      description: "Direct paragraph alignment; null restores style inheritance.",
+    },
+    spacing: FOLIO_CLEARABLE_PARAGRAPH_SPACING_JSON_SCHEMA,
+  },
+  minProperties: 1,
+  additionalProperties: false,
+} as const satisfies FolioJsonSchema;
+
 /**
  * JSON Schema (draft-07 compatible) for ONE document operation: the full
  * union accepted by `parseFolioDocumentOperationBatch` in
@@ -443,6 +459,16 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA: FolioJsonSchema = {
           type: "string",
           description: "Text at `offset` the break replaces, usually the space between the halves.",
         },
+        firstParagraphProperties: {
+          ...FOLIO_BLOCK_PARAGRAPH_PROPERTIES_JSON_SCHEMA,
+          description:
+            "Properties for the first result; omitted properties keep the source paragraph's value.",
+        },
+        secondParagraphProperties: {
+          ...FOLIO_BLOCK_PARAGRAPH_PROPERTIES_JSON_SCHEMA,
+          description:
+            "Properties for the second result; omitted properties keep the source paragraph's value.",
+        },
       },
       required: ["id", "type", "blockId", "offset"],
       additionalProperties: false,
@@ -460,6 +486,11 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA: FolioJsonSchema = {
           type: "string",
           description: "Text the join inserts between the two halves, usually a space.",
         },
+        mergedParagraphProperties: {
+          ...FOLIO_BLOCK_PARAGRAPH_PROPERTIES_JSON_SCHEMA,
+          description:
+            "Properties for the joined result; omitted properties keep the first paragraph's value.",
+        },
       },
       required: ["id", "type", "blockId"],
       additionalProperties: false,
@@ -473,21 +504,7 @@ export const FOLIO_DOCUMENT_OPERATION_JSON_SCHEMA: FolioJsonSchema = {
         ...suggestionIdProperty,
         type: { type: "string", enum: ["setBlockParagraphProperties"] },
         blockId: blockIdProperty,
-        properties: {
-          type: "object",
-          description: "The paragraph properties to set; at least one.",
-          properties: {
-            styleId: FOLIO_CLEARABLE_PARAGRAPH_STYLE_ID_JSON_SCHEMA,
-            listLevel: FOLIO_CLEARABLE_LIST_LEVEL_JSON_SCHEMA,
-            alignment: {
-              oneOf: [{ type: "string", enum: FOLIO_PARAGRAPH_ALIGNMENT_VALUES }, { type: "null" }],
-              description: "Direct paragraph alignment; null restores style inheritance.",
-            },
-            spacing: FOLIO_CLEARABLE_PARAGRAPH_SPACING_JSON_SCHEMA,
-          },
-          minProperties: 1,
-          additionalProperties: false,
-        },
+        properties: FOLIO_BLOCK_PARAGRAPH_PROPERTIES_JSON_SCHEMA,
       },
       required: ["id", "type", "blockId", "properties"],
       additionalProperties: false,

--- a/packages/agents/src/suggest-changes-options.test.ts
+++ b/packages/agents/src/suggest-changes-options.test.ts
@@ -231,11 +231,18 @@ describe("suggest_changes schema + capability description follow operationTypes"
           "insertAfterBlock",
           "insertBeforeBlock",
           "replaceBlock",
+          "splitBlock",
+          "mergeBlockWithNext",
           "setBlockParagraphProperties",
         ],
       }),
     );
-    const paragraphProperties = propertyOf(itemSchema, "properties");
+    const paragraphPropertyShapes = [
+      propertyOf(itemSchema, "properties"),
+      propertyOf(itemSchema, "firstParagraphProperties"),
+      propertyOf(itemSchema, "secondParagraphProperties"),
+      propertyOf(itemSchema, "mergedParagraphProperties"),
+    ];
     const clearableStyle = [{ type: "string" }, { type: "null" }];
     const clearableListLevel = [
       { type: "integer", minimum: 0, maximum: Number.MAX_SAFE_INTEGER },
@@ -244,8 +251,10 @@ describe("suggest_changes schema + capability description follow operationTypes"
 
     expect(propertyOf(itemSchema, "styleId")["oneOf"]).toEqual(clearableStyle);
     expect(propertyOf(itemSchema, "listLevel")["oneOf"]).toEqual(clearableListLevel);
-    expect(propertyOf(paragraphProperties, "styleId")["oneOf"]).toEqual(clearableStyle);
-    expect(propertyOf(paragraphProperties, "listLevel")["oneOf"]).toEqual(clearableListLevel);
+    for (const paragraphProperties of paragraphPropertyShapes) {
+      expect(propertyOf(paragraphProperties, "styleId")["oneOf"]).toEqual(clearableStyle);
+      expect(propertyOf(paragraphProperties, "listLevel")["oneOf"]).toEqual(clearableListLevel);
+    }
   });
 
   test("documentVersion pins a top-level enum and marks documentVersion required", () => {

--- a/packages/agents/src/tools.ts
+++ b/packages/agents/src/tools.ts
@@ -12,6 +12,7 @@ import {
   FOLIO_TEXT_RANGE_JSON_SCHEMA,
 } from "./codecs";
 import {
+  FOLIO_BLOCK_PARAGRAPH_PROPERTIES_JSON_SCHEMA,
   FOLIO_CLEARABLE_LIST_LEVEL_JSON_SCHEMA,
   FOLIO_CLEARABLE_PARAGRAPH_SPACING_JSON_SCHEMA,
   FOLIO_CLEARABLE_PARAGRAPH_STYLE_ID_JSON_SCHEMA,
@@ -206,20 +207,24 @@ const OPERATION_PROPERTY_SCHEMAS = {
     additionalProperties: false,
   },
   properties: {
-    type: "object",
+    ...FOLIO_BLOCK_PARAGRAPH_PROPERTIES_JSON_SCHEMA,
     description:
       "Required for `setBlockParagraphProperties`: the paragraph properties to set. Null clears a direct property.",
-    properties: {
-      styleId: FOLIO_CLEARABLE_PARAGRAPH_STYLE_ID_JSON_SCHEMA,
-      listLevel: FOLIO_CLEARABLE_LIST_LEVEL_JSON_SCHEMA,
-      alignment: {
-        oneOf: [{ type: "string", enum: FOLIO_PARAGRAPH_ALIGNMENT_VALUES }, { type: "null" }],
-        description: "Direct paragraph alignment; null restores style inheritance.",
-      },
-      spacing: FOLIO_CLEARABLE_PARAGRAPH_SPACING_JSON_SCHEMA,
-    },
-    minProperties: 1,
-    additionalProperties: false,
+  },
+  firstParagraphProperties: {
+    ...FOLIO_BLOCK_PARAGRAPH_PROPERTIES_JSON_SCHEMA,
+    description:
+      "For `splitBlock`, properties for the first result; omitted properties keep the source paragraph's value.",
+  },
+  secondParagraphProperties: {
+    ...FOLIO_BLOCK_PARAGRAPH_PROPERTIES_JSON_SCHEMA,
+    description:
+      "For `splitBlock`, properties for the second result; omitted properties keep the source paragraph's value.",
+  },
+  mergedParagraphProperties: {
+    ...FOLIO_BLOCK_PARAGRAPH_PROPERTIES_JSON_SCHEMA,
+    description:
+      "For `mergeBlockWithNext`, properties for the joined result; omitted properties keep the first paragraph's value.",
   },
   listLevel: FOLIO_CLEARABLE_LIST_LEVEL_JSON_SCHEMA,
   offset: {

--- a/packages/core/src/ai-edits/apply.ts
+++ b/packages/core/src/ai-edits/apply.ts
@@ -403,10 +403,24 @@ const hasRepresentableCommentAnchor = (item: ResolvedBase, mode: FolioAIEditAppl
   }
 };
 
-const writesParagraphPropertyChange = (item: ResolvedOperation): boolean =>
-  item.operation.type === "setBlockParagraphProperties" ||
-  (isResolvedReplaceBlockOperation(item) &&
-    REPLACE_BLOCK_IMPACT[item.replaceBlockImpact].changesStyle);
+const writesParagraphPropertyChange = (item: ResolvedOperation): boolean => {
+  if (item.operation.type === "setBlockParagraphProperties") {
+    return true;
+  }
+  if (item.operation.type === "splitBlock") {
+    return (
+      item.operation.firstParagraphProperties !== undefined ||
+      item.operation.secondParagraphProperties !== undefined
+    );
+  }
+  if (item.operation.type === "mergeBlockWithNext") {
+    return item.operation.mergedParagraphProperties !== undefined;
+  }
+  return (
+    isResolvedReplaceBlockOperation(item) &&
+    REPLACE_BLOCK_IMPACT[item.replaceBlockImpact].changesStyle
+  );
+};
 
 type ReplaceBlockImpactOptions = {
   changesText: boolean;
@@ -647,6 +661,72 @@ const resolveFormattingFromStyle = ({
     fallback.alignment = attrs.alignmentFromStyle;
   }
   return Object.keys(fallback).length > 0 ? fallback : undefined;
+};
+
+type ApplyBlockParagraphPropertiesOptions = {
+  tr: Transaction;
+  position: number;
+  node: PMNode;
+  properties: FolioAIBlockParagraphProperties;
+  styleResolver: ReturnType<typeof getDocumentStyleResolver>;
+  numbering?: NumberingMap | null;
+  revisionInfo?: () => ParagraphPropertyChangeAttrs["info"];
+};
+
+type ApplyBlockParagraphPropertiesResult = {
+  tr: Transaction;
+  changed: boolean;
+  revisionId: number | null;
+};
+
+/**
+ * Apply one paragraph-property patch to a live node. A tracked patch stores
+ * the complete previous pPr: a partial snapshot cannot distinguish a property
+ * the change left alone from one it explicitly cleared when rejecting it.
+ */
+const applyBlockParagraphProperties = ({
+  tr,
+  position,
+  node,
+  properties,
+  styleResolver,
+  numbering = null,
+  revisionInfo,
+}: ApplyBlockParagraphPropertiesOptions): ApplyBlockParagraphPropertiesResult => {
+  const attrs = expectParagraphAttrs(node);
+  const resolvedFormattingFromStyle =
+    properties.styleId === undefined
+      ? resolveFormattingFromStyle({ attrs, styleId: attrs.styleId, styleResolver })
+      : resolveFormattingFromStyle({ attrs, styleId: properties.styleId, styleResolver });
+  const patch = paragraphPropertiesPatch({
+    node,
+    properties,
+    resolvedFormattingFromStyle,
+    numbering,
+  });
+  if (patch === null) {
+    return { tr, changed: false, revisionId: null };
+  }
+  const changeInfo = revisionInfo?.();
+  const change: ParagraphPropertyChangeAttrs | null = changeInfo
+    ? {
+        type: "paragraphPropertyChange",
+        info: changeInfo,
+        previousFormatting: paragraphPropertiesSnapshot(node),
+      }
+    : null;
+  const existing = attrs._propertyChanges;
+  return {
+    tr: tr.setNodeMarkup(position, undefined, {
+      ...node.attrs,
+      ...patch,
+      ...(change
+        ? { _propertyChanges: [...(Array.isArray(existing) ? existing : []), change] }
+        : {}),
+    }),
+    changed: true,
+    revisionId: change?.info.id ?? null,
+  };
 };
 
 type ApplyReplaceBlockStyleIdResult = {
@@ -2305,7 +2385,7 @@ const applyFolioAIEditOperationsInternal = ({
     // text and the diff produced no marks; the panel said "accepted"
     // but the doc was untouched.
     const stepsBefore = tr.steps.length;
-    let appliedRevisionIds: number[] | undefined;
+    let appliedRevisionIds: number[] = [];
 
     // Suggested mode covers the inline text/format operations plus the block and
     // table row/column structural operations (see
@@ -3032,50 +3112,32 @@ const applyFolioAIEditOperationsInternal = ({
         // properties applied, the merge silently did not.
         const blockPosition = tr.mapping.map(item.blockFrom);
         const liveBlock = tr.doc.nodeAt(blockPosition) ?? item.blockNode;
-        const liveAttrs = expectParagraphAttrs(liveBlock);
-        const resolvedFormattingFromStyle =
-          item.operation.properties.styleId === undefined
-            ? resolveFormattingFromStyle({
-                attrs: liveAttrs,
-                styleId: liveAttrs.styleId,
-                styleResolver,
-              })
-            : resolveFormattingFromStyle({
-                attrs: liveAttrs,
-                styleId: item.operation.properties.styleId,
-                styleResolver,
-              });
-        const patch = paragraphPropertiesPatch({
+        const appliedProperties = applyBlockParagraphProperties({
+          tr,
+          position: blockPosition,
           node: liveBlock,
           properties: item.operation.properties,
-          resolvedFormattingFromStyle,
+          styleResolver,
           numbering,
+          ...(mode === "direct"
+            ? {}
+            : {
+                revisionInfo: () => ({
+                  id: operationRevisionSeed++,
+                  author,
+                  date,
+                  ...trackedRevisionExtras,
+                }),
+              }),
         });
-        if (patch === null) {
+        if (!appliedProperties.changed) {
           skipped.push({ id: item.operation.id, reason: "noopOperation" });
           continue;
         }
-        if (mode === "direct") {
-          tr = tr.setNodeMarkup(blockPosition, undefined, { ...liveBlock.attrs, ...patch });
-          break;
+        tr = appliedProperties.tr;
+        if (appliedProperties.revisionId !== null) {
+          appliedRevisionIds = [appliedProperties.revisionId];
         }
-        // Word stores the COMPLETE old pPr inside `w:pPrChange`, so rejecting
-        // restores the properties wholesale within that scope. Storing only
-        // the keys this operation touched would leave a reject unable to tell
-        // "the change did not set this" from "the change cleared it".
-        const revisionId = operationRevisionSeed++;
-        const change: ParagraphPropertyChangeAttrs = {
-          type: "paragraphPropertyChange",
-          info: { id: revisionId, author, date, ...trackedRevisionExtras },
-          previousFormatting: paragraphPropertiesSnapshot(liveBlock),
-        };
-        const existing = expectParagraphAttrs(liveBlock)._propertyChanges;
-        tr = tr.setNodeMarkup(blockPosition, undefined, {
-          ...liveBlock.attrs,
-          ...patch,
-          _propertyChanges: [...(Array.isArray(existing) ? existing : []), change],
-        });
-        appliedRevisionIds = [revisionId];
         break;
       }
       case "splitBlock": {
@@ -3084,30 +3146,71 @@ const applyFolioAIEditOperationsInternal = ({
             tr = tr.delete(item.from, item.to);
           }
           tr = tr.split(item.from);
-          break;
+        } else {
+          const revisionIdMark = operationRevisionSeed++;
+          const info = { id: revisionIdMark, author, date, ...trackedRevisionExtras };
+          appliedRevisionIds = [revisionIdMark];
+          if (item.to > item.from && deletionType) {
+            const revisionIdSeparator = operationRevisionSeed++;
+            tr = tr.addMark(
+              item.from,
+              item.to,
+              deletionType.create({
+                revisionId: revisionIdSeparator,
+                author,
+                date,
+                ...trackedRevisionExtras,
+              }),
+            );
+            appliedRevisionIds.push(revisionIdSeparator);
+          }
+          tr = tr.split(item.from);
+          // The mark goes on the FIRST half: the break belongs to the paragraph
+          // it now ends, and a reader rejecting it closes that paragraph back
+          // over the second half.
+          tr = tr.setNodeAttribute(item.blockFrom, "pPrMark", { kind: "ins", info });
         }
-        const revisionIdMark = operationRevisionSeed++;
-        const info = { id: revisionIdMark, author, date, ...trackedRevisionExtras };
-        appliedRevisionIds = [revisionIdMark];
-        if (item.to > item.from && deletionType) {
-          const revisionIdSeparator = operationRevisionSeed++;
-          tr = tr.addMark(
-            item.from,
-            item.to,
-            deletionType.create({
-              revisionId: revisionIdSeparator,
-              author,
-              date,
-              ...trackedRevisionExtras,
-            }),
-          );
-          appliedRevisionIds = [revisionIdMark, revisionIdSeparator];
+
+        const allocateSplitParagraphPropertyRevisionInfo = () => ({
+          id: operationRevisionSeed++,
+          author,
+          date,
+          ...trackedRevisionExtras,
+        });
+        const paragraphPropertyTargets = [
+          {
+            position: item.blockFrom,
+            properties: item.operation.firstParagraphProperties,
+          },
+          {
+            position: item.from + 1,
+            properties: item.operation.secondParagraphProperties,
+          },
+        ] as const;
+        for (const { position, properties } of paragraphPropertyTargets) {
+          if (!properties) {
+            continue;
+          }
+          const paragraph = tr.doc.nodeAt(position);
+          if (!paragraph) {
+            panic("A resolved split did not produce two paragraphs");
+          }
+          const appliedProperties = applyBlockParagraphProperties({
+            tr,
+            position,
+            node: paragraph,
+            properties,
+            styleResolver,
+            numbering,
+            ...(mode === "direct"
+              ? {}
+              : { revisionInfo: allocateSplitParagraphPropertyRevisionInfo }),
+          });
+          tr = appliedProperties.tr;
+          if (appliedProperties.revisionId !== null) {
+            appliedRevisionIds.push(appliedProperties.revisionId);
+          }
         }
-        tr = tr.split(item.from);
-        // The mark goes on the FIRST half: the break belongs to the paragraph
-        // it now ends, and a reader rejecting it closes that paragraph back
-        // over the second half.
-        tr = tr.setNodeAttribute(item.blockFrom, "pPrMark", { kind: "ins", info });
         break;
       }
       case "mergeBlockWithNext": {
@@ -3118,29 +3221,58 @@ const applyFolioAIEditOperationsInternal = ({
             tr = tr.insertText(separator, insertAt);
           }
           tr = tr.join(item.blockTo + separator.length);
-          break;
+        } else {
+          const revisionIdMark = operationRevisionSeed++;
+          appliedRevisionIds = [revisionIdMark];
+          if (separator.length > 0 && insertionType) {
+            const revisionIdSeparator = operationRevisionSeed++;
+            tr = tr.insertText(separator, insertAt);
+            tr = tr.addMark(
+              insertAt,
+              insertAt + separator.length,
+              insertionType.create({
+                revisionId: revisionIdSeparator,
+                author,
+                date,
+                ...trackedRevisionExtras,
+              }),
+            );
+            appliedRevisionIds.push(revisionIdSeparator);
+          }
+          tr = tr.setNodeAttribute(item.blockFrom, "pPrMark", {
+            kind: "del",
+            info: { id: revisionIdMark, author, date, ...trackedRevisionExtras },
+          });
         }
-        const revisionIdMark = operationRevisionSeed++;
-        appliedRevisionIds = [revisionIdMark];
-        if (separator.length > 0 && insertionType) {
-          const revisionIdSeparator = operationRevisionSeed++;
-          tr = tr.insertText(separator, insertAt);
-          tr = tr.addMark(
-            insertAt,
-            insertAt + separator.length,
-            insertionType.create({
-              revisionId: revisionIdSeparator,
-              author,
-              date,
-              ...trackedRevisionExtras,
-            }),
-          );
-          appliedRevisionIds = [revisionIdMark, revisionIdSeparator];
+
+        if (item.operation.mergedParagraphProperties) {
+          const mergedParagraph = tr.doc.nodeAt(item.blockFrom);
+          if (!mergedParagraph) {
+            panic("A resolved merge did not produce a paragraph");
+          }
+          const appliedProperties = applyBlockParagraphProperties({
+            tr,
+            position: item.blockFrom,
+            node: mergedParagraph,
+            properties: item.operation.mergedParagraphProperties,
+            styleResolver,
+            numbering,
+            ...(mode === "direct"
+              ? {}
+              : {
+                  revisionInfo: () => ({
+                    id: operationRevisionSeed++,
+                    author,
+                    date,
+                    ...trackedRevisionExtras,
+                  }),
+                }),
+          });
+          tr = appliedProperties.tr;
+          if (appliedProperties.revisionId !== null) {
+            appliedRevisionIds.push(appliedProperties.revisionId);
+          }
         }
-        tr = tr.setNodeAttribute(item.blockFrom, "pPrMark", {
-          kind: "del",
-          info: { id: revisionIdMark, author, date, ...trackedRevisionExtras },
-        });
         break;
       }
       case "commentOnBlock": {
@@ -3196,11 +3328,10 @@ const applyFolioAIEditOperationsInternal = ({
     applied.push({
       id: item.operation.id,
       ...(committedCommentId !== undefined && { commentId: committedCommentId }),
-      ...(appliedRevisionIds !== undefined &&
-        appliedRevisionIds[0] !== undefined && {
-          revisionId: appliedRevisionIds[0],
-          revisionIds: appliedRevisionIds,
-        }),
+      ...(appliedRevisionIds[0] !== undefined && {
+        revisionId: appliedRevisionIds[0],
+        revisionIds: appliedRevisionIds,
+      }),
       ...(suggestionId !== null && { suggestionId }),
     });
   }

--- a/packages/core/src/ai-edits/types.ts
+++ b/packages/core/src/ai-edits/types.ts
@@ -345,6 +345,16 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
          */
         separator?: string;
         blockId: string;
+        /**
+         * Paragraph properties for the first result. Omitted properties keep
+         * the source paragraph's value.
+         */
+        firstParagraphProperties?: FolioAIBlockParagraphProperties;
+        /**
+         * Paragraph properties for the second result. Omitted properties keep
+         * the source paragraph's value.
+         */
+        secondParagraphProperties?: FolioAIBlockParagraphProperties;
       }
     /**
      * Add a whole table next to the anchor block, its rows marked inserted in
@@ -410,6 +420,11 @@ export type FolioAIEditOperation = FolioAIEditReviewMeta & {
          */
         separator?: string;
         blockId: string;
+        /**
+         * Paragraph properties for the joined result. Omitted properties keep
+         * the first paragraph's value.
+         */
+        mergedParagraphProperties?: FolioAIBlockParagraphProperties;
       }
     | {
         id: string;

--- a/packages/core/src/compare/README.md
+++ b/packages/core/src/compare/README.md
@@ -106,7 +106,12 @@ exactly that: `splitBlock` writes an inserted mark on the paragraph the break
 now ends, `mergeBlockWithNext` a deleted one, and the change list says `split`
 or `merge`. The space the break stands in for travels with the operation as
 `separator`, so accepting reproduces the target's spacing and rejecting
-restores the base's.
+restores the base's. When the resulting paragraphs also differ in style,
+alignment, list level or direct spacing, the structural operation carries the
+properties of each split result or the merged result. They are written as
+`w:pPrChange` and reported as `paragraph-format` entries beside the structural
+change; accepting and rejecting therefore restore both the paragraph boundary
+and its formatting.
 
 ### Which paragraph mark changed
 

--- a/packages/core/src/compare/paragraphSplitMergeFormatting.test.ts
+++ b/packages/core/src/compare/paragraphSplitMergeFormatting.test.ts
@@ -1,0 +1,429 @@
+import { describe, expect, test } from "bun:test";
+import { panic } from "better-result";
+import JSZip from "jszip";
+
+import { FolioDocxReviewer } from "../ai-edits/headless";
+import type { FolioAIParagraphSpacing } from "../ai-edits/types";
+import { createDocx } from "../docx/rezip";
+import type { Paragraph, ParagraphAlignment, Table } from "../types/document";
+import { createEmptyDocument } from "../utils/createDocument";
+import { compareDocx } from "./compare";
+
+const OPTIONS = { author: "compare", timestamp: "2026-09-11T00:00:00.000Z" } as const;
+
+type DirectParagraphFormatting = {
+  styleId: string;
+  alignment: ParagraphAlignment;
+  spacing: FolioAIParagraphSpacing;
+};
+
+const JOINED_FORMATTING = {
+  styleId: "JoinedBody",
+  alignment: "left",
+  spacing: { spaceBefore: 120, spaceAfter: 60 },
+} as const satisfies DirectParagraphFormatting;
+
+const FIRST_SPLIT_FORMATTING = {
+  styleId: "OpeningBody",
+  alignment: "center",
+  spacing: { spaceBefore: 240, lineSpacing: 360, lineSpacingRule: "exact" },
+} as const satisfies DirectParagraphFormatting;
+
+const SECOND_SPLIT_FORMATTING = {
+  styleId: "ClosingBody",
+  alignment: "right",
+  spacing: { spaceAfter: 360, afterAutospacing: true },
+} as const satisfies DirectParagraphFormatting;
+
+const JOINED_BLOCKS = [
+  { paraId: "11111111", text: "Alpha Beta", formatting: JOINED_FORMATTING },
+] as const;
+
+const SPLIT_BLOCKS = [
+  { paraId: "22222222", text: "Alpha", formatting: FIRST_SPLIT_FORMATTING },
+  { paraId: "33333333", text: "Beta", formatting: SECOND_SPLIT_FORMATTING },
+] as const;
+
+const paragraph = (
+  paraId: string,
+  text: string,
+  { styleId, alignment, spacing }: DirectParagraphFormatting,
+): Paragraph => ({
+  type: "paragraph",
+  paraId,
+  textId: paraId,
+  formatting: { styleId, alignment, ...spacing },
+  content: [{ type: "run", content: [{ type: "text", text }] }],
+});
+
+const documentWith = async (
+  blocks: readonly {
+    paraId: string;
+    text: string;
+    formatting: DirectParagraphFormatting;
+  }[],
+): Promise<ArrayBuffer> => {
+  const document = createEmptyDocument();
+  document.package.styles = {
+    styles: [
+      { type: "paragraph", styleId: "Normal", name: "Normal", default: true },
+      { type: "paragraph", styleId: JOINED_FORMATTING.styleId, name: "Joined Body" },
+      { type: "paragraph", styleId: FIRST_SPLIT_FORMATTING.styleId, name: "Opening Body" },
+      { type: "paragraph", styleId: SECOND_SPLIT_FORMATTING.styleId, name: "Closing Body" },
+    ],
+  };
+  document.package.document.content = blocks.map(({ paraId, text, formatting }) =>
+    paragraph(paraId, text, formatting),
+  );
+  return await createDocx(document);
+};
+
+const tableDocumentWith = async (
+  blocks: readonly {
+    paraId: string;
+    text: string;
+    formatting: DirectParagraphFormatting;
+  }[],
+): Promise<ArrayBuffer> => {
+  const document = createEmptyDocument();
+  document.package.styles = {
+    styles: [
+      { type: "paragraph", styleId: "Normal", name: "Normal", default: true },
+      { type: "paragraph", styleId: JOINED_FORMATTING.styleId, name: "Joined Body" },
+      { type: "paragraph", styleId: FIRST_SPLIT_FORMATTING.styleId, name: "Opening Body" },
+      { type: "paragraph", styleId: SECOND_SPLIT_FORMATTING.styleId, name: "Closing Body" },
+    ],
+  };
+  const table: Table = {
+    type: "table",
+    rows: [
+      {
+        type: "tableRow",
+        cells: [
+          {
+            type: "tableCell",
+            content: blocks.map(({ paraId, text, formatting }) =>
+              paragraph(paraId, text, formatting),
+            ),
+          },
+        ],
+      },
+    ],
+  };
+  document.package.document.content = [
+    table,
+    { type: "paragraph", paraId: "44444444", textId: "44444444", content: [] },
+  ];
+  return await createDocx(document);
+};
+
+const joinedDocument = (): Promise<ArrayBuffer> => documentWith(JOINED_BLOCKS);
+
+const splitDocument = (): Promise<ArrayBuffer> => documentWith(SPLIT_BLOCKS);
+
+const projectedBlocks = (reviewer: FolioDocxReviewer) =>
+  reviewer.snapshot().blocks.map(({ text, styleId, directAlignment, directSpacing }) => ({
+    text,
+    styleId,
+    directAlignment,
+    directSpacing,
+  }));
+
+const JOINED_PROJECTION = [
+  {
+    text: "Alpha Beta",
+    styleId: JOINED_FORMATTING.styleId,
+    directAlignment: JOINED_FORMATTING.alignment,
+    directSpacing: JOINED_FORMATTING.spacing,
+  },
+];
+
+const SPLIT_PROJECTION = [
+  {
+    text: "Alpha",
+    styleId: FIRST_SPLIT_FORMATTING.styleId,
+    directAlignment: FIRST_SPLIT_FORMATTING.alignment,
+    directSpacing: FIRST_SPLIT_FORMATTING.spacing,
+  },
+  {
+    text: "Beta",
+    styleId: SECOND_SPLIT_FORMATTING.styleId,
+    directAlignment: SECOND_SPLIT_FORMATTING.alignment,
+    directSpacing: SECOND_SPLIT_FORMATTING.spacing,
+  },
+];
+
+const EMPTY_CARRIER_PROJECTION = {
+  text: "",
+  styleId: undefined,
+  directAlignment: undefined,
+  directSpacing: undefined,
+};
+
+const mainDocumentXml = async (buffer: ArrayBuffer): Promise<string> => {
+  const part = (await JSZip.loadAsync(buffer)).file("word/document.xml");
+  if (!part) {
+    return panic("expected word/document.xml");
+  }
+  return await part.async("string");
+};
+
+const expectReviewedProjection = async (
+  buffer: ArrayBuffer,
+  action: "accept" | "reject",
+  expected: readonly ReturnType<typeof projectedBlocks>[number][],
+): Promise<void> => {
+  const reviewer = await FolioDocxReviewer.fromBuffer(buffer);
+  const revisionCount = action === "accept" ? reviewer.acceptAll() : reviewer.rejectAll();
+  expect(revisionCount).toBeGreaterThan(0);
+  expect(reviewer.getChanges()).toEqual([]);
+  expect(projectedBlocks(reviewer)).toEqual(expected);
+
+  const saved = await reviewer.toBuffer();
+  const savedXml = await mainDocumentXml(saved);
+  expect(savedXml).not.toContain("<w:pPrChange");
+  expect(savedXml).not.toContain("<w:ins");
+  expect(savedXml).not.toContain("<w:del");
+  const reopened = await FolioDocxReviewer.fromBuffer(saved);
+  expect(reopened.getChanges()).toEqual([]);
+  expect(projectedBlocks(reopened)).toEqual(expected);
+};
+
+describe("paragraph split and merge formatting", () => {
+  test("direct split and merge operations apply their complete paragraph property payloads", async () => {
+    const splitting = await FolioDocxReviewer.fromBuffer(await joinedDocument());
+    const joinedBlockId = splitting.snapshot().blocks.at(0)?.id;
+    if (!joinedBlockId) {
+      panic("expected a joined paragraph block id");
+    }
+    const split = splitting.applyDocumentOperations({
+      version: 1,
+      mode: "direct",
+      operations: [
+        {
+          id: "split",
+          type: "splitBlock",
+          blockId: joinedBlockId,
+          offset: 5,
+          separator: " ",
+          firstParagraphProperties: {
+            styleId: FIRST_SPLIT_FORMATTING.styleId,
+            alignment: FIRST_SPLIT_FORMATTING.alignment,
+            spacing: FIRST_SPLIT_FORMATTING.spacing,
+          },
+          secondParagraphProperties: {
+            styleId: SECOND_SPLIT_FORMATTING.styleId,
+            alignment: SECOND_SPLIT_FORMATTING.alignment,
+            spacing: SECOND_SPLIT_FORMATTING.spacing,
+          },
+        },
+      ],
+    });
+    expect(split.skipped).toEqual([]);
+    expect(projectedBlocks(splitting)).toEqual(SPLIT_PROJECTION);
+
+    const merging = await FolioDocxReviewer.fromBuffer(await splitDocument());
+    const firstSplitBlockId = merging.snapshot().blocks.at(0)?.id;
+    if (!firstSplitBlockId) {
+      panic("expected a split paragraph block id");
+    }
+    const merge = merging.applyDocumentOperations({
+      version: 1,
+      mode: "direct",
+      operations: [
+        {
+          id: "merge",
+          type: "mergeBlockWithNext",
+          blockId: firstSplitBlockId,
+          separator: " ",
+          mergedParagraphProperties: {
+            styleId: JOINED_FORMATTING.styleId,
+            alignment: JOINED_FORMATTING.alignment,
+            spacing: JOINED_FORMATTING.spacing,
+          },
+        },
+      ],
+    });
+    expect(merge.skipped).toEqual([]);
+    expect(projectedBlocks(merging)).toEqual(JOINED_PROJECTION);
+  });
+
+  test("a split carries each resulting paragraph's style, alignment, and spacing", async () => {
+    const result = await compareDocx(await joinedDocument(), await splitDocument(), OPTIONS);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    expect(result.value.verification).toEqual({ status: "verified" });
+    expect(result.value.unsupported).toEqual([]);
+    expect(result.value.changes).toEqual([
+      expect.objectContaining({ kind: "split" }),
+      expect.objectContaining({
+        kind: "paragraph-format",
+        targetBlockId: "22222222",
+        properties: {
+          styleId: FIRST_SPLIT_FORMATTING.styleId,
+          alignment: FIRST_SPLIT_FORMATTING.alignment,
+          spacing: FIRST_SPLIT_FORMATTING.spacing,
+        },
+      }),
+      expect.objectContaining({
+        kind: "paragraph-format",
+        targetBlockId: "33333333",
+        properties: {
+          styleId: SECOND_SPLIT_FORMATTING.styleId,
+          alignment: SECOND_SPLIT_FORMATTING.alignment,
+          spacing: SECOND_SPLIT_FORMATTING.spacing,
+        },
+      }),
+    ]);
+    expect((await mainDocumentXml(result.value.buffer)).match(/<w:pPrChange\b/gu)).toHaveLength(2);
+    await expectReviewedProjection(result.value.buffer, "accept", SPLIT_PROJECTION);
+    await expectReviewedProjection(result.value.buffer, "reject", JOINED_PROJECTION);
+  });
+
+  test("the reverse merge carries the joined paragraph's style, alignment, and spacing", async () => {
+    const result = await compareDocx(await splitDocument(), await joinedDocument(), OPTIONS);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    expect(result.value.verification).toEqual({ status: "verified" });
+    expect(result.value.unsupported).toEqual([]);
+    expect(result.value.changes).toEqual([
+      expect.objectContaining({ kind: "merge" }),
+      expect.objectContaining({
+        kind: "paragraph-format",
+        targetBlockId: "11111111",
+        properties: {
+          styleId: JOINED_FORMATTING.styleId,
+          alignment: JOINED_FORMATTING.alignment,
+          spacing: JOINED_FORMATTING.spacing,
+        },
+      }),
+    ]);
+    expect((await mainDocumentXml(result.value.buffer)).match(/<w:pPrChange\b/gu)).toHaveLength(1);
+    await expectReviewedProjection(result.value.buffer, "accept", JOINED_PROJECTION);
+    await expectReviewedProjection(result.value.buffer, "reject", SPLIT_PROJECTION);
+  });
+
+  test.each([
+    {
+      label: "split",
+      baseBlocks: JOINED_BLOCKS,
+      revisedBlocks: SPLIT_BLOCKS,
+      accepted: [...SPLIT_PROJECTION, EMPTY_CARRIER_PROJECTION],
+      rejected: [...JOINED_PROJECTION, EMPTY_CARRIER_PROJECTION],
+    },
+    {
+      label: "merge",
+      baseBlocks: SPLIT_BLOCKS,
+      revisedBlocks: JOINED_BLOCKS,
+      accepted: [...JOINED_PROJECTION, EMPTY_CARRIER_PROJECTION],
+      rejected: [...SPLIT_PROJECTION, EMPTY_CARRIER_PROJECTION],
+    },
+  ] as const)(
+    "round-trips a formatting $label inside a table-cell container",
+    async ({ baseBlocks, revisedBlocks, accepted, rejected }) => {
+      const result = await compareDocx(
+        await tableDocumentWith(baseBlocks),
+        await tableDocumentWith(revisedBlocks),
+        OPTIONS,
+      );
+      if (result.isErr()) {
+        throw result.error;
+      }
+
+      expect(result.value.verification).toEqual({ status: "verified" });
+      expect(result.value.unsupported).toEqual([]);
+      await expectReviewedProjection(result.value.buffer, "accept", accepted);
+      await expectReviewedProjection(result.value.buffer, "reject", rejected);
+    },
+  );
+
+  test("refuses a formatting split when the source already has a pending pPrChange", async () => {
+    const reviewer = await FolioDocxReviewer.fromBuffer(await joinedDocument());
+    const blockId = reviewer.snapshot().blocks.at(0)?.id;
+    if (!blockId) {
+      panic("expected a joined paragraph block id");
+    }
+    expect(
+      reviewer.applyDocumentOperations({
+        version: 1,
+        mode: "tracked-changes",
+        operations: [
+          {
+            id: "pending",
+            type: "setBlockParagraphProperties",
+            blockId,
+            properties: { alignment: "both" },
+          },
+        ],
+      }).skipped,
+    ).toEqual([]);
+
+    const outcome = reviewer.applyDocumentOperations({
+      version: 1,
+      mode: "tracked-changes",
+      atomic: true,
+      operations: [
+        {
+          id: "split",
+          type: "splitBlock",
+          blockId,
+          offset: 5,
+          separator: " ",
+          firstParagraphProperties: { styleId: FIRST_SPLIT_FORMATTING.styleId },
+          secondParagraphProperties: { styleId: SECOND_SPLIT_FORMATTING.styleId },
+        },
+      ],
+    });
+
+    expect(outcome.status).toBe("rejected");
+    expect(outcome.applied).toEqual([]);
+    expect(outcome.skipped).toEqual([{ id: "split", reason: "pendingParagraphPropertyChange" }]);
+    expect(reviewer.snapshot().blocks.map(({ text }) => text)).toEqual(["Alpha Beta"]);
+  });
+
+  test("refuses a formatting merge when the first paragraph has a pending pPrChange", async () => {
+    const reviewer = await FolioDocxReviewer.fromBuffer(await splitDocument());
+    const blockId = reviewer.snapshot().blocks.at(0)?.id;
+    if (!blockId) {
+      panic("expected a split paragraph block id");
+    }
+    expect(
+      reviewer.applyDocumentOperations({
+        version: 1,
+        mode: "tracked-changes",
+        operations: [
+          {
+            id: "pending",
+            type: "setBlockParagraphProperties",
+            blockId,
+            properties: { alignment: "both" },
+          },
+        ],
+      }).skipped,
+    ).toEqual([]);
+
+    const outcome = reviewer.applyDocumentOperations({
+      version: 1,
+      mode: "tracked-changes",
+      atomic: true,
+      operations: [
+        {
+          id: "merge",
+          type: "mergeBlockWithNext",
+          blockId,
+          separator: " ",
+          mergedParagraphProperties: { styleId: JOINED_FORMATTING.styleId },
+        },
+      ],
+    });
+
+    expect(outcome.status).toBe("rejected");
+    expect(outcome.applied).toEqual([]);
+    expect(outcome.skipped).toEqual([{ id: "merge", reason: "pendingParagraphPropertyChange" }]);
+    expect(reviewer.snapshot().blocks.map(({ text }) => text)).toEqual(["Alpha", "Beta"]);
+  });
+});

--- a/packages/core/src/compare/plan.ts
+++ b/packages/core/src/compare/plan.ts
@@ -973,6 +973,20 @@ export const planStoryCompare = ({
     const paragraphMarkPlan = paragraphMarkPlans.get(stepIndex);
     if (paragraphMarkPlan?.type === "split") {
       const { baseBlock, revisedBlocks: splitInto, offset, separator } = paragraphMarkPlan;
+      const firstParagraphFormatting = changedFolioContentParagraphFormatting(
+        baseBlock,
+        splitInto[0],
+      );
+      const secondParagraphFormatting = changedFolioContentParagraphFormatting(
+        baseBlock,
+        splitInto[1],
+      );
+      const firstParagraphProperties = firstParagraphFormatting
+        ? toFolioAIBlockParagraphProperties(firstParagraphFormatting)
+        : undefined;
+      const secondParagraphProperties = secondParagraphFormatting
+        ? toFolioAIBlockParagraphProperties(secondParagraphFormatting)
+        : undefined;
       changes.push({
         kind: "split",
         location: locationOf(story, baseBlock),
@@ -980,17 +994,44 @@ export const planStoryCompare = ({
         targetBlockIds: splitInto.map(({ id }) => id),
         text: baseBlock.text,
       });
+      if (firstParagraphProperties) {
+        changes.push({
+          kind: "paragraph-format",
+          location: locationOf(story, baseBlock),
+          baseBlockId: baseBlock.id,
+          targetBlockId: splitInto[0].id,
+          properties: firstParagraphProperties,
+        });
+      }
+      if (secondParagraphProperties) {
+        changes.push({
+          kind: "paragraph-format",
+          location: locationOf(story, baseBlock),
+          baseBlockId: baseBlock.id,
+          targetBlockId: splitInto[1].id,
+          properties: secondParagraphProperties,
+        });
+      }
       operations.push({
         id: nextOperationId(),
         type: "splitBlock",
         blockId: baseBlock.id,
         offset,
         ...(separator.length > 0 && { separator }),
+        ...(firstParagraphProperties && { firstParagraphProperties }),
+        ...(secondParagraphProperties && { secondParagraphProperties }),
       });
       continue;
     }
     if (paragraphMarkPlan?.type === "merge") {
       const { baseBlocks, revisedBlock: targetBlock, separator } = paragraphMarkPlan;
+      const mergedParagraphFormatting = changedFolioContentParagraphFormatting(
+        baseBlocks[0],
+        targetBlock,
+      );
+      const mergedParagraphProperties = mergedParagraphFormatting
+        ? toFolioAIBlockParagraphProperties(mergedParagraphFormatting)
+        : undefined;
       changes.push({
         kind: "merge",
         location: locationOf(story, baseBlocks[0]),
@@ -998,11 +1039,21 @@ export const planStoryCompare = ({
         targetBlockId: targetBlock.id,
         text: targetBlock.text,
       });
+      if (mergedParagraphProperties) {
+        changes.push({
+          kind: "paragraph-format",
+          location: locationOf(story, baseBlocks[0]),
+          baseBlockId: baseBlocks[0].id,
+          targetBlockId: targetBlock.id,
+          properties: mergedParagraphProperties,
+        });
+      }
       operations.push({
         id: nextOperationId(),
         type: "mergeBlockWithNext",
         blockId: baseBlocks[0].id,
         ...(separator.length > 0 && { separator }),
+        ...(mergedParagraphProperties && { mergedParagraphProperties }),
       });
       continue;
     }

--- a/packages/core/src/document-operations.test.ts
+++ b/packages/core/src/document-operations.test.ts
@@ -383,6 +383,60 @@ describe("document operation contract", () => {
     }
   });
 
+  test("preserves paragraph properties carried by split and merge operations", () => {
+    const firstParagraphProperties = {
+      styleId: "OpeningBody",
+      alignment: "center",
+      spacing: { spaceBefore: 240 },
+    } as const;
+    const secondParagraphProperties = {
+      styleId: "ClosingBody",
+      alignment: "right",
+      spacing: { spaceAfter: 360 },
+    } as const;
+    const mergedParagraphProperties = {
+      styleId: "JoinedBody",
+      alignment: "both",
+      spacing: { lineSpacing: 480, lineSpacingRule: "exact" },
+    } as const;
+    const batch = parseFolioDocumentOperationBatch({
+      version: 1,
+      operations: [
+        {
+          id: "split",
+          type: "splitBlock",
+          blockId: "paragraph-1",
+          offset: 5,
+          firstParagraphProperties,
+          secondParagraphProperties,
+        },
+        {
+          id: "merge",
+          type: "mergeBlockWithNext",
+          blockId: "paragraph-2",
+          mergedParagraphProperties,
+        },
+      ],
+    });
+
+    expect(batch.operations).toEqual([
+      {
+        id: "split",
+        type: "splitBlock",
+        blockId: "paragraph-1",
+        offset: 5,
+        firstParagraphProperties,
+        secondParagraphProperties,
+      },
+      {
+        id: "merge",
+        type: "mergeBlockWithNext",
+        blockId: "paragraph-2",
+        mergedParagraphProperties,
+      },
+    ]);
+  });
+
   test.each([
     [{}, "spacing"],
     [{ spaceBefore: -1 }, "spacing.spaceBefore"],

--- a/packages/core/src/document-operations.ts
+++ b/packages/core/src/document-operations.ts
@@ -561,12 +561,23 @@ const readTableRows = (
   return parsed;
 };
 
-const readParagraphProperties = (
-  value: Record<string, unknown>,
-  path: string,
-): FolioAIBlockParagraphProperties => {
-  const candidate = value["properties"];
-  const propertiesPath = `${path}.properties`;
+type ReadParagraphPropertiesOptions = {
+  value: Record<string, unknown>;
+  key:
+    | "properties"
+    | "firstParagraphProperties"
+    | "secondParagraphProperties"
+    | "mergedParagraphProperties";
+  path: string;
+};
+
+const readParagraphProperties = ({
+  value,
+  key,
+  path,
+}: ReadParagraphPropertiesOptions): FolioAIBlockParagraphProperties => {
+  const candidate = value[key];
+  const propertiesPath = `${path}.${key}`;
   if (!isPlainObject(candidate)) {
     return invalidBatch(propertiesPath, "expected an object");
   }
@@ -793,8 +804,14 @@ export const FOLIO_DOCUMENT_OPERATION_KEYS_BY_TYPE = Object.freeze({
   ],
   replaceBlock: [...COMMON_OPERATION_KEYS, "text", "preserveFormatting", "styleId", "comment"],
   deleteBlock: [...COMMON_OPERATION_KEYS, "moveId", "comment"],
-  splitBlock: [...COMMON_OPERATION_KEYS, "offset", "separator"],
-  mergeBlockWithNext: [...COMMON_OPERATION_KEYS, "separator"],
+  splitBlock: [
+    ...COMMON_OPERATION_KEYS,
+    "offset",
+    "separator",
+    "firstParagraphProperties",
+    "secondParagraphProperties",
+  ],
+  mergeBlockWithNext: [...COMMON_OPERATION_KEYS, "separator", "mergedParagraphProperties"],
   setBlockParagraphProperties: [...COMMON_OPERATION_KEYS, "properties"],
   insertTable: [...COMMON_OPERATION_KEYS, "position", "rows"],
   deleteTable: COMMON_OPERATION_KEYS,
@@ -917,15 +934,34 @@ const parseDocumentOperation = (value: unknown, index: number): FolioDocumentOpe
       id,
       type,
       blockId,
-      properties: readParagraphProperties(value, path),
+      properties: readParagraphProperties({ value, key: "properties", path }),
     };
   }
 
   if (type === "splitBlock" || type === "mergeBlockWithNext") {
     const separator = readOptionalString(value, "separator", path);
     if (type === "mergeBlockWithNext") {
-      return { ...operationMeta, id, type, blockId, ...(separator !== undefined && { separator }) };
+      const mergedParagraphProperties =
+        value["mergedParagraphProperties"] === undefined
+          ? undefined
+          : readParagraphProperties({ value, key: "mergedParagraphProperties", path });
+      return {
+        ...operationMeta,
+        id,
+        type,
+        blockId,
+        ...(separator !== undefined && { separator }),
+        ...(mergedParagraphProperties !== undefined && { mergedParagraphProperties }),
+      };
     }
+    const firstParagraphProperties =
+      value["firstParagraphProperties"] === undefined
+        ? undefined
+        : readParagraphProperties({ value, key: "firstParagraphProperties", path });
+    const secondParagraphProperties =
+      value["secondParagraphProperties"] === undefined
+        ? undefined
+        : readParagraphProperties({ value, key: "secondParagraphProperties", path });
     return {
       ...operationMeta,
       id,
@@ -933,6 +969,8 @@ const parseDocumentOperation = (value: unknown, index: number): FolioDocumentOpe
       blockId,
       offset: readNonNegativeInteger(value, "offset", path),
       ...(separator !== undefined && { separator }),
+      ...(firstParagraphProperties !== undefined && { firstParagraphProperties }),
+      ...(secondParagraphProperties !== undefined && { secondParagraphProperties }),
     };
   }
 

--- a/scripts/api-surface-budget.json
+++ b/scripts/api-surface-budget.json
@@ -20,8 +20,8 @@
   "agents": {
     "reportBytes": 13171,
     "reportLines": 393,
-    "declarationBytes": 54007,
-    "declarationLines": 1116
+    "declarationBytes": 59761,
+    "declarationLines": 1194
   },
   "vue": {
     "reportBytes": 54675,


### PR DESCRIPTION
## Summary

- carry paragraph style, alignment, list level, and spacing changes atomically with split and merge operations
- preserve the complete prior paragraph properties so rejecting the structural revision restores the source
- expose the additive operation fields through the core parser and agents schemas
- cover body and table-cell splits and merges through tracked accept/reject and save/reopen invariants


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Paragraph styles, alignment, list levels and spacing are now preserved when comparisons split or merge paragraphs.
  * Formatting differences are tracked alongside paragraph-boundary changes and can be accepted or rejected together.
  * Support includes paragraphs within table cells.

* **Bug Fixes**
  * Split and merge formatting changes are no longer applied when conflicting tracked changes are already present.
  * Documents now retain their original formatting when paragraph properties are not explicitly provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->