### PR TITLE
fix(core): reuse snapshots across docx comparison

### DIFF
--- a/.changeset/quick-pandas-project.md
+++ b/.changeset/quick-pandas-project.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Reuse immutable document story projections throughout DOCX comparison.

--- a/packages/core/src/ai-edits/headless.test.ts
+++ b/packages/core/src/ai-edits/headless.test.ts
@@ -34,9 +34,11 @@ import {
   FolioDocxReviewer,
   UnsupportedFolioReviewedViewError,
   applyFolioAIEditsToBuffer,
+  getFolioDocxComparisonAccess,
 } from "./headless";
 import type { FolioReviewChange } from "./headless";
-import { isFolioAIContentBlock } from "./snapshot";
+import { getTrackedChangesFromSnapshot } from "./read";
+import { isFolioAIContentBlock, storyTablesOf } from "./snapshot";
 import type { FolioAIBlock } from "./types";
 
 const FIXTURE = path.join(
@@ -403,6 +405,45 @@ const findBlock = (blocks: FolioAIBlock[], needle: string): FolioAIBlock => {
 };
 
 describe("headless docx review round-trip", () => {
+  test("keeps text-box table projections isolated across tracked review views", async () => {
+    const reviewer = await FolioDocxReviewer.fromBuffer(await buildTextBoxTableDocument(), {
+      author: "Reviewer",
+    });
+    const before = reviewer.snapshot();
+    const target = findBlock(before.blocks, "Cell value");
+
+    const result = reviewer.applyOperations(
+      [
+        {
+          id: "replace-projected-shape-table-cell",
+          type: "replaceInBlock",
+          blockId: target.id,
+          find: "Cell value",
+          replace: "Updated projection",
+        },
+      ],
+      { mode: "tracked-changes", snapshot: before },
+    );
+    expect(result.skipped).toEqual([]);
+
+    const comparisonAccess = getFolioDocxComparisonAccess(reviewer);
+    const markup = comparisonAccess.snapshotReviewedStory({ view: "current-markup" });
+    const accepted = comparisonAccess.snapshotReviewedStory({ view: "final" });
+    const rejected = comparisonAccess.snapshotReviewedStory({ view: "original" });
+    if (!markup || !accepted || !rejected) {
+      throw new Error("expected every main-story review view");
+    }
+
+    expect(
+      getTrackedChangesFromSnapshot(markup)
+        .map(({ type }) => type)
+        .toSorted(),
+    ).toEqual(["deletion", "insertion"]);
+    expect(storyTablesOf(before).at(0)?.node.textContent).toBe("Cell value");
+    expect(storyTablesOf(accepted).at(0)?.node.textContent).toBe("Updated projection");
+    expect(storyTablesOf(rejected).at(0)?.node.textContent).toBe("Cell value");
+  });
+
   test("edits a table cell inside shape text and preserves its container", async () => {
     const baseline = await buildTextBoxTableDocument();
     const reviewer = await FolioDocxReviewer.fromBuffer(baseline);

--- a/packages/core/src/ai-edits/headless.ts
+++ b/packages/core/src/ai-edits/headless.ts
@@ -18,7 +18,7 @@
  * Scope: main, header, footer, footnote, and endnote blocks.
  */
 
-import { TaggedError } from "better-result";
+import { panic, TaggedError } from "better-result";
 import { Fragment } from "prosemirror-model";
 import type { Node as PMNode } from "prosemirror-model";
 import { EditorState } from "prosemirror-state";
@@ -91,7 +91,9 @@ import type { FolioRevisionStamp, FolioWordDiffOptions } from "./apply";
 import { buildAnnotatedBlockText } from "./clean-text";
 import {
   getCommentAnchorsFromDoc,
+  getTrackedChangeStatsFromDoc,
   getTrackedChangesFromDoc,
+  getTrackedChangesFromSnapshot,
   type FolioReviewChange,
   type FolioReviewChangeKind,
 } from "./read";
@@ -100,6 +102,7 @@ import {
   folioStoryTables,
   isFolioAIContentBlock,
   normalizeFolioAIBlockText,
+  sourceDocumentOf,
   type FolioStoryTable,
 } from "./snapshot";
 import { matchTableGeometry, type TableGeometryPairing } from "./table-geometry";
@@ -439,6 +442,28 @@ type ApplyDocumentOperationsInternalOptions = {
   createUndoEntry: boolean;
 };
 
+type FolioDocxComparisonProjectionMode = "with-revision-census" | "without-revision-census";
+
+type FolioDocxComparisonStoryProjection = {
+  handle: FolioDocumentStoryHandle;
+  snapshot: FolioAIEditSnapshot | null;
+};
+
+type FolioDocxComparisonProjection = {
+  stories: readonly FolioDocxComparisonStoryProjection[];
+  revisions: {
+    highestId: number;
+    present: boolean;
+  };
+};
+
+type FolioDocxComparisonAccess = {
+  projectStories: (mode: FolioDocxComparisonProjectionMode) => FolioDocxComparisonProjection;
+  snapshotReviewedStory: (options?: FolioReadReviewedStoryOptions) => FolioAIEditSnapshot | null;
+};
+
+const comparisonAccessByReviewer = new WeakMap<FolioDocxReviewer, FolioDocxComparisonAccess>();
+
 const MAIN_STORY = Object.freeze({ type: "main" } as const);
 
 const headerFooterStoryKey = ({ type, relationshipId }: FolioHeaderFooterStoryHandle): string =>
@@ -479,8 +504,7 @@ const createHeadlessPlugins = (
 const createStateSnapshot = (state: EditorState): FolioAIEditSnapshot =>
   createFolioAIEditSnapshotWithStyleResolver(state.doc, getDocumentStyleResolver(state));
 
-const formatStoryStateForLLM = (state: EditorState, annotated: boolean): string => {
-  const snapshot = createStateSnapshot(state);
+const formatStorySnapshotForLLM = (snapshot: FolioAIEditSnapshot, annotated: boolean): string => {
   // A reading surface shows content. The snapshot also carries the document's
   // blank paragraphs, which are structure rather than something to read.
   const blocks = snapshot.blocks.filter(isFolioAIContentBlock);
@@ -491,7 +515,7 @@ const formatStoryStateForLLM = (state: EditorState, annotated: boolean): string 
   // root and scans each level's fragment from index 0, so looking every block
   // up costs O(blocks^2) on a flat document.
   const nodeByStart = new Map<number, PMNode>();
-  state.doc.descendants((node, pos) => {
+  sourceDocumentOf(snapshot).descendants((node, pos) => {
     if (!node.isTextblock) {
       return true;
     }
@@ -658,6 +682,13 @@ export class FolioDocxReviewer {
     this.usedCommentIds = new Set(
       (args.baseDocument.package.document.comments ?? []).map(({ id }) => id),
     );
+    comparisonAccessByReviewer.set(
+      this,
+      Object.freeze({
+        projectStories: (mode) => this.projectComparisonStoriesInternal(mode),
+        snapshotReviewedStory: (options) => this.snapshotReviewedStoryInternal(options),
+      }),
+    );
   }
 
   /** Parse a `.docx` buffer into a reviewer. */
@@ -776,6 +807,52 @@ export class FolioDocxReviewer {
     return state ? createStateSnapshot(state) : null;
   }
 
+  private snapshotReviewedStoryInternal(
+    options: FolioReadReviewedStoryOptions = {},
+  ): FolioAIEditSnapshot | null {
+    const story = options.story ?? MAIN_STORY;
+    const view = options.view ?? "final";
+    if (!isFolioReviewedView(view)) {
+      throw new UnsupportedFolioReviewedViewError({
+        message: "Unsupported reviewed document view.",
+        receivedView: view,
+      });
+    }
+    const sourceState = this.getEditableStoryState(story);
+    return sourceState ? createStateSnapshot(resolveReviewedState(sourceState, view)) : null;
+  }
+
+  private projectComparisonStoriesInternal(
+    mode: FolioDocxComparisonProjectionMode,
+  ): FolioDocxComparisonProjection {
+    const handles = this.listStoryHandlesInternal();
+    let highestId = 0;
+    let present = false;
+    if (mode === "with-revision-census") {
+      // Census every arriving story before resolution mutates any reviewer
+      // state. The shared interpreter omits block ids, so this costs one
+      // carrier walk per story without constructing a throwaway snapshot.
+      for (const handle of handles) {
+        const state = this.getEditableStoryState(handle);
+        if (!state) {
+          continue;
+        }
+        const stats = getTrackedChangeStatsFromDoc(state.doc);
+        highestId = Math.max(highestId, stats.highestId);
+        present ||= stats.present;
+      }
+    }
+
+    const stories: FolioDocxComparisonStoryProjection[] = [];
+    for (const handle of handles) {
+      stories.push({
+        handle,
+        snapshot: this.resolveReviewedStorySnapshotInternal({ story: handle, view: "final" }),
+      });
+    }
+    return { stories, revisions: { highestId, present } };
+  }
+
   /**
    * One story's tables, in the document order {@link snapshotStory} numbers
    * them with, read through a reviewed view.
@@ -843,28 +920,28 @@ export class FolioDocxReviewer {
   readReviewedStory(options: FolioReadReviewedStoryOptions = {}): FolioReviewedStory | null {
     const story = options.story ?? MAIN_STORY;
     const view = options.view ?? "final";
-    if (!isFolioReviewedView(view)) {
-      throw new UnsupportedFolioReviewedViewError({
-        message: "Unsupported reviewed document view.",
-        receivedView: view,
-      });
-    }
-    const sourceState = this.getEditableStoryState(story);
-    if (!sourceState) {
+    const snapshot = this.snapshotReviewedStoryInternal({ story, view });
+    if (!snapshot) {
       return null;
     }
-    const state = resolveReviewedState(sourceState, view);
     return {
       story,
       view,
-      snapshot: createStateSnapshot(state),
-      text: formatStoryStateForLLM(state, view === "current-markup"),
-      changes: getTrackedChangesFromDoc(state.doc),
+      snapshot,
+      text: formatStorySnapshotForLLM(snapshot, view === "current-markup"),
+      changes: getTrackedChangesFromSnapshot(snapshot),
     };
   }
 
   /** Resolve one editable story to its original or final state. */
   resolveReviewedStory({ story = MAIN_STORY, view }: FolioResolveReviewedStoryOptions): boolean {
+    return this.resolveReviewedStorySnapshotInternal({ story, view }) !== null;
+  }
+
+  private resolveReviewedStorySnapshotInternal({
+    story = MAIN_STORY,
+    view,
+  }: FolioResolveReviewedStoryOptions): FolioAIEditSnapshot | null {
     if (!isFolioResolvedReviewedView(view)) {
       throw new UnsupportedFolioReviewedViewError({
         message: "Only original and final views can replace editable story state.",
@@ -873,16 +950,17 @@ export class FolioDocxReviewer {
     }
     const sourceState = this.getEditableStoryState(story);
     if (!sourceState) {
-      return false;
+      return null;
     }
     const resolvedState = resolveReviewedState(sourceState, view);
     this.setEditableStoryState(story, resolvedState);
+    const snapshot = createStateSnapshot(resolvedState);
     this.resolvedStoryExpectations.set(editableStoryKey(story), {
       story,
-      text: formatStoryStateForLLM(resolvedState, false),
-      blocks: createStateSnapshot(resolvedState).blocks.map(resolvedStoryBlockProjection),
+      text: formatStorySnapshotForLLM(snapshot, false),
+      blocks: snapshot.blocks.map(resolvedStoryBlockProjection),
     });
-    return true;
+    return snapshot;
   }
 
   /**
@@ -1055,7 +1133,7 @@ export class FolioDocxReviewer {
    * (clean) output flattens tracked changes and is unchanged.
    */
   getContentAsText(options: FolioGetContentAsTextOptions = {}): string {
-    return formatStoryStateForLLM(this.state, options.annotated === true);
+    return formatStorySnapshotForLLM(this.snapshot(), options.annotated === true);
   }
 
   /**
@@ -1111,45 +1189,34 @@ export class FolioDocxReviewer {
     return lines.join("\n");
   }
 
-  /** Discover every readable document story through a typed, serializable handle. */
-  listStories(): FolioDocumentStory[] {
+  private listStoryHandlesInternal(): FolioDocumentStoryHandle[] {
     const pkg = this.baseDocument.package;
-    const stories: FolioDocumentStory[] = [
-      { handle: { type: "main" }, text: this.getContentAsText() },
-    ];
-    for (const [relationshipId, header] of pkg.headers ?? []) {
-      const handle = { type: "header", relationshipId } as const;
-      stories.push({
-        handle,
-        text: this.getHeaderFooterStoryText(handle, header),
-      });
+    const handles: FolioDocumentStoryHandle[] = [{ type: "main" }];
+    for (const relationshipId of pkg.headers?.keys() ?? []) {
+      handles.push({ type: "header", relationshipId });
     }
-    for (const [relationshipId, footer] of pkg.footers ?? []) {
-      const handle = { type: "footer", relationshipId } as const;
-      stories.push({
-        handle,
-        text: this.getHeaderFooterStoryText(handle, footer),
-      });
+    for (const relationshipId of pkg.footers?.keys() ?? []) {
+      handles.push({ type: "footer", relationshipId });
     }
     for (const footnote of pkg.footnotes ?? []) {
       if (!isSeparatorFootnote(footnote)) {
-        const handle = { type: "footnote", noteId: footnote.id } as const;
-        stories.push({
-          handle,
-          text: this.getNoteStoryText(handle, footnote),
-        });
+        handles.push({ type: "footnote", noteId: footnote.id });
       }
     }
     for (const endnote of pkg.endnotes ?? []) {
       if (!isSeparatorEndnote(endnote)) {
-        const handle = { type: "endnote", noteId: endnote.id } as const;
-        stories.push({
-          handle,
-          text: this.getNoteStoryText(handle, endnote),
-        });
+        handles.push({ type: "endnote", noteId: endnote.id });
       }
     }
-    return stories;
+    return handles;
+  }
+
+  /** Discover every readable document story through a typed, serializable handle. */
+  listStories(): FolioDocumentStory[] {
+    return this.listStoryHandlesInternal().map((handle) => ({
+      handle,
+      text: this.getStoryText(handle),
+    }));
   }
 
   /** Read one discovered story; returns null when its handle is no longer present. */
@@ -1454,15 +1521,14 @@ export class FolioDocxReviewer {
     const reopened = await FolioDocxReviewer.fromBuffer(buffer);
     for (const { story, text, blocks } of expectations) {
       const serialized = reopened.readReviewedStory({ story, view: "current-markup" });
-      const serializedState = reopened.getEditableStoryState(story);
-      const serializedText = serializedState
-        ? formatStoryStateForLLM(serializedState, false)
+      const serializedText = serialized
+        ? formatStorySnapshotForLLM(serialized.snapshot, false)
         : null;
-      const serializedBlocks = serializedState
-        ? createStateSnapshot(serializedState).blocks.map(resolvedStoryBlockProjection)
+      const serializedBlocks = serialized
+        ? serialized.snapshot.blocks.map(resolvedStoryBlockProjection)
         : null;
       const mismatches: FolioResolvedStorySerializationMismatch[] = [];
-      if (!serialized || !serializedState) {
+      if (!serialized) {
         mismatches.push(FOLIO_RESOLVED_STORY_SERIALIZATION_MISMATCHES.storyMissing);
       } else {
         if (serialized.changes.length > 0) {
@@ -1613,6 +1679,24 @@ export class FolioDocxReviewer {
     return normalizeFolioAIBlockText(state?.doc.textContent ?? sourceText);
   }
 
+  private getStoryText(story: FolioDocumentStoryHandle): string {
+    if (story.type === "main") {
+      return this.getContentAsText();
+    }
+    if (story.type === "header" || story.type === "footer") {
+      const source = this.getHeaderFooterStory(story);
+      if (!source) {
+        return panic("A listed document story no longer exists", { story });
+      }
+      return this.getHeaderFooterStoryText(story, source);
+    }
+    const source = this.getNoteStory(story);
+    if (!source) {
+      return panic("A listed document story no longer exists", { story });
+    }
+    return this.getNoteStoryText(story, source);
+  }
+
   private mergeEditedSecondaryStories(
     document: Document,
     secondaryStoryStates: Iterable<FolioSecondaryStoryState> = this.secondaryStoryStates.values(),
@@ -1751,6 +1835,13 @@ export class FolioDocxReviewer {
     return handled;
   }
 }
+
+/** @internal Comparison-only access to atomic and fresh reviewer projections. */
+export const getFolioDocxComparisonAccess = (
+  reviewer: FolioDocxReviewer,
+): FolioDocxComparisonAccess =>
+  comparisonAccessByReviewer.get(reviewer) ??
+  panic("Comparison access was requested for an uninitialized DOCX reviewer");
 
 /** Options for {@link applyFolioAIEditsToBuffer}. */
 export type ApplyFolioAIEditsToBufferOptions = {

--- a/packages/core/src/ai-edits/read.ts
+++ b/packages/core/src/ai-edits/read.ts
@@ -23,7 +23,8 @@ import {
   type FolioNodeRevisionKind,
 } from "../prosemirror/revisionCarriers";
 import { getTableCellMergeChange } from "../prosemirror/tableCellMergeRevision";
-import { createFolioAIEditSnapshot } from "./snapshot";
+import { createFolioAIEditSnapshot, sourceDocumentOf } from "./snapshot";
+import type { FolioAIEditSnapshot } from "./types";
 
 export type FolioReviewChangeKind =
   | "insertion"
@@ -95,8 +96,13 @@ export type FolioCommentAnchor = {
 
 /** Map each snapshot block's start position to its stable id. */
 const blockStartIdsFromDoc = (doc: PMNode): Map<number, string> => {
+  return blockStartIdsFromSnapshot(createFolioAIEditSnapshot(doc));
+};
+
+/** Map an existing snapshot's block starts without projecting its document again. */
+const blockStartIdsFromSnapshot = (snapshot: FolioAIEditSnapshot): Map<number, string> => {
   const starts = new Map<number, string>();
-  for (const anchor of Object.values(createFolioAIEditSnapshot(doc).anchors)) {
+  for (const anchor of Object.values(snapshot.anchors)) {
     starts.set(anchor.from, anchor.id);
   }
   return starts;
@@ -105,7 +111,7 @@ const blockStartIdsFromDoc = (doc: PMNode): Map<number, string> => {
 type FirstBlockIdWithinParams = {
   node: PMNode;
   nodePos: number;
-  blockStarts: ReadonlyMap<number, string>;
+  blockStarts: ReadonlyMap<number, string> | null;
 };
 
 const firstBlockIdWithin = ({
@@ -113,6 +119,9 @@ const firstBlockIdWithin = ({
   nodePos,
   blockStarts,
 }: FirstBlockIdWithinParams): string | null => {
+  if (!blockStarts) {
+    return null;
+  }
   let blockId: string | null = null;
   node.descendants((child, relativePos) => {
     if (blockId !== null || !child.isTextblock) {
@@ -147,19 +156,13 @@ const belongsToRowRevision = (
   revision.id === scope.change.id ||
   (revision.author === scope.change.author && revision.date === scope.change.date);
 
-/**
- * The tracked changes present in the body, read from inline marks and
- * structural node attributes. Runs of one inline revision within a block fold
- * into a single entry.
- *
- * A tracked row insertion or deletion marks the row AND every run in its
- * cells, the way Word writes it. Both halves are one change, so the run marks
- * fold into the row's entry rather than reporting a second time.
- */
-export const getTrackedChangesFromDoc = (doc: PMNode): FolioReviewChange[] => {
+/** Shared revision interpreter; a null block map omits unrelated block-id projection. */
+const getTrackedChangesFromProjectedDoc = (
+  doc: PMNode,
+  blockStarts: ReadonlyMap<number, string> | null,
+): FolioReviewChange[] => {
   const insertionType = doc.type.schema.marks["insertion"];
   const deletionType = doc.type.schema.marks["deletion"];
-  const blockStarts = blockStartIdsFromDoc(doc);
   const grouped = new Map<string, FolioReviewChange>();
   const structuralChangeCellPositions = new Map<string, Set<number>>();
   // Innermost enclosing marked row first: a table nested in a marked row can
@@ -175,7 +178,7 @@ export const getTrackedChangesFromDoc = (doc: PMNode): FolioReviewChange[] => {
     const nodeRevisionCarriers = getFolioNodeRevisionCarriers(node, pos);
     if (nodeRevisionCarriers.length > 0) {
       const blockId = node.isTextblock
-        ? (blockStarts.get(pos) ?? null)
+        ? (blockStarts?.get(pos) ?? null)
         : firstBlockIdWithin({ node, nodePos: pos, blockStarts });
       nodeRevisionCarriers.forEach((carrier, carrierIndex) => {
         grouped.set(
@@ -296,7 +299,7 @@ export const getTrackedChangesFromDoc = (doc: PMNode): FolioReviewChange[] => {
       }
     }
     if (node.isTextblock) {
-      currentBlockId = blockStarts.get(pos) ?? null;
+      currentBlockId = blockStarts?.get(pos) ?? null;
       return true;
     }
     if (!node.isInline) {
@@ -392,6 +395,37 @@ export const getTrackedChangesFromDoc = (doc: PMNode): FolioReviewChange[] => {
   });
 
   return [...grouped.values()];
+};
+
+/** Read revisions from the exact immutable document that produced a snapshot. */
+export const getTrackedChangesFromSnapshot = (snapshot: FolioAIEditSnapshot): FolioReviewChange[] =>
+  getTrackedChangesFromProjectedDoc(
+    sourceDocumentOf(snapshot),
+    blockStartIdsFromSnapshot(snapshot),
+  );
+
+/**
+ * The tracked changes present in the body, read from inline marks and
+ * structural node attributes. Runs of one inline revision within a block fold
+ * into a single entry.
+ *
+ * A tracked row insertion or deletion marks the row AND every run in its
+ * cells, the way Word writes it. Both halves are one change, so the run marks
+ * fold into the row's entry rather than reporting a second time.
+ */
+export const getTrackedChangesFromDoc = (doc: PMNode): FolioReviewChange[] =>
+  getTrackedChangesFromProjectedDoc(doc, blockStartIdsFromDoc(doc));
+
+/** @internal Read revision statistics without paying for an unrelated block projection. */
+export const getTrackedChangeStatsFromDoc = (
+  doc: PMNode,
+): { highestId: number; present: boolean } => {
+  let highestId = 0;
+  const changes = getTrackedChangesFromProjectedDoc(doc, null);
+  for (const change of changes) {
+    highestId = Math.max(highestId, change.id);
+  }
+  return { highestId, present: changes.length > 0 };
 };
 
 /**

--- a/packages/core/src/ai-edits/revisionEnumeration.test.ts
+++ b/packages/core/src/ai-edits/revisionEnumeration.test.ts
@@ -20,8 +20,16 @@ import {
   FolioDocxReviewer,
   type FolioReviewComment,
   type FolioReviewCommentReply,
+  getFolioDocxComparisonAccess,
 } from "./headless";
-import { FOLIO_REVIEW_CHANGE_KINDS, getTrackedChangesFromDoc } from "./read";
+import {
+  FOLIO_REVIEW_CHANGE_KINDS,
+  getTrackedChangeStatsFromDoc,
+  getTrackedChangesFromDoc,
+  getTrackedChangesFromSnapshot,
+} from "./read";
+import { storyTablesOf } from "./snapshot";
+import type { FolioAIEditSnapshot } from "./types";
 
 const AUTHOR = "Reviewer";
 const DATE = "2026-08-16T10:00:00Z";
@@ -561,7 +569,28 @@ const MATRIX_CASES = FOLIO_RESOLVED_REVIEWED_VIEWS.flatMap((view) =>
 
 describe("body revision enumeration", () => {
   test("enumerates every property and paragraph-mark carrier the resolver supports", () => {
-    const changes = getTrackedChangesFromDoc(toProseDoc(revisionDocument()));
+    const doc = toProseDoc(revisionDocument());
+    const walk = doc.descendants.bind(doc);
+    let statsWalks = 0;
+    Object.defineProperty(doc, "descendants", {
+      configurable: true,
+      value: (callback: Parameters<typeof doc.descendants>[0]) => {
+        statsWalks += 1;
+        return walk(callback);
+      },
+    });
+    const stats = getTrackedChangeStatsFromDoc(doc);
+    expect(statsWalks).toBe(1);
+    expect(stats).toEqual({
+      highestId: Math.max(...expectedChanges.map(({ id }) => id)),
+      present: true,
+    });
+    expect(getTrackedChangeStatsFromDoc(toProseDoc(createEmptyDocument()))).toEqual({
+      highestId: 0,
+      present: false,
+    });
+
+    const changes = getTrackedChangesFromDoc(doc);
 
     expect(changes.map(({ id, type, text }) => ({ id, type, text }))).toEqual(expectedChanges);
     expect(
@@ -618,6 +647,80 @@ describe("body revision enumeration", () => {
 });
 
 describe("resolved story serialization structural matrix", () => {
+  test("keeps each story projection bound to its own state across resolution and mutation", async () => {
+    const reviewer = await FolioDocxReviewer.fromBuffer(await makeRevisionMatrixDocx("with"), {
+      author: AUTHOR,
+    });
+    const comparisonAccess = getFolioDocxComparisonAccess(reviewer);
+    const arrivingByStory = new Map<
+      string,
+      {
+        snapshot: FolioAIEditSnapshot;
+        changes: ReturnType<typeof getTrackedChangesFromSnapshot>;
+      }
+    >();
+
+    for (const story of REVIEW_STORIES) {
+      const arriving = comparisonAccess.snapshotReviewedStory({ story, view: "current-markup" });
+      if (!arriving) {
+        throw new Error(`revision matrix is missing ${storyKey(story)}`);
+      }
+      const arrivingChanges = getTrackedChangesFromSnapshot(arriving);
+      expect(arrivingChanges).not.toHaveLength(0);
+      arrivingByStory.set(storyKey(story), { snapshot: arriving, changes: arrivingChanges });
+    }
+
+    const projection = comparisonAccess.projectStories("with-revision-census");
+    expect(projection.stories.map(({ handle }) => handle)).toEqual(REVIEW_STORIES);
+    expect(projection.revisions).toEqual({
+      highestId: Math.max(...expectedChanges.map(({ id }) => id)),
+      present: true,
+    });
+
+    for (const { handle: story, snapshot: resolved } of projection.stories) {
+      if (!resolved) {
+        throw new Error(`revision matrix could not resolve ${storyKey(story)}`);
+      }
+      expect(getTrackedChangesFromSnapshot(resolved)).toEqual([]);
+      const target = resolved.blocks.find(({ text }) => text === "Cell");
+      if (!target) {
+        throw new Error(`revision matrix is missing the table cell in ${storyKey(story)}`);
+      }
+      const mutationText = `${story.type} mutation`;
+      const result = reviewer.applyDocumentOperationsToStory({
+        story,
+        snapshot: resolved,
+        batch: {
+          version: 1,
+          mode: "direct",
+          operations: [
+            {
+              id: `${story.type}-snapshot-freshness`,
+              type: "replaceInBlock",
+              blockId: target.id,
+              find: "Cell",
+              replace: mutationText,
+            },
+          ],
+        },
+      });
+      expect(result.status).toBe("committed");
+
+      const mutated = comparisonAccess.snapshotReviewedStory({ story, view: "current-markup" });
+      if (!mutated) {
+        throw new Error(`revision matrix lost ${storyKey(story)} after mutation`);
+      }
+      expect(storyTablesOf(resolved).at(0)?.node.textContent).toContain("Cell");
+      expect(storyTablesOf(resolved).at(0)?.node.textContent).not.toContain(mutationText);
+      expect(storyTablesOf(mutated).at(0)?.node.textContent).toContain(mutationText);
+      const arriving = arrivingByStory.get(storyKey(story));
+      expect(arriving).toBeDefined();
+      if (arriving) {
+        expect(getTrackedChangesFromSnapshot(arriving.snapshot)).toEqual(arriving.changes);
+      }
+    }
+  });
+
   test.each(WORDPROCESSINGML_NAMESPACES)(
     "recognizes comment anchors in the %s namespace independent of prefix",
     (namespace) => {

--- a/packages/core/src/ai-edits/snapshot.test.ts
+++ b/packages/core/src/ai-edits/snapshot.test.ts
@@ -21,10 +21,12 @@ import type { CleanTextStructuralBoundary } from "./clean-text";
 import {
   createFolioAIEditSnapshot,
   createFolioAIEditSnapshotWithStyleResolver,
+  folioStoryTables,
   hashFolioAIBlockStructuralBoundaries,
   hashFolioAIBlockText,
   isFolioAIContentBlock,
   projectFolioAIBlockStructuralBoundaries,
+  storyTablesOf,
 } from "./snapshot";
 
 const schema = new Schema({
@@ -246,6 +248,74 @@ describe("createFolioAIEditSnapshot", () => {
     );
 
     expect(createFolioAIEditSnapshot(doc).blocks).toHaveLength(480);
+  });
+
+  test("collects blocks and tables in one whole-document walk", () => {
+    const doc = schema.node("doc", null, [
+      paragraph("opening"),
+      table([row([cell([paragraph("table cell")])])]),
+      paragraph("closing"),
+    ]);
+    const walk = doc.descendants.bind(doc);
+    let wholeDocumentWalks = 0;
+    Object.defineProperty(doc, "descendants", {
+      configurable: true,
+      value: (callback: Parameters<PMNode["descendants"]>[0]) => {
+        wholeDocumentWalks += 1;
+        return walk(callback);
+      },
+    });
+
+    const snapshot = createFolioAIEditSnapshot(doc);
+
+    expect(wholeDocumentWalks).toBe(1);
+    expect(
+      storyTablesOf(snapshot).map(({ index, node }) => ({ index, text: node.textContent })),
+    ).toEqual([{ index: 0, text: "table cell" }]);
+  });
+
+  test("keeps the direct and snapshot table censuses identical across nested and hidden rows", () => {
+    const visibleNested = table([row([cell([paragraph("visible nested")])])]);
+    const hiddenNested = table([row([cell([paragraph("hidden nested")])])]);
+    const doc = schema.node("doc", null, [
+      paragraph("opening"),
+      table([
+        row([cell([paragraph("outer visible"), visibleNested])]),
+        row([cell([paragraph("hidden"), hiddenNested])], true),
+        row([cell([paragraph("outer trailing")])]),
+      ]),
+      table([row([cell([paragraph("body trailing")])])]),
+    ]);
+
+    const direct = folioStoryTables(doc);
+    const projected = storyTablesOf(createFolioAIEditSnapshot(doc));
+
+    expect(projected.map(({ index, start }) => ({ index, start }))).toEqual(
+      direct.map(({ index, start }) => ({ index, start })),
+    );
+    expect(projected).toHaveLength(3);
+    for (const [index, tableProjection] of projected.entries()) {
+      expect(tableProjection.node).toBe(direct.at(index)?.node);
+    }
+  });
+
+  test("binds each table census to the immutable document that produced its snapshot", () => {
+    const before = schema.node("doc", null, [table([row([cell([paragraph("before mutation")])])])]);
+    const after = schema.node("doc", null, [
+      table([row([cell([paragraph("after mutation")])])]),
+      table([row([cell([paragraph("new table")])])]),
+    ]);
+
+    const beforeSnapshot = createFolioAIEditSnapshot(before);
+    const afterSnapshot = createFolioAIEditSnapshot(after);
+
+    expect(storyTablesOf(beforeSnapshot).map(({ node }) => node.textContent)).toEqual([
+      "before mutation",
+    ]);
+    expect(storyTablesOf(afterSnapshot).map(({ node }) => node.textContent)).toEqual([
+      "after mutation",
+      "new table",
+    ]);
   });
 
   test("projects carrierless run marks without consulting the style package", () => {

--- a/packages/core/src/ai-edits/snapshot.ts
+++ b/packages/core/src/ai-edits/snapshot.ts
@@ -23,12 +23,29 @@ import type {
   FolioAITextRangeHandle,
 } from "./types";
 
-const numberingReferenceKeysBySnapshot = new WeakMap<FolioAIEditSnapshot, readonly string[]>();
+type FolioAIEditSnapshotMetadata = {
+  numberingReferenceKeys: readonly string[];
+  sourceDocument: PMNode;
+  storyTables: readonly FolioStoryTable[];
+};
+
+const metadataBySnapshot = new WeakMap<FolioAIEditSnapshot, FolioAIEditSnapshotMetadata>();
+
+const metadataOf = (snapshot: FolioAIEditSnapshot): FolioAIEditSnapshotMetadata =>
+  metadataBySnapshot.get(snapshot) ??
+  panic("Metadata was requested for a snapshot that did not record it");
 
 /** @internal Numbering references collected during the snapshot's document walk. */
 export const numberingReferenceKeysOf = (snapshot: FolioAIEditSnapshot): readonly string[] =>
-  numberingReferenceKeysBySnapshot.get(snapshot) ??
-  panic("A numbering census was requested for a snapshot that did not record one");
+  metadataOf(snapshot).numberingReferenceKeys;
+
+/** @internal Tables collected during the snapshot's document walk. */
+export const storyTablesOf = (snapshot: FolioAIEditSnapshot): readonly FolioStoryTable[] =>
+  metadataOf(snapshot).storyTables;
+
+/** @internal The immutable ProseMirror document that produced this snapshot. */
+export const sourceDocumentOf = (snapshot: FolioAIEditSnapshot): PMNode =>
+  metadataOf(snapshot).sourceDocument;
 
 export const normalizeFolioAIBlockText = (text: string): string =>
   text.replace(/\s+/gu, " ").trim();
@@ -191,14 +208,29 @@ export type FolioStoryTable = {
   node: PMNode;
 };
 
+const STORY_TABLE_CONTAINER = "container";
+const STORY_TABLE_HIDDEN_SUBTREE = "hidden-subtree";
+const STORY_TABLE = "table";
+
+type StoryTableNodeDisposition =
+  | typeof STORY_TABLE_CONTAINER
+  | typeof STORY_TABLE_HIDDEN_SUBTREE
+  | typeof STORY_TABLE;
+
+/** Shared visibility and table-role rule for both story projection walks. */
+const classifyNonTextblockStoryTableNode = (node: PMNode): StoryTableNodeDisposition => {
+  if (isHiddenTableRow(node)) {
+    return STORY_TABLE_HIDDEN_SUBTREE;
+  }
+  return node.type.spec["tableRole"] === TABLE_ROLE_TABLE ? STORY_TABLE : STORY_TABLE_CONTAINER;
+};
+
 /**
  * Every table of one story in document order, nested tables included and
  * hidden rows' subtrees excluded.
  *
- * The single place a story's tables are numbered. `table.tableIndex` on a
- * block, the geometry a comparison copies out of the target and the geometry
- * it checks its own work against all read this list, so no second walk can
- * number the same document differently.
+ * Uses the same traversal classification as the snapshot's integrated census,
+ * so both surfaces skip and number the same nodes in the same order.
  */
 export const folioStoryTables = (doc: PMNode): FolioStoryTable[] => {
   const tables: FolioStoryTable[] = [];
@@ -206,10 +238,11 @@ export const folioStoryTables = (doc: PMNode): FolioStoryTable[] => {
     if (node.isTextblock) {
       return false;
     }
-    if (isHiddenTableRow(node)) {
+    const disposition = classifyNonTextblockStoryTableNode(node);
+    if (disposition === STORY_TABLE_HIDDEN_SUBTREE) {
       return false;
     }
-    if (node.type.spec["tableRole"] === TABLE_ROLE_TABLE) {
+    if (disposition === STORY_TABLE) {
       tables.push({ index: tables.length, start: pos, node });
     }
     return true;
@@ -285,9 +318,8 @@ const createFolioAIEditSnapshotInternal = (
   const hashCounts = new Map<string, number>();
   const usedBlockIds = new Set<string>();
   const numberingReferenceKeys = new Set<string>();
-  const tableIndexByStart = new Map(
-    folioStoryTables(doc).map(({ start, index }) => [start, index] as const),
-  );
+  const tables: FolioStoryTable[] = [];
+  const tableIndexByStart = new Map<number, number>();
   // The containers enclosing the node being visited, innermost last. Kept in
   // step with the walk so no block has to resolve its own position.
   const path: AncestorPathEntry[] = [];
@@ -299,8 +331,14 @@ const createFolioAIEditSnapshotInternal = (
       path.pop();
     }
     if (!node.isTextblock) {
-      if (isHiddenTableRow(node)) {
+      const disposition = classifyNonTextblockStoryTableNode(node);
+      if (disposition === STORY_TABLE_HIDDEN_SUBTREE) {
         return false;
+      }
+      if (disposition === STORY_TABLE) {
+        const tableIndex = tables.length;
+        tables.push({ index: tableIndex, start: pos, node });
+        tableIndexByStart.set(pos, tableIndex);
       }
       if (!node.isLeaf) {
         path.push({ node, start: pos, end: pos + node.nodeSize, index });
@@ -408,7 +446,11 @@ const createFolioAIEditSnapshotInternal = (
   }
 
   const snapshot = { blocks, anchors };
-  numberingReferenceKeysBySnapshot.set(snapshot, [...numberingReferenceKeys]);
+  metadataBySnapshot.set(snapshot, {
+    numberingReferenceKeys: [...numberingReferenceKeys],
+    sourceDocument: doc,
+    storyTables: tables,
+  });
   return snapshot;
 };
 

--- a/packages/core/src/compare/compare.ts
+++ b/packages/core/src/compare/compare.ts
@@ -39,6 +39,7 @@ import type { Node as PMNode } from "prosemirror-model";
 
 import {
   FolioDocxReviewer,
+  getFolioDocxComparisonAccess,
   type FolioDocumentStoryHandle,
   type FolioNumberingLevel,
   type FolioRevisionStamp,
@@ -48,7 +49,7 @@ import {
   tableTemplateCanCrossPackageLosslessly,
   type FolioTableTemplates,
 } from "../ai-edits/table-template";
-import { numberingReferenceKeysOf } from "../ai-edits/snapshot";
+import { numberingReferenceKeysOf, storyTablesOf } from "../ai-edits/snapshot";
 import type { FolioAIBlock, FolioAIEditSkipReason, FolioAIEditSnapshot } from "../ai-edits/types";
 import { createScopedWordDiffOptions, type WordDiffGranularity } from "../ai-edits/word-diff";
 import { FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION } from "../document-operations";
@@ -99,36 +100,6 @@ const parseSide = async (
         cause,
       }),
   });
-
-type ExistingRevisions = {
-  /**
-   * One past the highest revision id the base package already uses, across
-   * every story. Seeding there keeps generated ids from colliding with
-   * revisions the base already carries, while staying a pure function of the
-   * base bytes.
-   */
-  idSeed: number;
-  /**
-   * Whether the base arrived carrying unresolved revisions. When it did, the
-   * compared base is its accepted view rather than the package as stored, and
-   * the result must be serialized even if nothing else changed.
-   */
-  present: boolean;
-};
-
-/** Read before either side is resolved, so it describes the package as it arrived. */
-const existingRevisionsOf = (reviewer: FolioDocxReviewer): ExistingRevisions => {
-  let highest = 0;
-  let present = false;
-  for (const { handle } of reviewer.listStories()) {
-    const story = reviewer.readReviewedStory({ story: handle, view: "current-markup" });
-    for (const change of story?.changes ?? []) {
-      highest = Math.max(highest, change.id);
-      present = true;
-    }
-  }
-  return { idSeed: highest + 1, present };
-};
 
 type FormattingRoundTripFailureOptions = {
   invariant: CompareVerificationFailure["invariant"];
@@ -256,7 +227,6 @@ export type ParsedComparison = {
   baseBuffer: ArrayBuffer;
   baseCarriedRevisions: boolean;
   reviewer: FolioDocxReviewer;
-  targetReviewer: FolioDocxReviewer;
   revisionStamp: FolioRevisionStamp;
   packageDate: Date;
   pairs: readonly ComparedStoryPair[];
@@ -293,7 +263,6 @@ export const parseComparison = async (
 
   const reviewer = baseParse.value;
   const targetReviewer = targetParse.value;
-  const existing = existingRevisionsOf(reviewer);
   // Compare the accepted view of both sides. An input that already carries
   // revisions otherwise makes the result unreadable: the redline would layer
   // this comparison's marks on top of someone else's, and rejecting them all
@@ -306,16 +275,26 @@ export const parseComparison = async (
   // still ships in the result, so it ships accepted like the rest -- and an
   // unresolvable mark it carried, on the paragraph a note ends with, would
   // otherwise fail the structural guard on bytes this comparison never wrote.
-  for (const { handle } of reviewer.listStories()) {
-    reviewer.resolveReviewedStory({ story: handle, view: "final" });
+  const baseProjection =
+    getFolioDocxComparisonAccess(reviewer).projectStories("with-revision-census");
+  const targetProjection =
+    getFolioDocxComparisonAccess(targetReviewer).projectStories("without-revision-census");
+  const baseStories: FolioDocumentStoryHandle[] = [];
+  const targetStories: FolioDocumentStoryHandle[] = [];
+  const baseSnapshots = new Map<FolioDocumentStoryHandle, FolioAIEditSnapshot | null>();
+  const targetSnapshots = new Map<FolioDocumentStoryHandle, FolioAIEditSnapshot | null>();
+  for (const { handle, snapshot } of baseProjection.stories) {
+    baseStories.push(handle);
+    baseSnapshots.set(handle, snapshot);
   }
-  for (const { handle } of targetReviewer.listStories()) {
-    targetReviewer.resolveReviewedStory({ story: handle, view: "final" });
+  for (const { handle, snapshot } of targetProjection.stories) {
+    targetStories.push(handle);
+    targetSnapshots.set(handle, snapshot);
   }
   const pairs: ComparedStoryPair[] = [];
   const unsupported: CompareUnsupportedPart[] = [];
   const referencedNumberingLevels = new Set<string>();
-  const collectNumberingReferences = (snapshot: FolioAIEditSnapshot | null): void => {
+  const collectNumberingReferences = (snapshot: FolioAIEditSnapshot | null | undefined): void => {
     if (!snapshot) {
       return;
     }
@@ -325,24 +304,24 @@ export const parseComparison = async (
   };
 
   for (const { baseStory, revisedStory: targetStory } of pairFolioDocumentStories(
-    reviewer.listStories().map(({ handle }) => handle),
-    targetReviewer.listStories().map(({ handle }) => handle),
+    baseStories,
+    targetStories,
   )) {
     if (!baseStory) {
       if (!targetStory) {
         panic("A story pair contained neither a base nor a target story");
       }
-      collectNumberingReferences(targetReviewer.snapshotStory(targetStory));
+      collectNumberingReferences(targetSnapshots.get(targetStory));
       unsupported.push({ reason: "story-missing-in-base", baseStory: null, targetStory });
       continue;
     }
     if (!targetStory) {
-      collectNumberingReferences(reviewer.snapshotStory(baseStory));
+      collectNumberingReferences(baseSnapshots.get(baseStory));
       unsupported.push({ reason: "story-missing-in-target", baseStory, targetStory: null });
       continue;
     }
-    const baseSnapshot = reviewer.snapshotStory(baseStory);
-    const targetSnapshot = targetReviewer.snapshotStory(targetStory);
+    const baseSnapshot = baseSnapshots.get(baseStory);
+    const targetSnapshot = targetSnapshots.get(targetStory);
     collectNumberingReferences(baseSnapshot);
     collectNumberingReferences(targetSnapshot);
     if (!baseSnapshot || !targetSnapshot) {
@@ -355,10 +334,12 @@ export const parseComparison = async (
   return Result.ok({
     granularity: options.granularity ?? "word",
     baseBuffer: base,
-    baseCarriedRevisions: existing.present,
+    baseCarriedRevisions: baseProjection.revisions.present,
     reviewer,
-    targetReviewer,
-    revisionStamp: { date: options.timestamp, idSeed: existing.idSeed },
+    revisionStamp: {
+      date: options.timestamp,
+      idSeed: baseProjection.revisions.highestId + 1,
+    },
     packageDate,
     pairs,
     numberingChanges: compareNumbering(reviewer, targetReviewer, referencedNumberingLevels),
@@ -370,14 +351,11 @@ export const parseComparison = async (
 export type PlannedStoryComparison = { pair: ComparedStoryPair; plan: CompareStoryPlan };
 
 const planCopiesNonPortableWholeTable = (
-  targetReviewer: FolioDocxReviewer,
   pair: ComparedStoryPair,
   plan: CompareStoryPlan,
 ): boolean => {
   const targetTables = new Map(
-    targetReviewer
-      .storyTables({ story: pair.targetStory })
-      .map(({ index, node }) => [index, node] as const),
+    storyTablesOf(pair.targetSnapshot).map(({ index, node }) => [index, node] as const),
   );
   return plan.tableTemplates.some(({ targetRowIndex, targetTableIndex }) => {
     if (targetRowIndex !== undefined) {
@@ -394,7 +372,6 @@ const planCopiesNonPortableWholeTable = (
  */
 export const planComparison = ({
   pairs,
-  targetReviewer,
 }: ParsedComparison): Result<readonly PlannedStoryComparison[], CompareDocxOperationLimitError> => {
   const planned: PlannedStoryComparison[] = [];
   const workSession = createContentComparisonWorkSession();
@@ -412,7 +389,7 @@ export const planComparison = ({
       wholeTableReplacement: "allow",
       workSession,
     });
-    if (plan && planCopiesNonPortableWholeTable(targetReviewer, pair, plan)) {
+    if (plan && planCopiesNonPortableWholeTable(pair, plan)) {
       // The first plan was speculative. Re-run the chosen fallback against
       // the same package-wide comparison allowance rather than charging both.
       workSession.alignment.remainingLcsCells = remainingLcsCells;
@@ -537,9 +514,10 @@ const resolveTableTemplates = (
  * are both legitimate asks and only the caller knows which one it is making.
  */
 export const applyComparison = (
-  { reviewer, targetReviewer, revisionStamp, granularity, numberingChanges }: ParsedComparison,
+  { reviewer, revisionStamp, granularity, numberingChanges }: ParsedComparison,
   planned: readonly PlannedStoryComparison[],
 ): Result<AppliedComparison, CompareDocxApplyError> => {
+  const comparisonAccess = getFolioDocxComparisonAccess(reviewer);
   const changes: CompareChange[] = [...numberingChanges];
   const failures: CompareVerificationFailure[] = [];
   // Each story gets the range that starts where the previous story's ended.
@@ -555,18 +533,12 @@ export const applyComparison = (
       continue;
     }
 
-    // Read before anything lands: this is the document the redline is written
-    // against, and rejecting every revision has to return to it.
-    const baseBeforeBlocks =
-      reviewer.readReviewedStory({ story: pair.baseStory, view: "final" })?.snapshot.blocks ?? [];
-    const baseBefore = baseBeforeBlocks;
-    const baseBeforeGeometry = projectTableGeometry(
-      reviewer.storyTables({ story: pair.baseStory }),
-    );
+    // Retained before anything lands: this is the document the redline is
+    // written against, and rejecting every revision has to return to it.
+    const baseBefore = pair.baseSnapshot.blocks;
+    const baseBeforeGeometry = projectTableGeometry(storyTablesOf(pair.baseSnapshot));
     const targetTables = new Map(
-      targetReviewer
-        .storyTables({ story: pair.targetStory })
-        .map(({ index, node }) => [index, node] as const),
+      storyTablesOf(pair.targetSnapshot).map(({ index, node }) => [index, node] as const),
     );
 
     // Table properties first, while the base's table indices still describe
@@ -621,11 +593,14 @@ export const applyComparison = (
       }
     }
 
-    const acceptedStory = reviewer.readReviewedStory({ story: pair.baseStory, view: "final" });
+    const acceptedSnapshot = comparisonAccess.snapshotReviewedStory({
+      story: pair.baseStory,
+      view: "final",
+    });
     const acceptFailure = classifyProjectionMismatch({
       invariant: "accept-reproduces-target",
       story: pair.baseStory,
-      actual: acceptedStory?.snapshot.blocks ?? [],
+      actual: acceptedSnapshot?.blocks ?? [],
       expected: pair.targetSnapshot.blocks,
     });
     if (acceptFailure) {
@@ -635,7 +610,7 @@ export const applyComparison = (
         invariant: "accept-reproduces-target",
         story: pair.baseStory,
         changes: plan.changes,
-        actualBlocks: acceptedStory?.snapshot.blocks ?? [],
+        actualBlocks: acceptedSnapshot?.blocks ?? [],
         expectedBlocks: pair.targetSnapshot.blocks,
         expectedBlockId: ({ targetBlockId }) => targetBlockId,
       });
@@ -643,11 +618,14 @@ export const applyComparison = (
         failures.push(formattingFailure);
       }
     }
-    const rejectedStory = reviewer.readReviewedStory({ story: pair.baseStory, view: "original" });
+    const rejectedSnapshot = comparisonAccess.snapshotReviewedStory({
+      story: pair.baseStory,
+      view: "original",
+    });
     const rejectFailure = classifyProjectionMismatch({
       invariant: "reject-reproduces-base",
       story: pair.baseStory,
-      actual: rejectedStory?.snapshot.blocks ?? [],
+      actual: rejectedSnapshot?.blocks ?? [],
       expected: baseBefore,
     });
     if (rejectFailure) {
@@ -657,7 +635,7 @@ export const applyComparison = (
         invariant: "reject-reproduces-base",
         story: pair.baseStory,
         changes: plan.changes,
-        actualBlocks: rejectedStory?.snapshot.blocks ?? [],
+        actualBlocks: rejectedSnapshot?.blocks ?? [],
         expectedBlocks: pair.baseSnapshot.blocks,
         expectedBlockId: ({ baseBlockId }) => baseBlockId,
       });
@@ -674,8 +652,8 @@ export const applyComparison = (
     const geometryAcceptFailure = classifyGeometryMismatch({
       invariant: "accept-reproduces-target",
       story: pair.baseStory,
-      actual: projectTableGeometry(reviewer.storyTables({ story: pair.baseStory, view: "final" })),
-      expected: projectTableGeometry(targetReviewer.storyTables({ story: pair.targetStory })),
+      actual: projectTableGeometry(acceptedSnapshot ? storyTablesOf(acceptedSnapshot) : []),
+      expected: projectTableGeometry(storyTablesOf(pair.targetSnapshot)),
     });
     if (geometryAcceptFailure) {
       failures.push(geometryAcceptFailure);
@@ -683,9 +661,7 @@ export const applyComparison = (
     const geometryRejectFailure = classifyGeometryMismatch({
       invariant: "reject-reproduces-base",
       story: pair.baseStory,
-      actual: projectTableGeometry(
-        reviewer.storyTables({ story: pair.baseStory, view: "original" }),
-      ),
+      actual: projectTableGeometry(rejectedSnapshot ? storyTablesOf(rejectedSnapshot) : []),
       expected: baseBeforeGeometry,
     });
     if (geometryRejectFailure) {

--- a/packages/core/src/compare/projection-session.test.ts
+++ b/packages/core/src/compare/projection-session.test.ts
@@ -1,0 +1,126 @@
+import { expect, test } from "bun:test";
+import type { Node as PMNode } from "prosemirror-model";
+
+import { FolioDocxReviewer, getFolioDocxComparisonAccess } from "../ai-edits/headless";
+import { sourceDocumentOf } from "../ai-edits/snapshot";
+import { createDocx } from "../docx/rezip";
+import type { HeaderFooter, Paragraph } from "../types/document";
+import { createEmptyDocument } from "../utils/createDocument";
+import { applyComparison, parseComparison, planComparison } from "./compare";
+
+const OPTIONS = { author: "compare", timestamp: "2026-09-11T00:00:00.000Z" } as const;
+const HEADER_RELATIONSHIP_ID = "rId_projection_header";
+const FOOTER_RELATIONSHIP_ID = "rId_projection_footer";
+
+const paragraph = (text: string, paraId: string): Paragraph => ({
+  type: "paragraph",
+  paraId,
+  content: [{ type: "run", content: [{ type: "text", text }] }],
+});
+
+const headerFooter = (type: "header" | "footer", text: string, paraId: string): HeaderFooter => ({
+  type,
+  hdrFtrType: "default",
+  content: [paragraph(text, paraId)],
+});
+
+const storyMatrixDocx = (label: string): Promise<ArrayBuffer> => {
+  const document = createEmptyDocument();
+  document.package.document.content = [paragraph(`main ${label}`, "A1000001")];
+  document.package.headers = new Map([
+    [HEADER_RELATIONSHIP_ID, headerFooter("header", `header ${label}`, "A1000002")],
+  ]);
+  document.package.footers = new Map([
+    [FOOTER_RELATIONSHIP_ID, headerFooter("footer", `footer ${label}`, "A1000003")],
+  ]);
+  document.package.document.finalSectionProperties = {
+    ...document.package.document.finalSectionProperties,
+    headerReferences: [{ type: "default", rId: HEADER_RELATIONSHIP_ID }],
+    footerReferences: [{ type: "default", rId: FOOTER_RELATIONSHIP_ID }],
+  };
+  document.package.footnotes = [
+    {
+      type: "footnote",
+      id: 2,
+      noteType: "normal",
+      content: [paragraph(`footnote ${label}`, "A1000004")],
+    },
+  ];
+  document.package.endnotes = [
+    {
+      type: "endnote",
+      id: 3,
+      noteType: "normal",
+      content: [paragraph(`endnote ${label}`, "A1000005")],
+    },
+  ];
+  return createDocx(document);
+};
+
+const instrumentStoryTraversals = (reviewer: FolioDocxReviewer): (() => number)[] => {
+  const counters: (() => number)[] = [];
+  for (const { handle } of reviewer.listStories()) {
+    const reviewed = reviewer.readReviewedStory({ story: handle, view: "current-markup" });
+    if (!reviewed) {
+      throw new Error(`missing ${handle.type} story`);
+    }
+    const doc = sourceDocumentOf(reviewed.snapshot);
+    const descendants = doc.descendants.bind(doc);
+    let traversals = 0;
+    Object.defineProperty(doc, "descendants", {
+      configurable: true,
+      value: (callback: Parameters<PMNode["descendants"]>[0]) => {
+        traversals += 1;
+        return descendants(callback);
+      },
+    });
+    counters.push(() => traversals);
+  }
+  return counters;
+};
+
+test("comparison projection has one snapshot walk plus only the requested revision census", async () => {
+  const baseReviewer = await FolioDocxReviewer.fromBuffer(await storyMatrixDocx("before"));
+  const baseTraversals = instrumentStoryTraversals(baseReviewer);
+  const baseProjection =
+    getFolioDocxComparisonAccess(baseReviewer).projectStories("with-revision-census");
+
+  expect(baseProjection.stories).toHaveLength(5);
+  expect(baseProjection.stories.every(({ snapshot }) => snapshot !== null)).toBe(true);
+  expect(baseProjection.revisions).toEqual({ highestId: 0, present: false });
+  expect(baseTraversals.map((read) => read())).toEqual([2, 2, 2, 2, 2]);
+
+  const targetReviewer = await FolioDocxReviewer.fromBuffer(await storyMatrixDocx("after"));
+  const targetTraversals = instrumentStoryTraversals(targetReviewer);
+  const targetProjection =
+    getFolioDocxComparisonAccess(targetReviewer).projectStories("without-revision-census");
+
+  expect(targetProjection.stories).toHaveLength(5);
+  expect(targetProjection.stories.every(({ snapshot }) => snapshot !== null)).toBe(true);
+  expect(targetProjection.revisions).toEqual({ highestId: 0, present: false });
+  expect(targetTraversals.map((read) => read())).toEqual([1, 1, 1, 1, 1]);
+});
+
+test("comparison consumes the retained story projections through apply verification", async () => {
+  const parsed = await parseComparison(
+    await storyMatrixDocx("before"),
+    await storyMatrixDocx("after"),
+    OPTIONS,
+  );
+  if (parsed.isErr()) {
+    throw parsed.error;
+  }
+  expect(parsed.value.pairs).toHaveLength(5);
+
+  const planned = planComparison(parsed.value);
+  if (planned.isErr()) {
+    throw planned.error;
+  }
+  expect(planned.value).toHaveLength(5);
+  const applied = applyComparison(parsed.value, planned.value);
+  if (applied.isErr()) {
+    throw applied.error;
+  }
+
+  expect(applied.value.verification).toEqual({ status: "verified" });
+});

--- a/packages/core/src/document-stories.test.ts
+++ b/packages/core/src/document-stories.test.ts
@@ -6,6 +6,20 @@ const header = (relationshipId: string) => ({ type: "header", relationshipId }) 
 const footer = (relationshipId: string) => ({ type: "footer", relationshipId }) as const;
 
 describe("pairFolioDocumentStories", () => {
+  test("returns the exact input handles after pairing", () => {
+    const baseMain = { type: "main" } as const;
+    const baseHeader = header("rId3");
+    const revisedMain = { type: "main" } as const;
+    const revisedHeader = header("rId8");
+
+    const pairs = pairFolioDocumentStories([baseMain, baseHeader], [revisedMain, revisedHeader]);
+
+    expect(pairs[0]?.baseStory).toBe(baseMain);
+    expect(pairs[0]?.revisedStory).toBe(revisedMain);
+    expect(pairs[1]?.baseStory).toBe(baseHeader);
+    expect(pairs[1]?.revisedStory).toBe(revisedHeader);
+  });
+
   test("pairs a header with the one carrying the same relationship id", () => {
     // Two revisions of one file carry their part ids forward, and matching on
     // them pairs the right header however the parts are ordered.


### PR DESCRIPTION
## Summary

- retain one immutable resolved snapshot per document story throughout DOCX comparison
- collect table and numbering references during the snapshot traversal instead of rescanning the story
- census arriving revision IDs without constructing an unrelated block projection
- keep the comparison access seam internal, with no supported API expansion
- bind table-order parity, snapshot freshness, story coverage, and traversal budgets with focused tests

## Validation

- focused snapshot, revision, headless, comparison, and story tests: 240 passed
- `bun scripts/api-reports.ts --package core`
- `bun --filter @stll/folio-core build`
