### PR TITLE
fix(core): bound headless inline resolution

### DIFF
--- a/.changeset/calm-otters-resolve.md
+++ b/.changeset/calm-otters-resolve.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Resolve full-document inline changes in one bounded headless transform.

--- a/packages/core/src/internal/headlessRevisionResolution.ts
+++ b/packages/core/src/internal/headlessRevisionResolution.ts
@@ -15,22 +15,26 @@ import {
 
 export type HeadlessRevisionResolutionMode = "accept" | "reject";
 
-type HeadlessDeleteRange = {
+type HeadlessRange = {
   from: number;
   to: number;
+};
+
+type HeadlessReplacementRange = HeadlessRange & {
+  newSize: number;
 };
 
 type HeadlessInlineContext = {
   mode: HeadlessRevisionResolutionMode;
   keepType: MarkType | undefined;
   removeType: MarkType | undefined;
-  deleteRanges: HeadlessDeleteRange[];
-  changedParagraphRanges: HeadlessDeleteRange[];
+  replacementRanges: HeadlessReplacementRange[];
+  changedParagraphRanges: HeadlessRange[];
   styleResolver: RunStyleResolver | null;
 };
 
 export type HeadlessInlineChangeTracking = {
-  ranges: readonly HeadlessDeleteRange[];
+  ranges: readonly HeadlessRange[];
   mappingFrom: number;
 };
 
@@ -169,6 +173,7 @@ const resolveInlineContent = ({
     node.type.name === "paragraph" && context.mode === "reject"
       ? { paragraph: node }
       : inheritedParagraphScope;
+  const replacementRangeStart = context.replacementRanges.length;
   let resolvedNode = node;
   if (node.isInline) {
     const resolved = resolveInlineNode({
@@ -177,7 +182,11 @@ const resolveInlineContent = ({
       paragraphScope,
     });
     if (resolved === null) {
-      context.deleteRanges.push({ from: position, to: position + node.nodeSize });
+      context.replacementRanges.push({
+        from: position,
+        to: position + node.nodeSize,
+        newSize: 0,
+      });
       return null;
     }
     resolvedNode = resolved;
@@ -207,19 +216,56 @@ const resolveInlineContent = ({
   if (!contentChanged) {
     return resolvedNode;
   }
+  let resolvedContent = Fragment.fromArray(children);
+  if (!resolvedNode.type.validContent(resolvedContent)) {
+    // A required-content parent may need a generated child after resolution
+    // removes its last carrier. Let the schema choose that filler instead of
+    // constructing an invalid node.
+    const fitted = resolvedNode.type.createAndFill(
+      resolvedNode.attrs,
+      resolvedContent,
+      resolvedNode.marks,
+    );
+    if (!fitted || !resolvedNode.type.validContent(fitted.content)) {
+      if (!resolvedNode.isInline) {
+        return panic(`Headless inline resolution invalidated ${resolvedNode.type.name} content`);
+      }
+      context.replacementRanges.splice(
+        replacementRangeStart,
+        context.replacementRanges.length - replacementRangeStart,
+        { from: position, to: position + node.nodeSize, newSize: 0 },
+      );
+      return null;
+    }
+    // The fitted content is larger than the deletion-only reconstruction.
+    // Replace its nested maps with the actual content-size transition so a
+    // selection after the parent moves by the same distance as the slice.
+    context.replacementRanges.splice(
+      replacementRangeStart,
+      context.replacementRanges.length - replacementRangeStart,
+      {
+        from: contentStart,
+        to: contentStart + node.content.size,
+        newSize: fitted.content.size,
+      },
+    );
+    resolvedContent = fitted.content;
+  }
   if (resolvedNode.type.name === "paragraph") {
     context.changedParagraphRanges.push({ from: position, to: position + resolvedNode.nodeSize });
   }
-  return rebuildNode(node, resolvedNode.attrs, Fragment.fromArray(children), resolvedNode.marks);
+  // Rebuild through the provenance-aware owner so a filled paragraph keeps
+  // its captured property source.
+  return rebuildNode(node, resolvedNode.attrs, resolvedContent, resolvedNode.marks);
 };
 
-const coalesceDeleteRanges = (
-  deleteRanges: readonly HeadlessDeleteRange[],
-): HeadlessDeleteRange[] => {
-  const coalesced: HeadlessDeleteRange[] = [];
-  for (const range of deleteRanges) {
+const coalesceReplacementRanges = (
+  replacementRanges: readonly HeadlessReplacementRange[],
+): HeadlessReplacementRange[] => {
+  const coalesced: HeadlessReplacementRange[] = [];
+  for (const range of replacementRanges) {
     const previous = coalesced.at(-1);
-    if (previous && range.from <= previous.to) {
+    if (previous && previous.newSize === 0 && range.newSize === 0 && range.from <= previous.to) {
       previous.to = Math.max(previous.to, range.to);
     } else {
       coalesced.push({ ...range });
@@ -247,7 +293,7 @@ export const appendHeadlessInlineResolution = ({
     mode,
     keepType,
     removeType,
-    deleteRanges: [],
+    replacementRanges: [],
     changedParagraphRanges: [],
     styleResolver,
   };
@@ -255,8 +301,10 @@ export const appendHeadlessInlineResolution = ({
   if (!resolved || resolved.eq(tr.doc)) {
     return null;
   }
-  const deleteRanges = coalesceDeleteRanges(context.deleteRanges);
-  const positionMap = new StepMap(deleteRanges.flatMap(({ from, to }) => [from, to - from, 0]));
+  const replacementRanges = coalesceReplacementRanges(context.replacementRanges);
+  const positionMap = new StepMap(
+    replacementRanges.flatMap(({ from, to, newSize }) => [from, to - from, newSize]),
+  );
   const mappingFrom = tr.steps.length;
   tr.step(
     new HeadlessInlineResolutionStep(

--- a/packages/core/src/prosemirror/commands/comments.bulk.test.ts
+++ b/packages/core/src/prosemirror/commands/comments.bulk.test.ts
@@ -2,7 +2,14 @@ import { describe, expect, test } from "bun:test";
 import fc from "fast-check";
 import type { Mark, Node as PMNode } from "prosemirror-model";
 import { history } from "prosemirror-history";
-import { EditorState, Plugin, PluginKey, type Command, type Transaction } from "prosemirror-state";
+import {
+  EditorState,
+  Plugin,
+  PluginKey,
+  TextSelection,
+  type Command,
+  type Transaction,
+} from "prosemirror-state";
 import { ySyncPlugin, yUndoPlugin } from "y-prosemirror";
 import * as Y from "yjs";
 
@@ -461,10 +468,59 @@ const secondaryStoryBuffer = async (): Promise<ArrayBuffer> => {
 };
 
 describe("headless bulk revision resolution equivalence", () => {
-  test("matches the legacy full-range semantics across generated nested revisions", () => {
+  test.each([
+    { mode: "reject", revisionType: "insertion" },
+    { mode: "accept", revisionType: "deletion" },
+  ] as const)(
+    "$mode fits an emptied required inline parent with the legacy position map",
+    ({ mode, revisionType }) => {
+      const field = schema.node(
+        "structuredField",
+        {
+          fieldType: "REF",
+          instruction: "REF required_inline_parent",
+          displayText: "removed",
+        },
+        [schema.text("removed", [revisionMark(revisionType, 1)])],
+      );
+      const trailingText = "following";
+      const doc = schema.node("doc", null, [
+        schema.node("paragraph", null, [field, schema.text(trailingText)]),
+      ]);
+      const trailingTextStart = 1 + field.nodeSize;
+      const selection = TextSelection.create(doc, trailingTextStart + 2);
+      const state = EditorState.create({
+        schema,
+        doc,
+        selection,
+        plugins: pluginsForHeadlessRevisionResolution([stepCountPlugin]),
+      });
+      const bulk = resolveAllChangesInHeadlessState(state, mode);
+      const legacy = apply(
+        state,
+        mode === "accept" ? acceptChange(0, doc.content.size) : rejectChange(0, doc.content.size),
+      ).state;
+
+      const legacyField = legacy.doc.firstChild?.firstChild;
+      expect(field.childCount).toBe(1);
+      expect(legacy.doc.textContent).toBe(trailingText);
+      expect(legacyField?.type.name).toBe("structuredField");
+      expect(legacyField?.firstChild?.type.name).toBe("tab");
+      expect(bulk.doc.toJSON()).toEqual(legacy.doc.toJSON());
+      expect(stepCountKey.getState(bulk)).toBe(1);
+      expect({ anchor: bulk.selection.anchor, head: bulk.selection.head }).toEqual({
+        anchor: legacy.selection.anchor,
+        head: legacy.selection.head,
+      });
+      expect(() => legacy.doc.check()).not.toThrow();
+      expect(() => bulk.doc.check()).not.toThrow();
+    },
+  );
+
+  test("matches the legacy small-document semantics across generated nested revisions", () => {
     fc.assert(
       fc.property(fc.integer({ min: 1, max: 100_000 }), (seed) => {
-        const doc = generatedDocument(seed, 40);
+        const doc = generatedDocument(seed, 4);
 
         for (const mode of ["accept", "reject"] as const) {
           const state = EditorState.create({
@@ -525,11 +581,7 @@ describe("headless bulk revision resolution equivalence", () => {
 
           expect(bulk.doc.toJSON()).toEqual(legacy.doc.toJSON());
           expect(pmRunPropertyChangeCount(bulk.doc)).toBe(0);
-          if (carrierCount < 256) {
-            expect(stepCountKey.getState(bulk)).toBeGreaterThan(1);
-          } else {
-            expect(stepCountKey.getState(bulk)).toBe(1);
-          }
+          expect(stepCountKey.getState(bulk)).toBe(1);
 
           const bulkModel = fromProseDoc(bulk.doc, fixture.document);
           const legacyModel = fromProseDoc(legacy.doc, fixture.document);
@@ -580,7 +632,7 @@ describe("headless bulk revision resolution equivalence", () => {
     });
 
     expect(stepCounts).toEqual([
-      { accept: 8, reject: 8 },
+      { accept: 1, reject: 1 },
       { accept: 1, reject: 1 },
       { accept: 1, reject: 1 },
     ]);

--- a/packages/core/src/prosemirror/commands/comments.ts
+++ b/packages/core/src/prosemirror/commands/comments.ts
@@ -117,8 +117,6 @@ export function removeCommentMark(commentId: number): Command {
 
 type ResolveMode = "accept" | "reject";
 
-const BULK_INLINE_RESOLUTION_THRESHOLD = 256;
-
 type ResolveExecution = "legacy" | "headless-bulk-inline";
 
 /**
@@ -167,8 +165,6 @@ function resolveChange(
       const pPrMarkOps: PPrMarkOp[] = [];
       const tableRowStructuralOps: TableRowStructuralOp[] = [];
       const tableCellStructuralOps: TableCellStructuralOp[] = [];
-      const deferredRunPropertyChanges: ResolveRunPropertyChangeOptions[] = [];
-      let bulkInlineCarrierCount = 0;
       let removedSectionEndpointCount = 0;
       const removedSectionReferences: RemovedSectionReference[] = [];
 
@@ -340,6 +336,9 @@ function resolveChange(
         if (!node.isInline) {
           return true;
         }
+        if (canBulkInlineResolution) {
+          return true;
+        }
         const nodeEnd = pos + node.nodeSize;
         const rangeFrom = Math.max(from, pos);
         const rangeTo = Math.min(to, nodeEnd);
@@ -347,36 +346,9 @@ function resolveChange(
         const runPropertyChangeMark = node.marks.find(
           (mark) => mark.type.name === "runPropertyChange",
         );
-        const resolvesRunPropertyChange =
-          runPropertyChangeMark !== undefined &&
-          expectRunPropertyChangeMarkAttrs(runPropertyChangeMark).changes.length > 0;
         const removesNode =
           removeType !== undefined &&
           node.marks.some((mark) => mark.type === removeType && matchesRevision(mark));
-        const removesKeptMark =
-          keepType !== undefined &&
-          node.marks.some((mark) => mark.type === keepType && matchesRevision(mark));
-        if (canBulkInlineResolution) {
-          if (resolvesRunPropertyChange) {
-            deferredRunPropertyChanges.push({
-              tr,
-              node,
-              from: rangeFrom,
-              to: rangeTo,
-              mark: runPropertyChangeMark,
-              mode,
-              revisionSet,
-              styleResolver,
-            });
-          }
-          if (removesNode) {
-            deleteRanges.push({ from: rangeFrom, to: rangeTo });
-          }
-          if (resolvesRunPropertyChange || removesNode || removesKeptMark) {
-            bulkInlineCarrierCount++;
-          }
-          return true;
-        }
         if (runPropertyChangeMark) {
           resolveRunPropertyChange({
             tr,
@@ -405,11 +377,9 @@ function resolveChange(
       });
 
       let bulkInlineChangeTracking: HeadlessInlineChangeTracking | null = null;
-      // The linear rewrite pays a fixed whole-document cost. The existing
-      // steps are faster for small batches and retain their compact slices.
-      const useBulkInlineResolution =
-        canBulkInlineResolution && bulkInlineCarrierCount >= BULK_INLINE_RESOLUTION_THRESHOLD;
-      if (useBulkInlineResolution) {
+      // Whole-document headless resolution rewrites inline carriers in one
+      // linear pass. Interactive commands retain granular, serializable steps.
+      if (canBulkInlineResolution) {
         bulkInlineChangeTracking = appendHeadlessInlineResolution({
           tr,
           mode,
@@ -418,9 +388,6 @@ function resolveChange(
           styleResolver,
         });
       } else {
-        for (const deferred of deferredRunPropertyChanges) {
-          resolveRunPropertyChange(deferred);
-        }
         if (removeKeptMarksInBulk) {
           tr.removeMark(from, to, keepType);
         }


### PR DESCRIPTION
## Summary

- resolve complete headless inline revision batches with one linear document rewrite at every batch size
- preserve schema-required inline content and expose accurate replacement maps for selections and later structural operations
- retain granular, serializable steps for interactive, history, and collaboration states

## Verification

- generated accept/reject parity against the granular resolver
- required inline parent parity, schema validation, and selection mapping in both directions
- one-step invariant at 4, 400, and 4,000 changed paragraphs
- 30 focused tests, 407 assertions
