### PR TITLE
fix(core): retain edited table row identity

### DIFF
--- a/.changeset/calm-rows-align.md
+++ b/.changeset/calm-rows-align.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep edited table rows paired when another row is inserted or deleted.

--- a/packages/core/src/compare/compare.property.test.ts
+++ b/packages/core/src/compare/compare.property.test.ts
@@ -240,6 +240,9 @@ const wordArb = fc.stringMatching(/^[A-Za-z]{3,9}$/u);
 const sentenceArb = fc
   .array(wordArb, { minLength: 3, maxLength: 6 })
   .map((words) => words.join(" "));
+const rowRewriteArb = fc
+  .array(wordArb, { minLength: 4, maxLength: 6 })
+  .map((words) => words.join(" "));
 
 /** A word already present in some block, so `replaceWords` resolves. */
 const findableWordArb = (blocks: readonly FolioAIBlock[]) => {
@@ -834,6 +837,88 @@ describe("compareDocx", () => {
     ]);
     expect(changes).toHaveLength(scripted.value.applied.length);
   });
+
+  test.each([0, 1, 2] as const)(
+    "deleting row %i keeps fully rewritten surviving rows at cell level",
+    async (deletedRow) => {
+      const base = readFixture("upstream-with-tables.docx");
+      await fc.assert(
+        fc.asyncProperty(rowRewriteArb, async (rewrittenText) => {
+          const survivingRows = [0, 1, 2].filter((rowIndex) => rowIndex !== deletedRow);
+          const script: EditScript = [
+            ...survivingRows.flatMap((rowIndex) =>
+              [0, 1, 2].map(
+                (columnIndex): EditScriptStep => ({
+                  type: "editTableCell",
+                  blockIndex: 1 + rowIndex * 3 + columnIndex,
+                  text: rewrittenText,
+                }),
+              ),
+            ),
+            { type: "deleteTableRow", blockIndex: 1 + deletedRow * 3 },
+          ];
+
+          const scripted = await applyEditScript(base, script);
+          if (scripted.isErr()) {
+            throw scripted.error;
+          }
+          expect(scripted.value.unresolved).toEqual([]);
+
+          const { changes } = await compareOrThrow(base, scripted.value.buffer);
+          expect(kindsOf(changes).toSorted()).toEqual([
+            "replace",
+            "replace",
+            "replace",
+            "replace",
+            "replace",
+            "replace",
+            "table-row-delete",
+          ]);
+          expect(changes).toHaveLength(scripted.value.applied.length);
+        }),
+        propertyConfig({ numRuns: 4 }),
+      );
+    },
+    propertyTestTimeout(120_000),
+  );
+
+  test.each([0, 1, 2, 3] as const)(
+    "inserting row at position %i keeps fully rewritten existing rows at cell level",
+    async (insertedRow) => {
+      const base = readFixture("upstream-with-tables.docx");
+      await fc.assert(
+        fc.asyncProperty(rowRewriteArb, async (rewrittenText) => {
+          const script: EditScript = [
+            ...Array.from({ length: 9 }, (_unused, blockOffset) => ({
+              type: "editTableCell" as const,
+              blockIndex: 1 + blockOffset,
+              text: rewrittenText,
+            })),
+            {
+              type: "insertTableRow",
+              blockIndex: insertedRow === 0 ? 1 : 1 + (insertedRow - 1) * 3,
+              position: insertedRow === 0 ? "before" : "after",
+              cellTexts: [rewrittenText, rewrittenText, rewrittenText],
+            },
+          ];
+
+          const scripted = await applyEditScript(base, script);
+          if (scripted.isErr()) {
+            throw scripted.error;
+          }
+          expect(scripted.value.unresolved).toEqual([]);
+
+          const { changes } = await compareOrThrow(base, scripted.value.buffer);
+          const kinds = kindsOf(changes);
+          expect(kinds.filter((kind) => kind === "replace")).toHaveLength(9);
+          expect(kinds.filter((kind) => kind !== "replace")).toEqual(["table-row-insert"]);
+          expect(changes).toHaveLength(scripted.value.applied.length);
+        }),
+        propertyConfig({ numRuns: 4 }),
+      );
+    },
+    propertyTestTimeout(120_000),
+  );
 
   for (const { name, buffer: base, blocks: baseBlocks } of BASE_CASES) {
     test(

--- a/packages/core/src/compare/compare.property.test.ts
+++ b/packages/core/src/compare/compare.property.test.ts
@@ -21,7 +21,12 @@ import { propertyConfig, propertyTestTimeout } from "../../../../test/property-t
 import { FolioDocxReviewer } from "../ai-edits/headless";
 import type { FolioAIBlock } from "../ai-edits/types";
 import { compareDocx } from "./compare";
-import { applyEditScript, type EditScript, type EditScriptStep } from "./scenario";
+import {
+  applyEditScript,
+  EDIT_SCRIPT_TABLE_ROW_POSITION,
+  type EditScript,
+  type EditScriptStep,
+} from "./scenario";
 import type { CompareChange, CompareResult } from "./types";
 import { revisedFinalParagraphMarks } from "./verification";
 
@@ -897,7 +902,10 @@ describe("compareDocx", () => {
             {
               type: "insertTableRow",
               blockIndex: insertedRow === 0 ? 1 : 1 + (insertedRow - 1) * 3,
-              position: insertedRow === 0 ? "before" : "after",
+              position:
+                insertedRow === 0
+                  ? EDIT_SCRIPT_TABLE_ROW_POSITION.before
+                  : EDIT_SCRIPT_TABLE_ROW_POSITION.after,
               cellTexts: [rewrittenText, rewrittenText, rewrittenText],
             },
           ];

--- a/packages/core/src/compare/content-alignment.test.ts
+++ b/packages/core/src/compare/content-alignment.test.ts
@@ -431,6 +431,168 @@ describe("container-safe structural alignment", () => {
 });
 
 describe("table row and column structural alignment", () => {
+  test("keeps several shifted persisted rows paired without textual anchors", () => {
+    const base = [
+      cell(
+        "removed-a",
+        "A1",
+        { rowIndex: 0, cellIndex: 0, gridColumnIndex: 0 },
+        { idStability: "positional" },
+      ),
+      cell(
+        "removed-b",
+        "B1",
+        { rowIndex: 0, cellIndex: 1, gridColumnIndex: 1 },
+        { idStability: "positional" },
+      ),
+      cell(
+        "first-a",
+        "A2",
+        { rowIndex: 1, cellIndex: 0, gridColumnIndex: 0 },
+        { idStability: "positional" },
+      ),
+      cell(
+        "first-b",
+        "B2",
+        { rowIndex: 1, cellIndex: 1, gridColumnIndex: 1 },
+        { idStability: "positional" },
+      ),
+      cell(
+        "second-a",
+        "A3",
+        { rowIndex: 2, cellIndex: 0, gridColumnIndex: 0 },
+        { idStability: "positional" },
+      ),
+      cell(
+        "second-b",
+        "B3",
+        { rowIndex: 2, cellIndex: 1, gridColumnIndex: 1 },
+        { idStability: "positional" },
+      ),
+    ];
+    const revised = [
+      cell("first-a", "Repeated rewritten value", {
+        rowIndex: 0,
+        cellIndex: 0,
+        gridColumnIndex: 0,
+      }),
+      cell("first-b", "Repeated rewritten value", {
+        rowIndex: 0,
+        cellIndex: 1,
+        gridColumnIndex: 1,
+      }),
+      cell("second-a", "Repeated rewritten value", {
+        rowIndex: 1,
+        cellIndex: 0,
+        gridColumnIndex: 0,
+      }),
+      cell("second-b", "Repeated rewritten value", {
+        rowIndex: 1,
+        cellIndex: 1,
+        gridColumnIndex: 1,
+      }),
+    ];
+
+    const steps = alignFolioContentStructure({
+      baseBlocks: base,
+      revisedBlocks: revised,
+      stableIdMismatch: "pair",
+    });
+
+    expect(
+      steps.flatMap((step) =>
+        step.type === "baseRow" || step.type === "revisedRow"
+          ? [[step.type, step.blocks.map(({ id }) => id)]]
+          : [],
+      ),
+    ).toEqual([["baseRow", ["removed-a", "removed-b"]]]);
+    expect(
+      steps.flatMap((step) =>
+        step.type === "pair" ? [[step.baseBlock.id, step.revisedBlock.id]] : [],
+      ),
+    ).toEqual([
+      ["first-a", "first-a"],
+      ["first-b", "first-b"],
+      ["second-a", "second-a"],
+      ["second-b", "second-b"],
+    ]);
+  });
+
+  test.each([
+    {
+      identity: "complete",
+      revisedSecondIds: ["second-base-only", "first-base-only"],
+    },
+    {
+      identity: "partial",
+      revisedSecondIds: ["second-revised-only", "first-revised-only"],
+    },
+  ] as const)("does not cross-pair reordered rows with $identity persisted identity", ({
+    revisedSecondIds,
+  }) => {
+    const base = [
+      cell(
+        "first-shared",
+        "Original first A",
+        { rowIndex: 0, cellIndex: 0, gridColumnIndex: 0 },
+        { idStability: "positional" },
+      ),
+      cell(
+        "first-base-only",
+        "Original first B",
+        { rowIndex: 0, cellIndex: 1, gridColumnIndex: 1 },
+        { idStability: "positional" },
+      ),
+      cell(
+        "second-shared",
+        "Original second A",
+        { rowIndex: 1, cellIndex: 0, gridColumnIndex: 0 },
+        { idStability: "positional" },
+      ),
+      cell(
+        "second-base-only",
+        "Original second B",
+        { rowIndex: 1, cellIndex: 1, gridColumnIndex: 1 },
+        { idStability: "positional" },
+      ),
+    ];
+    const revised = [
+      cell("second-shared", "Unrelated replacement A", {
+        rowIndex: 0,
+        cellIndex: 0,
+        gridColumnIndex: 0,
+      }),
+      cell(revisedSecondIds[0], "Unrelated replacement B", {
+        rowIndex: 0,
+        cellIndex: 1,
+        gridColumnIndex: 1,
+      }),
+      cell("first-shared", "Different replacement A", {
+        rowIndex: 1,
+        cellIndex: 0,
+        gridColumnIndex: 0,
+      }),
+      cell(revisedSecondIds[1], "Different replacement B", {
+        rowIndex: 1,
+        cellIndex: 1,
+        gridColumnIndex: 1,
+      }),
+    ];
+
+    const steps = alignFolioContentStructure({
+      baseBlocks: base,
+      revisedBlocks: revised,
+      stableIdMismatch: "pair",
+    });
+
+    expect(steps.filter(({ type }) => type === "pair")).toEqual([]);
+    expect(
+      steps.flatMap((step) =>
+        step.type === "baseRow" || step.type === "revisedRow" ? [step.type] : [],
+      ).toSorted(),
+    ).toEqual(["baseRow", "baseRow", "revisedRow", "revisedRow"]);
+  });
+
   test("keeps an edited persisted row paired after an inserted row", () => {
     const base = [
       cell(

--- a/packages/core/src/compare/content-alignment.test.ts
+++ b/packages/core/src/compare/content-alignment.test.ts
@@ -527,71 +527,74 @@ describe("table row and column structural alignment", () => {
       identity: "partial",
       revisedSecondIds: ["second-revised-only", "first-revised-only"],
     },
-  ] as const)("does not cross-pair reordered rows with $identity persisted identity", ({
-    revisedSecondIds,
-  }) => {
-    const base = [
-      cell(
-        "first-shared",
-        "Original first A",
-        { rowIndex: 0, cellIndex: 0, gridColumnIndex: 0 },
-        { idStability: "positional" },
-      ),
-      cell(
-        "first-base-only",
-        "Original first B",
-        { rowIndex: 0, cellIndex: 1, gridColumnIndex: 1 },
-        { idStability: "positional" },
-      ),
-      cell(
-        "second-shared",
-        "Original second A",
-        { rowIndex: 1, cellIndex: 0, gridColumnIndex: 0 },
-        { idStability: "positional" },
-      ),
-      cell(
-        "second-base-only",
-        "Original second B",
-        { rowIndex: 1, cellIndex: 1, gridColumnIndex: 1 },
-        { idStability: "positional" },
-      ),
-    ];
-    const revised = [
-      cell("second-shared", "Unrelated replacement A", {
-        rowIndex: 0,
-        cellIndex: 0,
-        gridColumnIndex: 0,
-      }),
-      cell(revisedSecondIds[0], "Unrelated replacement B", {
-        rowIndex: 0,
-        cellIndex: 1,
-        gridColumnIndex: 1,
-      }),
-      cell("first-shared", "Different replacement A", {
-        rowIndex: 1,
-        cellIndex: 0,
-        gridColumnIndex: 0,
-      }),
-      cell(revisedSecondIds[1], "Different replacement B", {
-        rowIndex: 1,
-        cellIndex: 1,
-        gridColumnIndex: 1,
-      }),
-    ];
+  ] as const)(
+    "does not cross-pair reordered rows with $identity persisted identity",
+    ({ revisedSecondIds }) => {
+      const base = [
+        cell(
+          "first-shared",
+          "Original first A",
+          { rowIndex: 0, cellIndex: 0, gridColumnIndex: 0 },
+          { idStability: "positional" },
+        ),
+        cell(
+          "first-base-only",
+          "Original first B",
+          { rowIndex: 0, cellIndex: 1, gridColumnIndex: 1 },
+          { idStability: "positional" },
+        ),
+        cell(
+          "second-shared",
+          "Original second A",
+          { rowIndex: 1, cellIndex: 0, gridColumnIndex: 0 },
+          { idStability: "positional" },
+        ),
+        cell(
+          "second-base-only",
+          "Original second B",
+          { rowIndex: 1, cellIndex: 1, gridColumnIndex: 1 },
+          { idStability: "positional" },
+        ),
+      ];
+      const revised = [
+        cell("second-shared", "Unrelated replacement A", {
+          rowIndex: 0,
+          cellIndex: 0,
+          gridColumnIndex: 0,
+        }),
+        cell(revisedSecondIds[0], "Unrelated replacement B", {
+          rowIndex: 0,
+          cellIndex: 1,
+          gridColumnIndex: 1,
+        }),
+        cell("first-shared", "Different replacement A", {
+          rowIndex: 1,
+          cellIndex: 0,
+          gridColumnIndex: 0,
+        }),
+        cell(revisedSecondIds[1], "Different replacement B", {
+          rowIndex: 1,
+          cellIndex: 1,
+          gridColumnIndex: 1,
+        }),
+      ];
 
-    const steps = alignFolioContentStructure({
-      baseBlocks: base,
-      revisedBlocks: revised,
-      stableIdMismatch: "pair",
-    });
+      const steps = alignFolioContentStructure({
+        baseBlocks: base,
+        revisedBlocks: revised,
+        stableIdMismatch: "pair",
+      });
 
-    expect(steps.filter(({ type }) => type === "pair")).toEqual([]);
-    expect(
-      steps.flatMap((step) =>
-        step.type === "baseRow" || step.type === "revisedRow" ? [step.type] : [],
-      ).toSorted(),
-    ).toEqual(["baseRow", "baseRow", "revisedRow", "revisedRow"]);
-  });
+      expect(steps.filter(({ type }) => type === "pair")).toEqual([]);
+      expect(
+        steps
+          .flatMap((step) =>
+            step.type === "baseRow" || step.type === "revisedRow" ? [step.type] : [],
+          )
+          .toSorted(),
+      ).toEqual(["baseRow", "baseRow", "revisedRow", "revisedRow"]);
+    },
+  );
 
   test("keeps an edited persisted row paired after an inserted row", () => {
     const base = [

--- a/packages/core/src/compare/content-alignment.ts
+++ b/packages/core/src/compare/content-alignment.ts
@@ -1050,9 +1050,9 @@ const persistedContentSequencePairs = <Item>({
   anchors,
   canPair,
 }: PersistedContentSequencePairsOptions<Item>): ReadonlySet<number> => {
-  if (anchors.length === 0) {
-    return new Set();
-  }
+  // A complete positional-to-stable identity transition is evidence in its own right.
+  // Text and stable-id anchors constrain it when present; requiring an anchor first
+  // loses every surviving row when each one also contains an edit.
   const uniqueIndexesByFirstId = (
     items: readonly ProfiledContentSequenceItem<Item>[],
   ): ReadonlyMap<string, number | null> => {

--- a/packages/core/src/compare/scenario.ts
+++ b/packages/core/src/compare/scenario.ts
@@ -54,7 +54,12 @@ export type EditScriptStep =
       endOffset: number;
       formatting: FolioAIInlineFormattingPatch;
     }
-  | { type: "insertTableRow"; blockIndex: number; cellTexts: readonly string[] }
+  | {
+      type: "insertTableRow";
+      blockIndex: number;
+      position?: "after" | "before";
+      cellTexts: readonly string[];
+    }
   | { type: "deleteTableRow"; blockIndex: number }
   | { type: "editTableCell"; blockIndex: number; text: string };
 
@@ -225,7 +230,7 @@ const planStep = ({ step, blocks, nextOperationId }: PlanStepOptions): StepPlan 
                 id: nextOperationId(),
                 type: "insertTableRow",
                 blockId: block.id,
-                position: "after",
+                position: step.position ?? "after",
                 cellTexts: [...step.cellTexts],
               },
             ],

--- a/packages/core/src/compare/scenario.ts
+++ b/packages/core/src/compare/scenario.ts
@@ -31,6 +31,14 @@ import type {
 } from "../ai-edits/types";
 import { CompareDocxParseError, CompareDocxSerializeError } from "./types";
 
+type InsertTableRowOperation = Extract<FolioAIEditOperation, { type: "insertTableRow" }>;
+type TableRowPosition = NonNullable<InsertTableRowOperation["position"]>;
+
+export const EDIT_SCRIPT_TABLE_ROW_POSITION = {
+  after: "after",
+  before: "before",
+} as const satisfies Record<TableRowPosition, TableRowPosition>;
+
 export type EditScriptStep =
   | { type: "insertParagraphAfter"; blockIndex: number; text: string }
   | { type: "deleteParagraph"; blockIndex: number }
@@ -57,7 +65,7 @@ export type EditScriptStep =
   | {
       type: "insertTableRow";
       blockIndex: number;
-      position?: "after" | "before";
+      position?: TableRowPosition;
       cellTexts: readonly string[];
     }
   | { type: "deleteTableRow"; blockIndex: number }
@@ -230,7 +238,7 @@ const planStep = ({ step, blocks, nextOperationId }: PlanStepOptions): StepPlan 
                 id: nextOperationId(),
                 type: "insertTableRow",
                 blockId: block.id,
-                position: step.position ?? "after",
+                position: step.position ?? EDIT_SCRIPT_TABLE_ROW_POSITION.after,
                 cellTexts: [...step.cellTexts],
               },
             ],


### PR DESCRIPTION
## Summary

- retain complete table-row identity when every surviving cell is edited
- keep alignment constrained by identity completeness, monotonicity, trusted anchors, and existing complexity caps
- cover every row insertion and deletion position with repeated, fully rewritten cell content

## Verification

- focused alignment and generated comparison properties pass
- restoring the previous anchor prerequisite fails the new deletion and shifted-insertion properties
- comparison coverage and serialized output remain unchanged outside the new counterexample
- deterministic output and performance gates remain stable

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Edited table rows now remain correctly matched when rows are inserted, deleted or shifted.
  * Rewritten cell content is reported against the correct rows, preventing misleading changes or unresolved edits.
  * Row identity is preserved more reliably during transitions between positional and stable identifiers.

* **New Features**
  * New table rows can be inserted either before or after the relevant row block, with insertion after remaining the default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->