### PR TITLE
fix(core): preserve paragraph sources across collaboration

### DIFF
--- a/.changeset/quiet-paragraphs-bind.md
+++ b/.changeset/quiet-paragraphs-bind.md
@@ -2,4 +2,4 @@
 "@stll/folio-core": patch
 ---
 
-Preserve opaque paragraph properties through collaborative DOCX edits with missing or duplicate paragraph IDs.
+Preserve opaque paragraph properties through collaborative DOCX edits with missing or duplicate paragraph IDs, including collapsed vertical-merge continuation cells.

--- a/.changeset/quiet-paragraphs-bind.md
+++ b/.changeset/quiet-paragraphs-bind.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve opaque paragraph properties through collaborative DOCX edits with missing or duplicate paragraph IDs.

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -519,7 +519,7 @@ export type TableCellAttrs = {
         verticalMergeOriginal?: "continue" | "rest";
     };
     _preserveVMergeRestart?: boolean;
-    _docxVMergeContinuationCells?: import__stll_docx_core_model.TableCell[];
+    _docxVMergeContinuationCells?: unknown;
 };
 
 // @public

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -210,7 +210,6 @@ export type PageBreakRunOwnerMarkAttrs = {
 export type ParagraphAttrs = {
     paraId?: string;
     textId?: string;
-    _docxParagraphSourceToken?: string;
     alignment?: import__stll_docx_core_model.ParagraphAlignment;
     alignmentFromStyle?: import__stll_docx_core_model.ParagraphAlignment;
     kinsoku?: boolean;

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -210,6 +210,7 @@ export type PageBreakRunOwnerMarkAttrs = {
 export type ParagraphAttrs = {
     paraId?: string;
     textId?: string;
+    _docxParagraphSourceToken?: string;
     alignment?: import__stll_docx_core_model.ParagraphAlignment;
     alignmentFromStyle?: import__stll_docx_core_model.ParagraphAlignment;
     kinsoku?: boolean;

--- a/api-reports/core/prosemirror.api.md
+++ b/api-reports/core/prosemirror.api.md
@@ -291,7 +291,6 @@ export const PAINTABLE_MARK_NAMES: ReadonlySet<string>;
 export type ParagraphAttrs = {
     paraId?: string;
     textId?: string;
-    _docxParagraphSourceToken?: string;
     alignment?: import__stll_docx_core_model.ParagraphAlignment;
     alignmentFromStyle?: import__stll_docx_core_model.ParagraphAlignment;
     kinsoku?: boolean;

--- a/api-reports/core/prosemirror.api.md
+++ b/api-reports/core/prosemirror.api.md
@@ -291,6 +291,7 @@ export const PAINTABLE_MARK_NAMES: ReadonlySet<string>;
 export type ParagraphAttrs = {
     paraId?: string;
     textId?: string;
+    _docxParagraphSourceToken?: string;
     alignment?: import__stll_docx_core_model.ParagraphAlignment;
     alignmentFromStyle?: import__stll_docx_core_model.ParagraphAlignment;
     kinsoku?: boolean;

--- a/api-reports/core/server.api.md
+++ b/api-reports/core/server.api.md
@@ -472,7 +472,7 @@ export const FOLIO_VERSION_COMPARISON_PRIVACY_TRANSFORMS: readonly ["remove-attr
 export const FOLIO_VERSION_COMPARISON_SCOPES: readonly ["text", "formatting", "metadata"];
 
 // @public
-export const FOLIO_YJS_DOCX_MATERIALIZATION_ERROR_CODES: readonly ["empty_update", "invalid_update", "missing_document", "update_too_large"];
+export const FOLIO_YJS_DOCX_MATERIALIZATION_ERROR_CODES: readonly ["empty_update", "invalid_update", "missing_document", "source_mismatch", "update_too_large"];
 
 // @public
 export const FOLIO_YJS_PROSEMIRROR_FRAGMENT_NAME = "prosemirror";

--- a/packages/core/src/ai-edits/aiEdits.test.ts
+++ b/packages/core/src/ai-edits/aiEdits.test.ts
@@ -4750,6 +4750,7 @@ describe("Folio AI edit operations", () => {
         },
         content: [
           {
+            _docxParagraphSourceBinding: { type: "authored" as const },
             type: "paragraph" as const,
             content: [
               {
@@ -4768,6 +4769,7 @@ describe("Folio AI edit operations", () => {
         },
         content: [
           {
+            _docxParagraphSourceBinding: { type: "authored" as const },
             type: "paragraph" as const,
             content: [
               {
@@ -4884,6 +4886,7 @@ describe("Folio AI edit operations", () => {
         },
         content: [
           {
+            _docxParagraphSourceBinding: { type: "authored" as const },
             type: "paragraph" as const,
             content: [{ type: "run" as const, content: [{ type: "text" as const, text: "Wide" }] }],
           },

--- a/packages/core/src/ai-edits/table-cell-mutations.ts
+++ b/packages/core/src/ai-edits/table-cell-mutations.ts
@@ -4,6 +4,7 @@ import type { Transaction } from "prosemirror-state";
 import { TableMap } from "prosemirror-tables";
 
 import {
+  decodeTableCellParagraphSourcePayload,
   restoreTableCellsWithParagraphPropertySources,
   transportTableCellsWithParagraphPropertySources,
 } from "../docx/paragraphPropertySource";
@@ -215,7 +216,8 @@ export const mergeTrackedVerticalTableCells = ({
       attrs.colspan !== 1 ||
       attrs.rowspan !== 1 ||
       attrs.cellMarker !== undefined ||
-      attrs._docxVMergeContinuationCells !== undefined ||
+      (attrs._docxVMergeContinuationCells !== undefined &&
+        attrs._docxVMergeContinuationCells !== null) ||
       attrs._preserveVMergeRestart === true ||
       attrs._originalFormatting?.vMerge !== undefined
     ) {
@@ -394,13 +396,20 @@ export const splitTrackedVerticalTableCell = ({
   ) {
     return null;
   }
-  const continuationCells = attrs._docxVMergeContinuationCells;
+  const continuationPayload =
+    attrs._docxVMergeContinuationCells === undefined || attrs._docxVMergeContinuationCells === null
+      ? null
+      : decodeTableCellParagraphSourcePayload(attrs._docxVMergeContinuationCells);
+  const continuationCells = continuationPayload?.cells;
   if (
     continuationCells !== undefined &&
     continuationCells.length !== rectangle.bottom - rectangle.top - 1
   ) {
     return null;
   }
+  const restoredContinuationCells = continuationPayload
+    ? restoreTableCellsWithParagraphPropertySources(continuationPayload)
+    : undefined;
 
   const marker = {
     kind: "merge" as const,
@@ -413,8 +422,12 @@ export const splitTrackedVerticalTableCell = ({
     if (source?.structuralChange !== undefined) {
       return null;
     }
-    const insertedCell = source
-      ? trackedSplitCellFromStoredSource({ origin: cell, source, marker })
+    const restoredSource = restoredContinuationCells?.[index];
+    if (source && !restoredSource) {
+      return null;
+    }
+    const insertedCell = restoredSource
+      ? trackedSplitCellFromStoredSource({ origin: cell, source: restoredSource, marker })
       : cell.type.createAndFill({
           ...cell.attrs,
           rowspan: 1,
@@ -480,24 +493,15 @@ const trackedSplitCellFromStoredSource = ({
   // prior (possibly attacker-supplied) parse; trusting its `gridSpan`
   // wholesale would let a crafted document restore a cell spanning many
   // columns here. Reject rather than silently widening the cell.
-  const restoredSourceCell = restoreTableCellsWithParagraphPropertySources([source]).at(0);
-  if (!restoredSourceCell) {
+  if (source.formatting?.gridSpan !== undefined && source.formatting.gridSpan > 1) {
     return null;
   }
-  if (
-    restoredSourceCell.formatting?.gridSpan !== undefined &&
-    restoredSourceCell.formatting.gridSpan > 1
-  ) {
-    return null;
-  }
-  const formatting = formattingWithoutVerticalMerge(restoredSourceCell.formatting);
+  const formatting = formattingWithoutVerticalMerge(source.formatting);
   const restoredSource: TableCell = {
     type: "tableCell",
     ...(formatting ? { formatting } : {}),
-    ...(restoredSourceCell.propertyChanges
-      ? { propertyChanges: restoredSourceCell.propertyChanges }
-      : {}),
-    content: restoredSourceCell.content,
+    ...(source.propertyChanges ? { propertyChanges: source.propertyChanges } : {}),
+    content: source.content,
   };
   const converted = standaloneTableCellToProseMirror(
     restoredSource,

--- a/packages/core/src/ai-edits/table-cell-mutations.ts
+++ b/packages/core/src/ai-edits/table-cell-mutations.ts
@@ -3,6 +3,10 @@ import { Fragment, type Node as PMNode } from "prosemirror-model";
 import type { Transaction } from "prosemirror-state";
 import { TableMap } from "prosemirror-tables";
 
+import {
+  restoreTableCellsWithParagraphPropertySources,
+  transportTableCellsWithParagraphPropertySources,
+} from "../docx/paragraphPropertySource";
 import { expectTableCellAttrs } from "../prosemirror/attrs";
 import { standaloneTableCellFromProseMirror } from "../prosemirror/conversion/fromProseDoc";
 import { standaloneTableCellToProseMirror } from "../prosemirror/conversion/toProseDoc";
@@ -253,7 +257,7 @@ export const mergeTrackedVerticalTableCells = ({
   nextTr.setNodeAttribute(
     tablePosition + 1 + origin.position,
     "_docxVMergeContinuationCells",
-    continuationCells,
+    transportTableCellsWithParagraphPropertySources(continuationCells),
   );
   markStructuralChange(nextTr);
   return nextTr;
@@ -476,15 +480,24 @@ const trackedSplitCellFromStoredSource = ({
   // prior (possibly attacker-supplied) parse; trusting its `gridSpan`
   // wholesale would let a crafted document restore a cell spanning many
   // columns here. Reject rather than silently widening the cell.
-  if (source.formatting?.gridSpan !== undefined && source.formatting.gridSpan > 1) {
+  const restoredSourceCell = restoreTableCellsWithParagraphPropertySources([source]).at(0);
+  if (!restoredSourceCell) {
     return null;
   }
-  const formatting = formattingWithoutVerticalMerge(source.formatting);
+  if (
+    restoredSourceCell.formatting?.gridSpan !== undefined &&
+    restoredSourceCell.formatting.gridSpan > 1
+  ) {
+    return null;
+  }
+  const formatting = formattingWithoutVerticalMerge(restoredSourceCell.formatting);
   const restoredSource: TableCell = {
     type: "tableCell",
     ...(formatting ? { formatting } : {}),
-    ...(source.propertyChanges ? { propertyChanges: source.propertyChanges } : {}),
-    content: source.content,
+    ...(restoredSourceCell.propertyChanges
+      ? { propertyChanges: restoredSourceCell.propertyChanges }
+      : {}),
+    content: restoredSourceCell.content,
   };
   const converted = standaloneTableCellToProseMirror(
     restoredSource,

--- a/packages/core/src/ai-edits/table-template.test.ts
+++ b/packages/core/src/ai-edits/table-template.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import { Schema } from "prosemirror-model";
+
+import {
+  decodeTableCellParagraphSourcePayload,
+  transportTableCellsWithParagraphPropertySources,
+} from "../docx/paragraphPropertySource";
+import { tableFromTemplate, tableRowFromTemplate } from "./table-template";
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: "block+" },
+    paragraph: { content: "text*", group: "block" },
+    text: {},
+    table: {
+      content: "tableRow+",
+      group: "block",
+      tableRole: "table",
+    },
+    tableRow: {
+      content: "tableCell*",
+      tableRole: "row",
+    },
+    tableCell: {
+      content: "block+",
+      tableRole: "cell",
+      attrs: {
+        colspan: { default: 1 },
+        rowspan: { default: 1 },
+        _preserveVMergeRestart: { default: null },
+        _docxVMergeContinuationCells: { default: null },
+      },
+    },
+  },
+});
+
+const continuationCells = () =>
+  transportTableCellsWithParagraphPropertySources([
+    { type: "tableCell", content: [{ type: "paragraph", content: [] }] },
+  ]);
+
+const mergedCell = () =>
+  schema.node(
+    "tableCell",
+    {
+      rowspan: 2,
+      _docxVMergeContinuationCells: continuationCells(),
+    },
+    [schema.node("paragraph")],
+  );
+
+describe("table templates", () => {
+  test("a row copy clears the continuation payload when it clamps the rowspan", () => {
+    const copied = tableRowFromTemplate({
+      template: schema.node("tableRow", null, [mergedCell()]),
+      columnCount: 1,
+    });
+
+    expect(copied?.child(0).attrs["rowspan"]).toBe(1);
+    expect(copied?.child(0).attrs["_docxVMergeContinuationCells"]).toBeNull();
+  });
+
+  test("a whole-table copy preserves the rowspan and its continuation payload", () => {
+    const copied = tableFromTemplate({
+      schema,
+      template: schema.node("table", null, [
+        schema.node("tableRow", null, [mergedCell()]),
+        schema.node("tableRow"),
+      ]),
+    });
+    const copiedCell = copied?.child(0).child(0);
+    const payload = copiedCell?.attrs["_docxVMergeContinuationCells"];
+
+    expect(copiedCell?.attrs["rowspan"]).toBe(2);
+    expect(payload).not.toBeNull();
+    expect(decodeTableCellParagraphSourcePayload(payload).cells).toHaveLength(1);
+  });
+});

--- a/packages/core/src/ai-edits/table-template.ts
+++ b/packages/core/src/ai-edits/table-template.ts
@@ -24,6 +24,7 @@ import { Fragment, type Mark, type Node as PMNode, type Schema } from "prosemirr
 
 import {
   cloneTableCellsWithParagraphPropertyCaptures,
+  decodeTableCellParagraphSourcePayload,
   recreateProseNodeWithDetachedParagraphPropertySource,
 } from "../docx/paragraphPropertySource";
 import { expectTableCellAttrs } from "../prosemirror/attrs";
@@ -210,13 +211,15 @@ const copiedAttrs = (node: PMNode, context: TemplateContext): Record<string, unk
     case "cell":
     case "header_cell": {
       const continuationCells = expectTableCellAttrs(node)._docxVMergeContinuationCells;
-      const portableAttrs = continuationCells
-        ? {
-            ...attrs,
-            _docxVMergeContinuationCells:
-              cloneTableCellsWithParagraphPropertyCaptures(continuationCells),
-          }
-        : attrs;
+      const portableAttrs =
+        continuationCells !== undefined && continuationCells !== null
+          ? {
+              ...attrs,
+              _docxVMergeContinuationCells: cloneTableCellsWithParagraphPropertyCaptures(
+                decodeTableCellParagraphSourcePayload(continuationCells),
+              ),
+            }
+          : attrs;
       return context.clampRowSpan ? { ...portableAttrs, rowspan: 1 } : portableAttrs;
     }
     default:

--- a/packages/core/src/ai-edits/table-template.ts
+++ b/packages/core/src/ai-edits/table-template.ts
@@ -22,6 +22,11 @@
 
 import { Fragment, type Mark, type Node as PMNode, type Schema } from "prosemirror-model";
 
+import {
+  cloneTableCellsWithParagraphPropertyCaptures,
+  recreateProseNodeWithDetachedParagraphPropertySource,
+} from "../docx/paragraphPropertySource";
+import { expectTableCellAttrs } from "../prosemirror/attrs";
 import type { TrackedChangeProvenance } from "../prosemirror/schema/marks";
 import { stripBlockIdentityAttrs } from "./block-identity";
 
@@ -203,8 +208,17 @@ const copiedAttrs = (node: PMNode, context: TemplateContext): Record<string, unk
     case "row":
       return context.revision ? { ...attrs, trIns: context.revision } : attrs;
     case "cell":
-    case "header_cell":
-      return context.clampRowSpan ? { ...attrs, rowspan: 1 } : attrs;
+    case "header_cell": {
+      const continuationCells = expectTableCellAttrs(node)._docxVMergeContinuationCells;
+      const portableAttrs = continuationCells
+        ? {
+            ...attrs,
+            _docxVMergeContinuationCells:
+              cloneTableCellsWithParagraphPropertyCaptures(continuationCells),
+          }
+        : attrs;
+      return context.clampRowSpan ? { ...portableAttrs, rowspan: 1 } : portableAttrs;
+    }
     default:
       return attrs;
   }
@@ -237,7 +251,11 @@ const copyNode = (node: PMNode, context: TemplateContext): PMNode | null => {
       content.push(copied);
     }
   });
-  return node.type.create(copiedAttrs(node, context), Fragment.fromArray(content), marks);
+  return recreateProseNodeWithDetachedParagraphPropertySource(node, {
+    attrs: copiedAttrs(node, context),
+    content: Fragment.fromArray(content),
+    marks,
+  });
 };
 
 type TableFromTemplateOptions = {

--- a/packages/core/src/ai-edits/table-template.ts
+++ b/packages/core/src/ai-edits/table-template.ts
@@ -210,17 +210,22 @@ const copiedAttrs = (node: PMNode, context: TemplateContext): Record<string, unk
       return context.revision ? { ...attrs, trIns: context.revision } : attrs;
     case "cell":
     case "header_cell": {
+      if (context.clampRowSpan) {
+        return {
+          ...attrs,
+          rowspan: 1,
+          _docxVMergeContinuationCells: null,
+        };
+      }
       const continuationCells = expectTableCellAttrs(node)._docxVMergeContinuationCells;
-      const portableAttrs =
-        continuationCells !== undefined && continuationCells !== null
-          ? {
-              ...attrs,
-              _docxVMergeContinuationCells: cloneTableCellsWithParagraphPropertyCaptures(
-                decodeTableCellParagraphSourcePayload(continuationCells),
-              ),
-            }
-          : attrs;
-      return context.clampRowSpan ? { ...portableAttrs, rowspan: 1 } : portableAttrs;
+      return continuationCells !== undefined && continuationCells !== null
+        ? {
+            ...attrs,
+            _docxVMergeContinuationCells: cloneTableCellsWithParagraphPropertyCaptures(
+              decodeTableCellParagraphSourcePayload(continuationCells),
+            ),
+          }
+        : attrs;
     }
     default:
       return attrs;

--- a/packages/core/src/compare/paragraphAlignment.test.ts
+++ b/packages/core/src/compare/paragraphAlignment.test.ts
@@ -6,6 +6,10 @@ import { EditorState, type Transaction } from "prosemirror-state";
 import { applyFolioAIEditOperations } from "../ai-edits/apply";
 import { FolioDocxReviewer } from "../ai-edits/headless";
 import { createFolioAIEditSnapshot } from "../ai-edits/snapshot";
+import {
+  PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR,
+  PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR,
+} from "../docx/paragraphPropertySource";
 import { createDocx } from "../docx/rezip";
 import { expectParagraphAttrs } from "../prosemirror/attrs";
 import {
@@ -36,6 +40,18 @@ const REPLACEMENT_TEXT = "The replacement paragraph keeps its intended style and
 const ORDINARY_PARAGRAPH_STATE_SIZE_BUDGET = 1_823_095;
 const STYLED_PARAGRAPH_STATE_SIZE_BUDGET = 1_610_095;
 const STYLED_ALIGNMENT_PROVENANCE_SIZE_BUDGET = 29_000;
+
+const serializeWithoutParagraphSource = (json: unknown, omitAlignment = false): string =>
+  JSON.stringify(json, (key, value) => {
+    if (
+      key === PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR ||
+      key === PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR ||
+      (omitAlignment && key === "alignmentFromStyle")
+    ) {
+      return undefined;
+    }
+    return value;
+  });
 
 const SUGGESTION_REJECTION_ORDERS = [
   { label: "oldest to newest", ids: ["suggestion-left", "suggestion-right", "suggestion-both"] },
@@ -3018,10 +3034,8 @@ describe("paragraph alignment provenance in editor state", () => {
       content: [{ type: "run" as const, content: [{ type: "text" as const, text: TEXT }] }],
     }));
     const json = toProseDoc(source).toJSON();
-    const serialized = JSON.stringify(json);
-    const withoutAlignmentProvenance = JSON.stringify(json, (key, value) =>
-      key === "alignmentFromStyle" ? undefined : value,
-    );
+    const serialized = serializeWithoutParagraphSource(json);
+    const withoutAlignmentProvenance = serializeWithoutParagraphSource(json, true);
 
     expect(json.content).toHaveLength(1_000);
     expect(serialized.length).toBeLessThanOrEqual(ORDINARY_PARAGRAPH_STATE_SIZE_BUDGET);
@@ -3039,10 +3053,8 @@ describe("paragraph alignment provenance in editor state", () => {
       paraId: index.toString(16).padStart(8, "0"),
     }));
     const json = toProseDoc(source).toJSON();
-    const serialized = JSON.stringify(json);
-    const withoutAlignmentProvenance = JSON.stringify(json, (key, value) =>
-      key === "alignmentFromStyle" ? undefined : value,
-    );
+    const serialized = serializeWithoutParagraphSource(json);
+    const withoutAlignmentProvenance = serializeWithoutParagraphSource(json, true);
 
     expect(json.content).toHaveLength(1_000);
     expect(serialized.length).toBeLessThanOrEqual(STYLED_PARAGRAPH_STATE_SIZE_BUDGET);

--- a/packages/core/src/controller/hiddenEditorManager.ts
+++ b/packages/core/src/controller/hiddenEditorManager.ts
@@ -36,6 +36,12 @@ import {
 import { createDocumentStylesPlugin } from "../prosemirror/plugins/documentStyles";
 import { createDocumentNumberingPlugin } from "../prosemirror/plugins/documentNumbering";
 import { schema } from "../prosemirror/schema";
+import {
+  proseDocumentParagraphSourceContract,
+  readYjsParagraphSourceContract,
+  withParagraphSourceContract,
+  writeYjsParagraphSourceContract,
+} from "../prosemirror/yjsParagraphSourceContract";
 import type { Document, StyleDefinitions } from "../types/document";
 import type { RemoteSelection } from "../types/remote-selection";
 import { createHiddenEditorApi, type HiddenEditorApi } from "./hiddenEditorApi";
@@ -286,6 +292,13 @@ export function createHiddenEditorState(options: CreateHiddenEditorStateOptions)
         seedState.doc,
         collaboration.yXmlFragment,
       );
+      const collaborationDocument = collaboration.yXmlFragment.doc;
+      if (!collaborationDocument) {
+        panic("A collaboration fragment must belong to a Yjs document before seeding.");
+      }
+      if (proseDocumentParagraphSourceContract(seedState.doc)) {
+        writeYjsParagraphSourceContract(collaborationDocument, seedState.doc);
+      }
       collaboration.onSeeded?.();
     }
 
@@ -293,6 +306,18 @@ export function createHiddenEditorState(options: CreateHiddenEditorStateOptions)
       collaboration.yXmlFragment,
       activeSchema,
     );
+    const collaborationDocument = collaboration.yXmlFragment.doc;
+    if (!collaborationDocument) {
+      panic("A collaboration fragment must belong to a Yjs document before loading.");
+    }
+    const collaborationContract = readYjsParagraphSourceContract(collaborationDocument);
+    const localContract = proseDocumentParagraphSourceContract(localDoc);
+    if (localContract && collaborationContract !== localContract) {
+      panic("The collaboration state belongs to a different paragraph-property source.");
+    }
+    if (collaborationContract) {
+      doc = withParagraphSourceContract(doc, collaborationContract);
+    }
 
     const initializedState = normalizeSeedState(
       PMEditorState.create({
@@ -310,6 +335,9 @@ export function createHiddenEditorState(options: CreateHiddenEditorStateOptions)
         collaboration.yXmlFragment,
         activeSchema,
       ));
+      if (collaborationContract) {
+        doc = withParagraphSourceContract(doc, collaborationContract);
+      }
     }
 
     const startedAt = performance.now();

--- a/packages/core/src/docx/paragraphPropertyRoundTrip.test.ts
+++ b/packages/core/src/docx/paragraphPropertyRoundTrip.test.ts
@@ -14,6 +14,8 @@ import { withoutOrphanCommentRanges } from "./commentRangeIntegrity";
 import { parseDocx } from "./parser";
 import { DATE_UTC_NAMESPACE_URI } from "./trackedChangeInfo";
 import {
+  PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR,
+  TABLE_CELL_PARAGRAPH_SOURCE_BINDING_ATTR,
   ParagraphPropertySourceValidationError,
   assignParagraphPropertySource,
   copyParagraphPropertyCapture,
@@ -334,7 +336,9 @@ describe("paragraph properties survive a no-edit full repack", () => {
     expect(getParagraphPropertySource(paragraph)).toEqual(
       getParagraphPropertySource(sourceParagraph),
     );
+    expect(paragraph).not.toBe(sourceParagraph);
     expect(getParagraphPropertySourceToken(paragraph)).toBeUndefined();
+    expect(Reflect.get(paragraph, PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR)).toBeUndefined();
   });
 
   test("a foreign table paragraph stays unbound across repeated saves into a source-bound document", async () => {
@@ -404,7 +408,12 @@ describe("paragraph properties survive a no-edit full repack", () => {
     expect(getParagraphPropertySource(paragraph)).toEqual(
       getParagraphPropertySource(sourceParagraph),
     );
+    expect(continuation).not.toBe(hiddenCell);
+    expect(paragraph).not.toBe(sourceParagraph);
     expect(getParagraphPropertySourceToken(paragraph)).toBeUndefined();
+    expect(Reflect.get(paragraph, TABLE_CELL_PARAGRAPH_SOURCE_BINDING_ATTR)).toEqual({
+      type: "authored",
+    });
   });
 
   test("durable source tokens survive regenerated duplicate paragraph ids", async () => {
@@ -482,7 +491,7 @@ describe("paragraph properties survive a no-edit full repack", () => {
     }
   });
 
-  test("a deleted source paragraph can return after an intervening save", async () => {
+  test("a deleted source paragraph can return from serialized state after an intervening save", async () => {
     const parsed = await parseDocx(await documentWithDuplicateParagraphIds(), {
       preloadFonts: false,
     });
@@ -490,7 +499,10 @@ describe("paragraph properties survive a no-edit full repack", () => {
     const withoutFirst = original.type.create(original.attrs, [original.child(1)]);
 
     const afterDeletion = fromProseDoc(withoutFirst, parsed);
-    const restored = fromProseDoc(original, afterDeletion);
+    const reconstructedOriginal = original.type.schema.nodeFromJSON(
+      JSON.parse(JSON.stringify(original.toJSON())),
+    );
+    const restored = fromProseDoc(reconstructedOriginal, afterDeletion);
     const paragraphs = restored.package.document.content.filter(
       (block): block is Paragraph => block.type === "paragraph",
     );

--- a/packages/core/src/docx/paragraphPropertyRoundTrip.test.ts
+++ b/packages/core/src/docx/paragraphPropertyRoundTrip.test.ts
@@ -16,6 +16,7 @@ import { DATE_UTC_NAMESPACE_URI } from "./trackedChangeInfo";
 import {
   ParagraphPropertySourceValidationError,
   assignParagraphPropertySource,
+  copyParagraphPropertyCapture,
   getParagraphPropertySourceCandidate,
   getParagraphPropertySource,
   getParagraphPropertySourceToken,
@@ -336,6 +337,45 @@ describe("paragraph properties survive a no-edit full repack", () => {
     expect(getParagraphPropertySourceToken(paragraph)).toBeUndefined();
   });
 
+  test("a foreign table paragraph stays unbound across repeated saves into a source-bound document", async () => {
+    const target = await parseDocx(await documentWithSourceProperties(), { preloadFonts: false });
+    const foreign = await parseDocx(
+      await documentWithSourceProperties(
+        SOURCE_PROPERTIES.replace('w:left="720"', 'w:left="1440"'),
+        "87654321",
+      ),
+      { preloadFonts: false },
+    );
+    const targetProseDoc = toProseDoc(target);
+    const foreignProseDoc = toProseDoc(foreign);
+    const schema = targetProseDoc.type.schema;
+    const template = schema.node("table", null, [
+      schema.node("tableRow", null, [schema.node("tableCell", null, [foreignProseDoc.child(0)])]),
+    ]);
+    const copied = tableFromTemplate({ schema, template });
+    if (!copied) {
+      panic("expected the foreign table template to cross the package boundary");
+    }
+    const edited = targetProseDoc.type.create(targetProseDoc.attrs, [
+      targetProseDoc.child(0),
+      copied,
+    ]);
+
+    const firstSave = fromProseDoc(edited, target);
+    const secondSave = fromProseDoc(toProseDoc(firstSave), firstSave);
+
+    for (const saved of [firstSave, secondSave]) {
+      const table = saved.package.document.content.at(1);
+      const paragraph =
+        table?.type === "table" ? table.rows.at(0)?.cells.at(0)?.content.at(0) : null;
+      if (paragraph?.type !== "paragraph") {
+        panic("expected the repeatedly saved foreign table paragraph");
+      }
+      expect(getParagraphPropertySource(paragraph)?.xml).toContain('w:left="1440"');
+      expect(getParagraphPropertySourceToken(paragraph)).toBeUndefined();
+    }
+  });
+
   test("a hidden vertical-merge cell crosses with its local properties but no durable token", async () => {
     const parsed = await parseDocx(await documentWithSourceProperties(), { preloadFonts: false });
     const sourceParagraph = firstParagraph(parsed);
@@ -416,6 +456,73 @@ describe("paragraph properties survive a no-edit full repack", () => {
     expect(getParagraphPropertySource(firstParagraph(restored))).toEqual(
       getParagraphPropertySource(firstParagraph(parsed)),
     );
+  });
+
+  test("an authored paragraph stays unbound across repeated saves", async () => {
+    const parsed = await parseDocx(await documentWithSourceProperties(), { preloadFonts: false });
+    const proseDoc = toProseDoc(parsed);
+    const authored = proseDoc.type.schema.node("paragraph", null, [
+      proseDoc.type.schema.text("Authored"),
+    ]);
+    const edited = proseDoc.type.create(proseDoc.attrs, [proseDoc.child(0), authored]);
+
+    const firstSave = fromProseDoc(edited, parsed);
+    const secondSave = fromProseDoc(toProseDoc(firstSave), firstSave);
+
+    for (const saved of [firstSave, secondSave]) {
+      const sourceParagraph = saved.package.document.content.at(0);
+      const authoredParagraph = saved.package.document.content.at(1);
+      if (sourceParagraph?.type !== "paragraph" || authoredParagraph?.type !== "paragraph") {
+        panic("expected the source and authored paragraphs");
+      }
+      expect(getParagraphPropertySource(sourceParagraph)?.xml).toContain('w:left="720"');
+      expect(getParagraphPropertySourceToken(sourceParagraph)).toBeDefined();
+      expect(getParagraphPropertySource(authoredParagraph)).toBeUndefined();
+      expect(getParagraphPropertySourceToken(authoredParagraph)).toBeUndefined();
+    }
+  });
+
+  test("a deleted source paragraph can return after an intervening save", async () => {
+    const parsed = await parseDocx(await documentWithDuplicateParagraphIds(), {
+      preloadFonts: false,
+    });
+    const original = toProseDoc(parsed);
+    const withoutFirst = original.type.create(original.attrs, [original.child(1)]);
+
+    const afterDeletion = fromProseDoc(withoutFirst, parsed);
+    const restored = fromProseDoc(original, afterDeletion);
+    const paragraphs = restored.package.document.content.filter(
+      (block): block is Paragraph => block.type === "paragraph",
+    );
+
+    expect(paragraphs).toHaveLength(2);
+    expect(getParagraphPropertySource(paragraphs[0])?.xml).toContain('w:left="720"');
+    expect(getParagraphPropertySource(paragraphs[1])?.xml).toContain('w:left="1440"');
+  });
+
+  test("a source-owned paragraph cannot lose its durable token", async () => {
+    const parsed = await parseDocx(await documentWithSourceProperties(), { preloadFonts: false });
+    const sourceParagraph = firstParagraph(parsed);
+    const detached = { ...sourceParagraph };
+    copyParagraphPropertyCapture(detached, sourceParagraph);
+    const corrupted = {
+      ...parsed,
+      package: {
+        ...parsed.package,
+        document: { ...parsed.package.document, content: [detached] },
+      },
+    };
+
+    try {
+      fromProseDoc(toProseDoc(parsed), corrupted);
+      panic("expected source validation to reject the missing token");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ParagraphPropertySourceValidationError);
+      expect(error).toMatchObject({
+        code: "invalid_token",
+        message: "A source-bound paragraph is missing its paragraph-property token.",
+      });
+    }
   });
 
   test("paragraph id transfer cannot change durable source ownership", async () => {

--- a/packages/core/src/docx/paragraphPropertyRoundTrip.test.ts
+++ b/packages/core/src/docx/paragraphPropertyRoundTrip.test.ts
@@ -3,7 +3,9 @@ import { panic } from "better-result";
 import JSZip from "jszip";
 import { Fragment, Slice } from "prosemirror-model";
 
+import { tableFromTemplate } from "../ai-edits/table-template";
 import type { Document, Paragraph } from "../types/document";
+import { expectTableCellAttrs } from "../prosemirror/attrs";
 import { fromProseDoc } from "../prosemirror/conversion/fromProseDoc";
 import { toProseDoc } from "../prosemirror/conversion/toProseDoc";
 import { ensureParaIdsInDoc } from "../prosemirror/extensions/features/ParaIdAllocatorExtension";
@@ -12,9 +14,11 @@ import { withoutOrphanCommentRanges } from "./commentRangeIntegrity";
 import { parseDocx } from "./parser";
 import { DATE_UTC_NAMESPACE_URI } from "./trackedChangeInfo";
 import {
+  ParagraphPropertySourceValidationError,
   assignParagraphPropertySource,
   getParagraphPropertySourceCandidate,
   getParagraphPropertySource,
+  getParagraphPropertySourceToken,
   transferProseParagraphPropertySource,
 } from "./paragraphPropertySource";
 import { createEmptyDocx, repackDocx } from "./rezip";
@@ -305,7 +309,65 @@ describe("paragraph properties survive a no-edit full repack", () => {
     expect(getParagraphPropertySource(paragraphs[1])?.xml).toContain('w:left="1440"');
   });
 
-  test("load-time allocation transfers only the regenerated duplicate identity", async () => {
+  test("a table crossing package ownership keeps its local properties without its durable token", async () => {
+    const parsed = await parseDocx(await documentWithSourceProperties(), { preloadFonts: false });
+    const sourceParagraph = firstParagraph(parsed);
+    const proseDoc = toProseDoc(parsed);
+    const sourceNode = proseDoc.child(0);
+    const nodeSchema = proseDoc.type.schema;
+    const template = nodeSchema.node("table", null, [
+      nodeSchema.node("tableRow", null, [nodeSchema.node("tableCell", null, [sourceNode])]),
+    ]);
+    const copied = tableFromTemplate({ schema: nodeSchema, template });
+    if (!copied) {
+      panic("expected the table template to cross the package boundary");
+    }
+    const contractFree = nodeSchema.node("doc", null, [copied]);
+    const restored = fromProseDoc(contractFree);
+    const table = restored.package.document.content.at(0);
+    const paragraph = table?.type === "table" ? table.rows.at(0)?.cells.at(0)?.content.at(0) : null;
+    if (paragraph?.type !== "paragraph") {
+      panic("expected the copied table paragraph");
+    }
+
+    expect(getParagraphPropertySource(paragraph)).toEqual(
+      getParagraphPropertySource(sourceParagraph),
+    );
+    expect(getParagraphPropertySourceToken(paragraph)).toBeUndefined();
+  });
+
+  test("a hidden vertical-merge cell crosses with its local properties but no durable token", async () => {
+    const parsed = await parseDocx(await documentWithSourceProperties(), { preloadFonts: false });
+    const sourceParagraph = firstParagraph(parsed);
+    const proseDoc = toProseDoc(parsed);
+    const nodeSchema = proseDoc.type.schema;
+    const hiddenCell = { type: "tableCell" as const, content: [sourceParagraph] };
+    const template = nodeSchema.node("table", null, [
+      nodeSchema.node("tableRow", null, [
+        nodeSchema.node("tableCell", { rowspan: 2, _docxVMergeContinuationCells: [hiddenCell] }, [
+          nodeSchema.node("paragraph"),
+        ]),
+      ]),
+    ]);
+    const copied = tableFromTemplate({ schema: nodeSchema, template });
+    if (!copied) {
+      panic("expected the vertical-merge table template to cross the package boundary");
+    }
+    const continuation = expectTableCellAttrs(
+      copied.child(0).child(0),
+    )._docxVMergeContinuationCells?.at(0);
+    const paragraph = continuation?.content.at(0);
+    if (paragraph?.type !== "paragraph") {
+      panic("expected the hidden continuation paragraph");
+    }
+
+    expect(getParagraphPropertySource(paragraph)).toEqual(
+      getParagraphPropertySource(sourceParagraph),
+    );
+    expect(getParagraphPropertySourceToken(paragraph)).toBeUndefined();
+  });
+
+  test("durable source tokens survive regenerated duplicate paragraph ids", async () => {
     const parsed = await parseDocx(await documentWithDuplicateParagraphIds(), {
       preloadFonts: false,
     });
@@ -322,11 +384,41 @@ describe("paragraph properties survive a no-edit full repack", () => {
     );
 
     expect(paragraphs).toHaveLength(2);
-    expect(getParagraphPropertySource(paragraphs[0])).toBeUndefined();
+    expect(getParagraphPropertySource(paragraphs[0])?.xml).toContain('w:left="720"');
     expect(getParagraphPropertySource(paragraphs[1])?.xml).toContain('w:left="1440"');
   });
 
-  test("a transferred id that collides with another paragraph cannot lend its capture", async () => {
+  test("durable duplicate-id sources survive a shallow document derivation and PM reconstruction", async () => {
+    const parsed = await parseDocx(await documentWithDuplicateParagraphIds(), {
+      preloadFonts: false,
+    });
+    const derived = { ...parsed, package: { ...parsed.package } };
+    const normalized = ensureParaIdsInDoc(toProseDoc(parsed));
+    const reconstructed = normalized.type.schema.nodeFromJSON(normalized.toJSON());
+    const restored = fromProseDoc(reconstructed, derived);
+    const paragraphs = restored.package.document.content.filter(
+      (block): block is Paragraph => block.type === "paragraph",
+    );
+
+    expect(getParagraphPropertySource(paragraphs[0])?.xml).toContain('w:left="720"');
+    expect(getParagraphPropertySource(paragraphs[1])?.xml).toContain('w:left="1440"');
+  });
+
+  test("a durable id-less source survives a shallow document derivation and PM reconstruction", async () => {
+    const parsed = await parseDocx(await documentWithSourceProperties(SOURCE_PROPERTIES, null), {
+      preloadFonts: false,
+    });
+    const derived = { ...parsed, package: { ...parsed.package } };
+    const normalized = ensureParaIdsInDoc(toProseDoc(parsed));
+    const reconstructed = normalized.type.schema.nodeFromJSON(normalized.toJSON());
+    const restored = fromProseDoc(reconstructed, derived);
+
+    expect(getParagraphPropertySource(firstParagraph(restored))).toEqual(
+      getParagraphPropertySource(firstParagraph(parsed)),
+    );
+  });
+
+  test("paragraph id transfer cannot change durable source ownership", async () => {
     const parsed = await parseDocx(await documentWithDuplicateParagraphIds(), {
       preloadFonts: false,
     });
@@ -353,7 +445,7 @@ describe("paragraph properties survive a no-edit full repack", () => {
       (block): block is Paragraph => block.type === "paragraph",
     );
     expect(getParagraphPropertySource(paragraphs[0])?.xml).toContain('w:left="720"');
-    expect(getParagraphPropertySource(paragraphs[1])).toBeUndefined();
+    expect(getParagraphPropertySource(paragraphs[1])?.xml).toContain('w:left="1440"');
   });
 
   test("duplicate editable paragraph identities cannot share a property capture", async () => {
@@ -368,12 +460,7 @@ describe("paragraph properties survive a no-edit full repack", () => {
       ...json,
       content: [paragraph, paragraph],
     });
-    const restored = fromProseDoc(duplicate, parsed);
-    const paragraphs = restored.package.document.content.filter(
-      (block): block is Paragraph => block.type === "paragraph",
-    );
-    expect(paragraphs).toHaveLength(2);
-    expect(paragraphs.map(getParagraphPropertySource)).toEqual([undefined, undefined]);
+    expect(() => fromProseDoc(duplicate, parsed)).toThrow(ParagraphPropertySourceValidationError);
   });
 
   test("one exact parser-linked paragraph node cannot lend its capture twice", async () => {
@@ -381,12 +468,7 @@ describe("paragraph properties survive a no-edit full repack", () => {
     const proseDoc = toProseDoc(parsed);
     const paragraph = proseDoc.child(0);
     const duplicate = proseDoc.type.create(proseDoc.attrs, [paragraph, paragraph]);
-    const restored = fromProseDoc(duplicate, parsed);
-    const paragraphs = restored.package.document.content.filter(
-      (block): block is Paragraph => block.type === "paragraph",
-    );
-
-    expect(paragraphs.map(getParagraphPropertySource)).toEqual([undefined, undefined]);
+    expect(() => fromProseDoc(duplicate, parsed)).toThrow(ParagraphPropertySourceValidationError);
   });
 
   test("a copied slice cannot borrow the exact owner's property capture", async () => {
@@ -401,12 +483,32 @@ describe("paragraph properties survive a no-edit full repack", () => {
     transferProseParagraphPropertySource(copied, paragraph, "87654321");
     const copiedSlice = new Slice(Fragment.fromArray([paragraph, copied]), 0, 0);
     const duplicated = proseDoc.type.create(proseDoc.attrs, copiedSlice.content);
-    const restored = fromProseDoc(duplicated, parsed);
-    const paragraphs = restored.package.document.content.filter(
-      (block): block is Paragraph => block.type === "paragraph",
+    expect(() => fromProseDoc(duplicated, parsed)).toThrow(ParagraphPropertySourceValidationError);
+  });
+
+  test("rejects a source-bearing model paired with a contract-free ProseMirror document", async () => {
+    const parsed = await parseDocx(await documentWithSourceProperties(), { preloadFonts: false });
+    const proseDoc = toProseDoc(parsed);
+    const contractFree = proseDoc.type.create(
+      { ...proseDoc.attrs, _docxParagraphSourceContract: null },
+      proseDoc.content,
+      proseDoc.marks,
     );
 
-    expect(paragraphs.map(getParagraphPropertySource)).toEqual([undefined, undefined]);
+    expect(() => fromProseDoc(contractFree, parsed)).toThrow(
+      ParagraphPropertySourceValidationError,
+    );
+  });
+
+  test("rejects a contract-bearing ProseMirror document paired with a source-free model", async () => {
+    const parsed = await parseDocx(await documentWithSourceProperties(), { preloadFonts: false });
+    const original = toProseDoc(parsed);
+    const proseDoc = original.type.schema.nodeFromJSON(original.toJSON());
+    const sourceFree = structuredClone(parsed);
+
+    expect(() => fromProseDoc(proseDoc, sourceFree)).toThrow(
+      ParagraphPropertySourceValidationError,
+    );
   });
 
   test("a JSON-cloned model falls back to its typed paragraph properties", async () => {

--- a/packages/core/src/docx/paragraphPropertyRoundTrip.test.ts
+++ b/packages/core/src/docx/paragraphPropertyRoundTrip.test.ts
@@ -19,9 +19,11 @@ import {
   ParagraphPropertySourceValidationError,
   assignParagraphPropertySource,
   copyParagraphPropertyCapture,
+  decodeTableCellParagraphSourcePayload,
   getParagraphPropertySourceCandidate,
   getParagraphPropertySource,
   getParagraphPropertySourceToken,
+  transportTableCellsWithParagraphPropertySources,
   transferProseParagraphPropertySource,
 } from "./paragraphPropertySource";
 import { createEmptyDocx, repackDocx } from "./rezip";
@@ -386,20 +388,27 @@ describe("paragraph properties survive a no-edit full repack", () => {
     const proseDoc = toProseDoc(parsed);
     const nodeSchema = proseDoc.type.schema;
     const hiddenCell = { type: "tableCell" as const, content: [sourceParagraph] };
+    const continuationCells = transportTableCellsWithParagraphPropertySources([hiddenCell]);
     const template = nodeSchema.node("table", null, [
       nodeSchema.node("tableRow", null, [
-        nodeSchema.node("tableCell", { rowspan: 2, _docxVMergeContinuationCells: [hiddenCell] }, [
-          nodeSchema.node("paragraph"),
-        ]),
+        nodeSchema.node(
+          "tableCell",
+          { rowspan: 2, _docxVMergeContinuationCells: continuationCells },
+          [nodeSchema.node("paragraph")],
+        ),
       ]),
     ]);
     const copied = tableFromTemplate({ schema: nodeSchema, template });
     if (!copied) {
       panic("expected the vertical-merge table template to cross the package boundary");
     }
-    const continuation = expectTableCellAttrs(
+    const continuationPayload = expectTableCellAttrs(
       copied.child(0).child(0),
-    )._docxVMergeContinuationCells?.at(0);
+    )._docxVMergeContinuationCells;
+    const continuation =
+      continuationPayload === undefined || continuationPayload === null
+        ? undefined
+        : decodeTableCellParagraphSourcePayload(continuationPayload).cells.at(0);
     const paragraph = continuation?.content.at(0);
     if (paragraph?.type !== "paragraph") {
       panic("expected the hidden continuation paragraph");

--- a/packages/core/src/docx/paragraphPropertySource.test.ts
+++ b/packages/core/src/docx/paragraphPropertySource.test.ts
@@ -4,11 +4,15 @@ import { readFile } from "node:fs/promises";
 import type { BlockContent, Paragraph } from "../types/document";
 import { parseDocx } from "./parser";
 import {
+  TABLE_CELL_PARAGRAPH_SOURCE_BINDING_ATTR,
   cloneDocumentWithParagraphPropertySources,
   copyDocumentParagraphPropertySources,
+  copyParagraphPropertySource,
   getDocumentParagraphPropertySourceContract,
   getParagraphPropertySource,
   getParagraphPropertySourceToken,
+  restoreTableCellsWithParagraphPropertySources,
+  transportTableCellsWithParagraphPropertySources,
   visitDocumentStoryParagraphs,
 } from "./paragraphPropertySource";
 
@@ -153,5 +157,72 @@ describe("paragraph-property source identity", () => {
     expect(paragraph && getParagraphPropertySourceToken(paragraph)).toBe(
       token(BLOCK_SDT_DIGEST, 0),
     );
+  });
+
+  test("hidden table paragraphs retain one source identity across transport clones", async () => {
+    const document = await parseDocx(await readFile(LAYOUT_FIXTURE), { preloadFonts: false });
+    const paragraph = firstParagraphIn(document.package.document.content);
+    if (!paragraph) {
+      throw new Error("Layout fixture must contain a paragraph");
+    }
+    const sourceToken = getParagraphPropertySourceToken(paragraph);
+    const firstTransport = transportTableCellsWithParagraphPropertySources([
+      { type: "tableCell", content: [paragraph] },
+    ]);
+    const secondTransport = transportTableCellsWithParagraphPropertySources(firstTransport);
+    const restored = restoreTableCellsWithParagraphPropertySources(secondTransport);
+    const restoredParagraph = restored.at(0)?.content.at(0);
+    if (typeof sourceToken !== "string" || restoredParagraph?.type !== "paragraph") {
+      throw new Error("Transport fixture lost its paragraph source");
+    }
+
+    expect(getParagraphPropertySourceToken(restoredParagraph)).toBe(sourceToken);
+    expect(Object.hasOwn(restoredParagraph, TABLE_CELL_PARAGRAPH_SOURCE_BINDING_ATTR)).toBe(false);
+  });
+
+  test("transport explicitly marks a newly authored hidden paragraph", () => {
+    const paragraph: Paragraph = { type: "paragraph", content: [] };
+    const transported = transportTableCellsWithParagraphPropertySources([
+      { type: "tableCell", content: [paragraph] },
+    ]);
+    const transportedParagraph = transported.at(0)?.content.at(0);
+    if (transportedParagraph?.type !== "paragraph") {
+      throw new Error("Transport fixture lost its authored paragraph");
+    }
+
+    expect(Reflect.get(transportedParagraph, TABLE_CELL_PARAGRAPH_SOURCE_BINDING_ATTR)).toEqual({
+      type: "authored",
+    });
+    const restored = restoreTableCellsWithParagraphPropertySources(transported);
+    const restoredParagraph = restored.at(0)?.content.at(0);
+    expect(restoredParagraph?.type).toBe("paragraph");
+    expect(
+      restoredParagraph?.type === "paragraph"
+        ? Object.hasOwn(restoredParagraph, TABLE_CELL_PARAGRAPH_SOURCE_BINDING_ATTR)
+        : true,
+    ).toBe(false);
+  });
+
+  test.each([
+    { type: "source" },
+    { token: "p1d:00000000000000000000000000000000:0", type: "source" },
+    { type: "authored" },
+  ] as const)("rejects conflicting hidden transport binding %#", async (binding) => {
+    const document = await parseDocx(await readFile(LAYOUT_FIXTURE), { preloadFonts: false });
+    const paragraph = firstParagraphIn(document.package.document.content);
+    if (!paragraph) {
+      throw new Error("Layout fixture must contain a paragraph");
+    }
+    const tampered = { ...paragraph };
+    copyParagraphPropertySource(tampered, paragraph);
+    if (!Reflect.set(tampered, TABLE_CELL_PARAGRAPH_SOURCE_BINDING_ATTR, binding)) {
+      throw new Error("Transport fixture could not attach its invalid binding");
+    }
+
+    expect(() =>
+      transportTableCellsWithParagraphPropertySources([
+        { type: "tableCell", content: [tampered] },
+      ]),
+    ).toThrow();
   });
 });

--- a/packages/core/src/docx/paragraphPropertySource.test.ts
+++ b/packages/core/src/docx/paragraphPropertySource.test.ts
@@ -5,6 +5,7 @@ import type { BlockContent, Paragraph } from "../types/document";
 import { parseDocx } from "./parser";
 import {
   cloneDocumentWithParagraphPropertySources,
+  copyDocumentParagraphPropertySources,
   getDocumentParagraphPropertySourceContract,
   getParagraphPropertySource,
   getParagraphPropertySourceToken,
@@ -67,8 +68,20 @@ describe("paragraph-property source identity", () => {
     const derived = { ...document, package: { ...document.package } };
 
     expect(getDocumentParagraphPropertySourceContract(derived)).toBe(contract);
-    expect(JSON.stringify(derived)).not.toContain("paragraphPropertySourceContract");
+    expect(copyDocumentParagraphPropertySources(derived)?.size).toBe(41);
+    expect(JSON.stringify(derived)).not.toContain("paragraphPropertySourceBinding");
     expect(JSON.stringify(derived)).not.toContain("folio-ppr-v1");
+  });
+
+  test("callers receive an isolated copy of the private source registry", async () => {
+    const document = await parseDocx(await readFile(LAYOUT_FIXTURE), { preloadFonts: false });
+    const sources = copyDocumentParagraphPropertySources(document);
+    const sourceCount = sources?.size;
+
+    sources?.clear();
+
+    expect(sourceCount).toBe(41);
+    expect(copyDocumentParagraphPropertySources(document)?.size).toBe(sourceCount);
   });
 
   test("the sanctioned structured clone explicitly transfers private source identity", async () => {
@@ -79,9 +92,11 @@ describe("paragraph-property source identity", () => {
     const clonedParagraph = firstParagraphIn(ownedClone.package.document.content);
 
     expect(getDocumentParagraphPropertySourceContract(rawClone)).toBeUndefined();
+    expect(copyDocumentParagraphPropertySources(rawClone)).toBeUndefined();
     expect(getDocumentParagraphPropertySourceContract(ownedClone)).toBe(
       getDocumentParagraphPropertySourceContract(document),
     );
+    expect(copyDocumentParagraphPropertySources(ownedClone)?.size).toBe(41);
     expect(sourceParagraph && getParagraphPropertySource(sourceParagraph)).toEqual(
       clonedParagraph && getParagraphPropertySource(clonedParagraph),
     );

--- a/packages/core/src/docx/paragraphPropertySource.test.ts
+++ b/packages/core/src/docx/paragraphPropertySource.test.ts
@@ -4,16 +4,19 @@ import { readFile } from "node:fs/promises";
 import type { BlockContent, Paragraph } from "../types/document";
 import { parseDocx } from "./parser";
 import {
+  ParagraphPropertySourceValidationError,
   TABLE_CELL_PARAGRAPH_SOURCE_BINDING_ATTR,
   cloneDocumentWithParagraphPropertySources,
   copyDocumentParagraphPropertySources,
   copyParagraphPropertySource,
+  decodeTableCellParagraphSourcePayload,
   getDocumentParagraphPropertySourceContract,
   getParagraphPropertySource,
   getParagraphPropertySourceToken,
   restoreTableCellsWithParagraphPropertySources,
   transportTableCellsWithParagraphPropertySources,
   visitDocumentStoryParagraphs,
+  visitTableCellParagraphPropertySourceBindings,
 } from "./paragraphPropertySource";
 
 const LAYOUT_FIXTURE = new URL(
@@ -170,7 +173,9 @@ describe("paragraph-property source identity", () => {
       { type: "tableCell", content: [paragraph] },
     ]);
     const secondTransport = transportTableCellsWithParagraphPropertySources(firstTransport);
-    const restored = restoreTableCellsWithParagraphPropertySources(secondTransport);
+    const restored = restoreTableCellsWithParagraphPropertySources(
+      decodeTableCellParagraphSourcePayload(secondTransport),
+    );
     const restoredParagraph = restored.at(0)?.content.at(0);
     if (typeof sourceToken !== "string" || restoredParagraph?.type !== "paragraph") {
       throw new Error("Transport fixture lost its paragraph source");
@@ -193,7 +198,9 @@ describe("paragraph-property source identity", () => {
     expect(Reflect.get(transportedParagraph, TABLE_CELL_PARAGRAPH_SOURCE_BINDING_ATTR)).toEqual({
       type: "authored",
     });
-    const restored = restoreTableCellsWithParagraphPropertySources(transported);
+    const restored = restoreTableCellsWithParagraphPropertySources(
+      decodeTableCellParagraphSourcePayload(transported),
+    );
     const restoredParagraph = restored.at(0)?.content.at(0);
     expect(restoredParagraph?.type).toBe("paragraph");
     expect(
@@ -220,9 +227,180 @@ describe("paragraph-property source identity", () => {
     }
 
     expect(() =>
-      transportTableCellsWithParagraphPropertySources([
-        { type: "tableCell", content: [tampered] },
-      ]),
+      transportTableCellsWithParagraphPropertySources([{ type: "tableCell", content: [tampered] }]),
     ).toThrow();
   });
+
+  test("decodes nested hidden table-cell paragraph bindings before typed traversal", () => {
+    const payload = decodeTableCellParagraphSourcePayload([
+      {
+        type: "tableCell",
+        content: [
+          {
+            type: "table",
+            rows: [
+              {
+                type: "tableRow",
+                cells: [
+                  {
+                    type: "tableCell",
+                    content: [
+                      {
+                        [TABLE_CELL_PARAGRAPH_SOURCE_BINDING_ATTR]: { type: "authored" },
+                        type: "paragraph",
+                        content: [],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+    const bindings: string[] = [];
+    visitTableCellParagraphPropertySourceBindings(payload, (binding, path) => {
+      bindings.push(`${binding.type}:${path}`);
+    });
+
+    expect(bindings).toEqual([
+      "authored:continuationCells[0].content[0].rows[0].cells[0].content[0]",
+    ]);
+  });
+
+  test("decoded hidden payloads are immutable fixed points", () => {
+    const transported = transportTableCellsWithParagraphPropertySources([
+      { type: "tableCell", content: [{ type: "paragraph", content: [] }] },
+    ]);
+    const first = decodeTableCellParagraphSourcePayload(transported);
+    const second = decodeTableCellParagraphSourcePayload(first.cells);
+    const firstCell = first.cells.at(0);
+    if (!firstCell) {
+      throw new Error("Decoded payload lost its table cell");
+    }
+
+    expect(second).toBe(first);
+    expect(Reflect.set(firstCell, "content", [])).toBe(false);
+    expect(restoreTableCellsWithParagraphPropertySources(first).at(0)?.content.at(0)?.type).toBe(
+      "paragraph",
+    );
+  });
+
+  test("payload validation errors never retain document values", () => {
+    const documentValue = "privileged-document-content";
+    try {
+      decodeTableCellParagraphSourcePayload([
+        {
+          type: "tableCell",
+          content: [
+            {
+              [TABLE_CELL_PARAGRAPH_SOURCE_BINDING_ATTR]: {
+                token: documentValue,
+                type: "source",
+              },
+              type: "paragraph",
+              content: [],
+            },
+          ],
+        },
+      ]);
+      throw new Error("Expected hidden payload decoding to fail");
+    } catch (error) {
+      if (!(error instanceof ParagraphPropertySourceValidationError)) {
+        throw error;
+      }
+      expect(JSON.stringify(error)).not.toContain(documentValue);
+      expect(Object.hasOwn(error, "token")).toBe(false);
+    }
+
+    const unreadableCell = new Proxy(
+      { type: "tableCell", content: [] },
+      {
+        ownKeys: () => {
+          throw new Error(documentValue);
+        },
+      },
+    );
+    try {
+      decodeTableCellParagraphSourcePayload([unreadableCell]);
+      throw new Error("Expected unreadable hidden payload decoding to fail");
+    } catch (error) {
+      if (!(error instanceof ParagraphPropertySourceValidationError)) {
+        throw error;
+      }
+      expect(error.classification).toBe("invalid_graph_value");
+      expect(JSON.stringify(error)).not.toContain(documentValue);
+    }
+  });
+
+  test.each([
+    {
+      classification: "cyclic_or_aliased_graph",
+      createPayload: () => {
+        const cell: Record<string, unknown> = { type: "tableCell", content: [] };
+        cell["content"] = [cell];
+        return [cell];
+      },
+      type: "cyclic",
+    },
+    {
+      classification: "cyclic_or_aliased_graph",
+      createPayload: () => {
+        const paragraph = {
+          [TABLE_CELL_PARAGRAPH_SOURCE_BINDING_ATTR]: { type: "authored" },
+          type: "paragraph",
+          content: [],
+        };
+        return [{ type: "tableCell", content: [paragraph, paragraph] }];
+      },
+      type: "aliased",
+    },
+    {
+      classification: "cyclic_or_aliased_graph",
+      createPayload: () => {
+        const formatting: Record<string, unknown> = {};
+        formatting["nested"] = formatting;
+        return [{ type: "tableCell", formatting, content: [] }];
+      },
+      type: "nested cyclic",
+    },
+    {
+      classification: "depth_limit",
+      createPayload: () => {
+        let block: unknown = {
+          [TABLE_CELL_PARAGRAPH_SOURCE_BINDING_ATTR]: { type: "authored" },
+          type: "paragraph",
+          content: [],
+        };
+        for (let depth = 0; depth < 130; depth += 1) {
+          block = { type: "blockSdt", properties: {}, content: [block] };
+        }
+        return [{ type: "tableCell", content: [block] }];
+      },
+      type: "deeply nested",
+    },
+    {
+      classification: "complexity_limit",
+      createPayload: () =>
+        Array.from({ length: 50_001 }, () => ({ type: "tableCell", content: [] })),
+      type: "over-complex",
+    },
+  ] as const)(
+    "rejects $type hidden payload deterministically",
+    ({ classification, createPayload }) => {
+      try {
+        decodeTableCellParagraphSourcePayload(createPayload());
+        throw new Error("Expected hidden payload decoding to fail");
+      } catch (error) {
+        if (!(error instanceof ParagraphPropertySourceValidationError)) {
+          throw error;
+        }
+        expect(error.code).toBe("invalid_token");
+        expect(error.classification).toBe(classification);
+        expect(error.path?.startsWith("continuationCells")).toBe(true);
+        expect(Object.hasOwn(error, "token")).toBe(false);
+      }
+    },
+  );
 });

--- a/packages/core/src/docx/paragraphPropertySource.test.ts
+++ b/packages/core/src/docx/paragraphPropertySource.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+
+import type { BlockContent, Paragraph } from "../types/document";
+import { parseDocx } from "./parser";
+import {
+  cloneDocumentWithParagraphPropertySources,
+  getDocumentParagraphPropertySourceContract,
+  getParagraphPropertySource,
+  getParagraphPropertySourceToken,
+  visitDocumentStoryParagraphs,
+} from "./paragraphPropertySource";
+
+const LAYOUT_FIXTURE = new URL(
+  "../../../../parity/fixtures/layout-kitchen-sink.docx",
+  import.meta.url,
+);
+const BLOCK_SDT_FIXTURE = new URL(
+  "./__tests__/__fixtures__/corpus/nested-block-sdt.docx",
+  import.meta.url,
+);
+const LAYOUT_DIGEST = "96aef5ba6161127dc9b85ec487101c934ca1bc93f63fbb8caa53dde196a5fd5b";
+const BLOCK_SDT_DIGEST = "2c4d3273683c5a7a059711c5d2a6ba2d040e914cb6b84d72fa809b7419b42e11";
+
+const token = (digest: string, ordinal: number) =>
+  `p1d:${digest.slice(0, 32)}:${ordinal.toString(36)}`;
+
+const tokensIn = (content: BlockContent[]): string[] => {
+  const tokens: string[] = [];
+  visitDocumentStoryParagraphs(content, (paragraph) => {
+    const sourceToken = getParagraphPropertySourceToken(paragraph);
+    if (sourceToken) {
+      tokens.push(sourceToken);
+    }
+  });
+  return tokens;
+};
+
+const firstParagraphIn = (content: BlockContent[]): Paragraph | undefined => {
+  for (const block of content) {
+    if (block.type === "paragraph") {
+      return block;
+    }
+    if (block.type === "blockSdt") {
+      const paragraph = firstParagraphIn(block.content);
+      if (paragraph) {
+        return paragraph;
+      }
+      continue;
+    }
+    for (const row of block.rows) {
+      for (const cell of row.cells) {
+        const paragraph = firstParagraphIn(cell.content);
+        if (paragraph) {
+          return paragraph;
+        }
+      }
+    }
+  }
+  return undefined;
+};
+
+describe("paragraph-property source identity", () => {
+  test("the private contract follows immutable derivations without entering JSON", async () => {
+    const document = await parseDocx(await readFile(LAYOUT_FIXTURE), { preloadFonts: false });
+    const contract = getDocumentParagraphPropertySourceContract(document);
+    const derived = { ...document, package: { ...document.package } };
+
+    expect(getDocumentParagraphPropertySourceContract(derived)).toBe(contract);
+    expect(JSON.stringify(derived)).not.toContain("paragraphPropertySourceContract");
+    expect(JSON.stringify(derived)).not.toContain("folio-ppr-v1");
+  });
+
+  test("the sanctioned structured clone explicitly transfers private source identity", async () => {
+    const document = await parseDocx(await readFile(LAYOUT_FIXTURE), { preloadFonts: false });
+    const rawClone = structuredClone(document);
+    const ownedClone = cloneDocumentWithParagraphPropertySources(document);
+    const sourceParagraph = firstParagraphIn(document.package.document.content);
+    const clonedParagraph = firstParagraphIn(ownedClone.package.document.content);
+
+    expect(getDocumentParagraphPropertySourceContract(rawClone)).toBeUndefined();
+    expect(getDocumentParagraphPropertySourceContract(ownedClone)).toBe(
+      getDocumentParagraphPropertySourceContract(document),
+    );
+    expect(sourceParagraph && getParagraphPropertySource(sourceParagraph)).toEqual(
+      clonedParagraph && getParagraphPropertySource(clonedParagraph),
+    );
+  });
+
+  test("v1 traversal fixes body, text-box, and table ordinals across parse options", async () => {
+    const source = await readFile(LAYOUT_FIXTURE);
+    const browser = await parseDocx(source, { preloadFonts: true });
+    const materializer = await parseDocx(source, { preloadFonts: false });
+    const browserTokens = tokensIn(browser.package.document.content);
+    const materializerTokens = tokensIn(materializer.package.document.content);
+
+    expect(getDocumentParagraphPropertySourceContract(browser)).toBe(
+      `folio-ppr-v1:${LAYOUT_DIGEST}`,
+    );
+    expect(browserTokens).toEqual(
+      Array.from({ length: 41 }, (_, ordinal) => token(LAYOUT_DIGEST, ordinal)),
+    );
+    expect(materializerTokens).toEqual(browserTokens);
+
+    const bodyParagraph = browser.package.document.content.at(0);
+    if (bodyParagraph?.type !== "paragraph") {
+      throw new Error("Layout fixture must start with a paragraph");
+    }
+    const textBoxParagraph = bodyParagraph.content
+      .filter((content) => content.type === "run")
+      .flatMap((run) => run.content)
+      .find((content) => content.type === "shape" && content.shape.textBody)
+      ?.shape.textBody?.content.at(0);
+    const table = browser.package.document.content.find((block) => block.type === "table");
+    const tableParagraph = table?.rows.at(0)?.cells.at(0)?.content.at(0);
+
+    expect(getParagraphPropertySourceToken(bodyParagraph)).toBe(token(LAYOUT_DIGEST, 0));
+    expect(textBoxParagraph?.type).toBe("paragraph");
+    expect(
+      textBoxParagraph?.type === "paragraph"
+        ? getParagraphPropertySourceToken(textBoxParagraph)
+        : undefined,
+    ).toBe(token(LAYOUT_DIGEST, 1));
+    expect(tableParagraph?.type).toBe("paragraph");
+    expect(
+      tableParagraph?.type === "paragraph"
+        ? getParagraphPropertySourceToken(tableParagraph)
+        : undefined,
+    ).toBe(token(LAYOUT_DIGEST, 7));
+  });
+
+  test("v1 traversal includes nested block content controls", async () => {
+    const source = await readFile(BLOCK_SDT_FIXTURE);
+    const document = await parseDocx(source, { preloadFonts: false });
+    const paragraph = firstParagraphIn(document.package.document.content);
+
+    expect(tokensIn(document.package.document.content)).toEqual([token(BLOCK_SDT_DIGEST, 0)]);
+    expect(paragraph && getParagraphPropertySourceToken(paragraph)).toBe(
+      token(BLOCK_SDT_DIGEST, 0),
+    );
+  });
+});

--- a/packages/core/src/docx/paragraphPropertySource.ts
+++ b/packages/core/src/docx/paragraphPropertySource.ts
@@ -1,8 +1,8 @@
-import { panic } from "better-result";
-import type { Fragment, Mark, Node as PMNode } from "prosemirror-model";
-import type { Transaction } from "prosemirror-state";
+import { panic, TaggedError } from "better-result";
+import type { Fragment, Mark, Node as PMNode, NodeType } from "prosemirror-model";
+import { PluginKey, type Transaction } from "prosemirror-state";
 
-import type { Document, Paragraph } from "../types/document";
+import type { Document, Paragraph, TableCell } from "../types/document";
 import { visitDocxParagraphs } from "./paragraphTraversal";
 
 type ParagraphPropertySource = {
@@ -15,6 +15,103 @@ const paragraphPropertySourceOwners = new WeakMap<Paragraph, Paragraph>();
 const proseParagraphSourceOwners = new WeakMap<PMNode, Paragraph>();
 const paragraphPropertySourceCandidates = new WeakMap<Paragraph, Paragraph>();
 const paragraphPropertySourceTransferIds = new WeakMap<Paragraph, string>();
+const paragraphPropertySourceTokens = new WeakMap<Paragraph, string>();
+// Enumerable symbols follow ordinary immutable `{ ...document }` derivations,
+// while JSON and other string-key serialization cannot expose the contract.
+// `structuredClone` deliberately drops symbols, so the one sanctioned deep
+// clone path transfers this value explicitly below.
+const documentParagraphPropertySourceContract = Symbol("paragraphPropertySourceContract");
+
+export const PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR = "_docxParagraphSourceToken";
+export const PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR = "_docxParagraphSourceContract";
+
+const PARAGRAPH_SOURCE_TOKEN_VERSION = "folio-ppr-v1";
+const PARAGRAPH_SOURCE_TOKEN_PREFIX = "p1d";
+const SHA256_HEX = /^[0-9a-f]{64}$/;
+const SOURCE_TOKEN = /^p1d:([0-9a-f]{32}):(0|[1-9a-z][0-9a-z]*)$/;
+
+export const PARAGRAPH_PROPERTY_SOURCE_VALIDATION_CODES = [
+  "contract_mismatch",
+  "duplicate_token",
+  "invalid_token",
+  "unknown_token",
+] as const;
+
+export type ParagraphPropertySourceValidationCode =
+  (typeof PARAGRAPH_PROPERTY_SOURCE_VALIDATION_CODES)[number];
+
+export class ParagraphPropertySourceValidationError extends TaggedError(
+  "ParagraphPropertySourceValidationError",
+)<{
+  code: ParagraphPropertySourceValidationCode;
+  message: string;
+  token?: unknown;
+}> {}
+
+const contractForDigest = (sourceDigest: string): string => {
+  if (!SHA256_HEX.test(sourceDigest)) {
+    panic("Paragraph-property source digest must be lowercase SHA-256 hex");
+  }
+  return `${PARAGRAPH_SOURCE_TOKEN_VERSION}:${sourceDigest}`;
+};
+
+const fingerprintFromContract = (contract: string): string | null => {
+  const prefix = `${PARAGRAPH_SOURCE_TOKEN_VERSION}:`;
+  const digest = contract.startsWith(prefix) ? contract.slice(prefix.length) : "";
+  return SHA256_HEX.test(digest) ? digest.slice(0, 32) : null;
+};
+
+const tokenForOrdinal = (contract: string, ordinal: number): string => {
+  const fingerprint = fingerprintFromContract(contract);
+  if (!fingerprint) {
+    panic("Cannot mint a paragraph-property token for an invalid source contract");
+  }
+  return `${PARAGRAPH_SOURCE_TOKEN_PREFIX}:${fingerprint}:${ordinal.toString(36)}`;
+};
+
+const setDocumentParagraphPropertySourceContract = (document: Document, contract: string): void => {
+  if (!fingerprintFromContract(contract)) {
+    panic("Cannot attach an invalid paragraph-property source contract");
+  }
+  const existing = Object.hasOwn(document, documentParagraphPropertySourceContract)
+    ? Reflect.get(document, documentParagraphPropertySourceContract)
+    : undefined;
+  if (existing === contract) {
+    return;
+  }
+  if (
+    !Reflect.defineProperty(document, documentParagraphPropertySourceContract, {
+      enumerable: true,
+      value: contract,
+    })
+  ) {
+    panic("Cannot attach the paragraph-property source contract to the document");
+  }
+};
+
+export const isParagraphPropertySourceToken = (token: unknown): token is string =>
+  typeof token === "string" && SOURCE_TOKEN.test(token);
+
+/** True only for a body-story token derived from the exact source contract. */
+export const paragraphPropertySourceTokenMatchesContract = (
+  token: unknown,
+  contract: string,
+): token is string => {
+  if (!isParagraphPropertySourceToken(token)) {
+    return false;
+  }
+  const match = SOURCE_TOKEN.exec(token);
+  const fingerprint = fingerprintFromContract(contract);
+  return match !== null && fingerprint !== null && match[1] === fingerprint;
+};
+
+/** Visit the v1 provenance scope in canonical OOXML body-story order. */
+export const visitDocumentStoryParagraphs = (
+  content: Document["package"]["document"]["content"],
+  visit: (paragraph: Paragraph) => void,
+): void => {
+  visitDocxParagraphs({ documentBody: { content } }, visit);
+};
 
 export const assignParagraphPropertySource = (
   paragraph: Paragraph,
@@ -28,12 +125,17 @@ export const getParagraphPropertySource = (
   paragraph: Paragraph,
 ): ParagraphPropertySource | undefined => paragraphPropertySources.get(paragraph);
 
-export const copyParagraphPropertySource = (target: Paragraph, source: Paragraph): void => {
+/** Copy the captured `w:pPr` without claiming the source paragraph's durable identity. */
+export const copyParagraphPropertyCapture = (target: Paragraph, source: Paragraph): void => {
   const propertySource = paragraphPropertySources.get(source);
   if (propertySource) {
     paragraphPropertySources.set(target, { ...propertySource });
     paragraphPropertySourceOwners.set(target, paragraphPropertySourceOwners.get(source) ?? source);
   }
+};
+
+export const copyParagraphPropertySource = (target: Paragraph, source: Paragraph): void => {
+  copyParagraphPropertyCapture(target, source);
   const transferId = paragraphPropertySourceTransferIds.get(source);
   if (transferId) {
     paragraphPropertySourceTransferIds.set(target, transferId);
@@ -42,7 +144,63 @@ export const copyParagraphPropertySource = (target: Paragraph, source: Paragraph
   if (candidate) {
     paragraphPropertySourceCandidates.set(target, candidate);
   }
+  const token = paragraphPropertySourceTokens.get(source);
+  if (token) {
+    paragraphPropertySourceTokens.set(target, token);
+  }
 };
+
+/** Bind parsed body paragraphs to one exact source package. */
+export const assignDocumentParagraphPropertySourceContract = (
+  document: Document,
+  sourceDigest: string,
+): void => {
+  const contract = contractForDigest(sourceDigest);
+  setDocumentParagraphPropertySourceContract(document, contract);
+  let ordinal = 0;
+  // The traversal is part of the v1 durable identity contract. Any ordering
+  // change requires a token-version bump and collaboration reseed.
+  visitDocumentStoryParagraphs(document.package.document.content, (paragraph) => {
+    paragraphPropertySourceTokens.set(paragraph, tokenForOrdinal(contract, ordinal));
+    ordinal += 1;
+  });
+};
+
+export const getDocumentParagraphPropertySourceContract = (
+  document: Document,
+): string | undefined => {
+  if (!Object.hasOwn(document, documentParagraphPropertySourceContract)) {
+    return undefined;
+  }
+  const contract = Reflect.get(document, documentParagraphPropertySourceContract);
+  if (typeof contract !== "string" || !fingerprintFromContract(contract)) {
+    panic("The document carries an invalid paragraph-property source contract");
+  }
+  return contract;
+};
+
+export const getProseDocumentParagraphPropertySourceContract = (
+  document: PMNode,
+): string | null => {
+  const contract = document.attrs[PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR];
+  return typeof contract === "string" && fingerprintFromContract(contract) ? contract : null;
+};
+
+export const getProseParagraphPropertySourceToken = (paragraph: PMNode): unknown =>
+  paragraph.attrs[PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR];
+
+export const copyDocumentParagraphPropertySourceContract = (
+  target: Document,
+  source: Document,
+): void => {
+  const contract = getDocumentParagraphPropertySourceContract(source);
+  if (contract) {
+    setDocumentParagraphPropertySourceContract(target, contract);
+  }
+};
+
+export const getParagraphPropertySourceToken = (paragraph: Paragraph): string | undefined =>
+  paragraphPropertySourceTokens.get(paragraph);
 
 type ParagraphCloneOverrides = Omit<Partial<Paragraph>, "type">;
 
@@ -96,6 +254,38 @@ export const cloneDocumentWithParagraphPropertySources = (document: Document): D
     }
     copyParagraphPropertySource(target, source);
   }
+  copyDocumentParagraphPropertySourceContract(cloned, document);
+  return cloned;
+};
+
+const paragraphsInTableCells = (cells: TableCell[]): Paragraph[] => {
+  const paragraphs: Paragraph[] = [];
+  for (const cell of cells) {
+    visitDocxParagraphs({ documentBody: { content: cell.content } }, (paragraph) =>
+      paragraphs.push(paragraph),
+    );
+  }
+  return paragraphs;
+};
+
+/**
+ * Clone package-crossing vertical-merge payloads with their captured `w:pPr`,
+ * but without the durable paragraph tokens owned by the source package.
+ */
+export const cloneTableCellsWithParagraphPropertyCaptures = (cells: TableCell[]): TableCell[] => {
+  const cloned = structuredClone(cells);
+  const sources = paragraphsInTableCells(cells);
+  const targets = paragraphsInTableCells(cloned);
+  if (sources.length !== targets.length) {
+    panic("The cloned table cells changed paragraph graph ownership.");
+  }
+  for (const [index, source] of sources.entries()) {
+    const target = targets.at(index);
+    if (!target) {
+      panic("The cloned table cells lost a paragraph owner.");
+    }
+    copyParagraphPropertyCapture(target, source);
+  }
   return cloned;
 };
 
@@ -110,6 +300,91 @@ export const linkProseParagraphPropertySource = (
     );
   }
 };
+
+type CreateProseParagraphOptions = {
+  attrs?: PMNode["attrs"];
+  content?: Fragment | PMNode | readonly PMNode[] | null;
+  marks?: readonly Mark[];
+};
+
+/** Create a parsed paragraph with both its same-process owner and durable body token. */
+export const createProseParagraphWithPropertySource = (
+  nodeType: NodeType | undefined,
+  sourceParagraph: Paragraph,
+  options: CreateProseParagraphOptions = {},
+): PMNode => {
+  if (!nodeType || nodeType.name !== "paragraph") {
+    panic("Paragraph-property provenance can only seed a paragraph node");
+  }
+  const paragraph = nodeType.create(
+    {
+      ...options.attrs,
+      [PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR]:
+        paragraphPropertySourceTokens.get(sourceParagraph) ?? null,
+    },
+    options.content,
+    options.marks,
+  );
+  linkProseParagraphPropertySource(paragraph, sourceParagraph);
+  return paragraph;
+};
+
+type ParagraphPropertySourceTransfer = {
+  displacedToken: string | null;
+  selectedToken: string | null;
+};
+
+const paragraphPropertySourceTransfersKey = new PluginKey<
+  readonly ParagraphPropertySourceTransfer[]
+>("paragraphPropertySourceTransfers");
+
+type JoinProseParagraphsWithRightPropertySourceOptions = {
+  attrs: PMNode["attrs"];
+  pos: number;
+  transaction: Transaction;
+};
+
+/** Join adjacent paragraphs when revision semantics deliberately select the right owner. */
+export const joinProseParagraphsWithRightPropertySource = ({
+  attrs,
+  pos,
+  transaction,
+}: JoinProseParagraphsWithRightPropertySourceOptions): Transaction => {
+  const $pos = transaction.doc.resolve(pos);
+  const left = $pos.nodeBefore;
+  const right = $pos.nodeAfter;
+  if (!left || !right || left.type.name !== "paragraph" || right.type.name !== "paragraph") {
+    panic("Paragraph-property ownership can only join adjacent paragraphs");
+  }
+  const leftToken = getProseParagraphPropertySourceToken(left);
+  const rightToken = getProseParagraphPropertySourceToken(right);
+  const leftPos = pos - left.nodeSize;
+  transaction.join(pos);
+  const joined = transaction.doc.nodeAt(leftPos);
+  if (!joined || joined.type.name !== "paragraph") {
+    panic("Joining paragraphs did not produce a paragraph");
+  }
+  transaction.setNodeMarkup(
+    leftPos,
+    undefined,
+    { ...attrs, [PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR]: rightToken ?? null },
+    joined.marks,
+  );
+  const transfers = transaction.getMeta(paragraphPropertySourceTransfersKey) ?? [];
+  transaction.setMeta(paragraphPropertySourceTransfersKey, [
+    ...transfers,
+    {
+      displacedToken: typeof leftToken === "string" ? leftToken : null,
+      selectedToken: typeof rightToken === "string" ? rightToken : null,
+    },
+  ]);
+  return transaction;
+};
+
+export const getExplicitParagraphPropertySourceTransfers = (
+  transaction: Transaction,
+): readonly ParagraphPropertySourceTransfer[] =>
+  transaction.getMeta(paragraphPropertySourceTransfersKey) ?? [];
 
 /** Carry a parser-linked paragraph owner across an immutable PM node rebuild. */
 const copyProseParagraphPropertySource = (target: PMNode, source: PMNode): void => {
@@ -140,6 +415,25 @@ export const recreateProseNodeWithParagraphPropertySource = (
   );
   copyProseParagraphPropertySource(target, source);
   return target;
+};
+
+/**
+ * Rebuild a PM node that is crossing from another package: retain its
+ * same-process paragraph-property capture, but detach the durable token that
+ * can only name a paragraph in the package it came from.
+ */
+export const recreateProseNodeWithDetachedParagraphPropertySource = (
+  source: PMNode,
+  options: RecreateProseNodeOptions = {},
+): PMNode => {
+  const attrs = options.attrs ?? source.attrs;
+  return recreateProseNodeWithParagraphPropertySource(source, {
+    ...options,
+    attrs:
+      source.type.name === "paragraph"
+        ? { ...attrs, [PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR]: null }
+        : attrs,
+  });
 };
 
 type SetProseParagraphMarkupOptions = {
@@ -191,6 +485,10 @@ export const transferProseParagraphPropertySource = (
 };
 
 export const linkParagraphPropertySourceCandidate = (target: Paragraph, source: PMNode): void => {
+  const token = source.attrs[PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR];
+  if (typeof token === "string") {
+    paragraphPropertySourceTokens.set(target, token);
+  }
   const sourceOwner = proseParagraphSourceOwners.get(source);
   if (sourceOwner) {
     paragraphPropertySourceCandidates.set(target, sourceOwner);

--- a/packages/core/src/docx/paragraphPropertySource.ts
+++ b/packages/core/src/docx/paragraphPropertySource.ts
@@ -16,11 +16,21 @@ const proseParagraphSourceOwners = new WeakMap<PMNode, Paragraph>();
 const paragraphPropertySourceCandidates = new WeakMap<Paragraph, Paragraph>();
 const paragraphPropertySourceTransferIds = new WeakMap<Paragraph, string>();
 const paragraphPropertySourceTokens = new WeakMap<Paragraph, string>();
+const documentParagraphPropertySourceBindingBrand = Symbol(
+  "documentParagraphPropertySourceBinding",
+);
 // Enumerable symbols follow ordinary immutable `{ ...document }` derivations,
 // while JSON and other string-key serialization cannot expose the contract.
 // `structuredClone` deliberately drops symbols, so the one sanctioned deep
 // clone path transfers this value explicitly below.
-const documentParagraphPropertySourceContract = Symbol("paragraphPropertySourceContract");
+const documentParagraphPropertySourceBinding = Symbol("paragraphPropertySourceBinding");
+
+type DocumentParagraphPropertySourceBinding = Readonly<{
+  [documentParagraphPropertySourceBindingBrand]: true;
+  contract: string;
+  sourceOwners: ReadonlySet<Paragraph>;
+  sources: ReadonlyMap<string, Paragraph>;
+}>;
 
 export const PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR = "_docxParagraphSourceToken";
 export const PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR = "_docxParagraphSourceContract";
@@ -69,20 +79,37 @@ const tokenForOrdinal = (contract: string, ordinal: number): string => {
   return `${PARAGRAPH_SOURCE_TOKEN_PREFIX}:${fingerprint}:${ordinal.toString(36)}`;
 };
 
-const setDocumentParagraphPropertySourceContract = (document: Document, contract: string): void => {
-  if (!fingerprintFromContract(contract)) {
+const isDocumentParagraphPropertySourceBinding = (
+  value: unknown,
+): value is DocumentParagraphPropertySourceBinding =>
+  typeof value === "object" &&
+  value !== null &&
+  documentParagraphPropertySourceBindingBrand in value &&
+  value[documentParagraphPropertySourceBindingBrand] === true &&
+  "contract" in value &&
+  typeof value.contract === "string" &&
+  "sourceOwners" in value &&
+  value.sourceOwners instanceof Set &&
+  "sources" in value &&
+  value.sources instanceof Map;
+
+const setDocumentParagraphPropertySourceBinding = (
+  document: Document,
+  binding: DocumentParagraphPropertySourceBinding,
+): void => {
+  if (!fingerprintFromContract(binding.contract)) {
     panic("Cannot attach an invalid paragraph-property source contract");
   }
-  const existing = Object.hasOwn(document, documentParagraphPropertySourceContract)
-    ? Reflect.get(document, documentParagraphPropertySourceContract)
+  const existing: unknown = Object.hasOwn(document, documentParagraphPropertySourceBinding)
+    ? Reflect.get(document, documentParagraphPropertySourceBinding)
     : undefined;
-  if (existing === contract) {
+  if (existing === binding) {
     return;
   }
   if (
-    !Reflect.defineProperty(document, documentParagraphPropertySourceContract, {
+    !Reflect.defineProperty(document, documentParagraphPropertySourceBinding, {
       enumerable: true,
-      value: contract,
+      value: binding,
     })
   ) {
     panic("Cannot attach the paragraph-property source contract to the document");
@@ -156,27 +183,61 @@ export const assignDocumentParagraphPropertySourceContract = (
   sourceDigest: string,
 ): void => {
   const contract = contractForDigest(sourceDigest);
-  setDocumentParagraphPropertySourceContract(document, contract);
+  const sources = new Map<string, Paragraph>();
   let ordinal = 0;
   // The traversal is part of the v1 durable identity contract. Any ordering
   // change requires a token-version bump and collaboration reseed.
   visitDocumentStoryParagraphs(document.package.document.content, (paragraph) => {
-    paragraphPropertySourceTokens.set(paragraph, tokenForOrdinal(contract, ordinal));
+    const token = tokenForOrdinal(contract, ordinal);
+    paragraphPropertySourceTokens.set(paragraph, token);
+    sources.set(token, paragraph);
     ordinal += 1;
   });
+  setDocumentParagraphPropertySourceBinding(
+    document,
+    Object.freeze({
+      [documentParagraphPropertySourceBindingBrand]: true,
+      contract,
+      sourceOwners: new Set(sources.values()),
+      sources,
+    }),
+  );
+};
+
+const getDocumentParagraphPropertySourceBinding = (
+  document: Document,
+): DocumentParagraphPropertySourceBinding | undefined => {
+  if (!Object.hasOwn(document, documentParagraphPropertySourceBinding)) {
+    return undefined;
+  }
+  const binding: unknown = Reflect.get(document, documentParagraphPropertySourceBinding);
+  if (
+    !isDocumentParagraphPropertySourceBinding(binding) ||
+    !fingerprintFromContract(binding.contract)
+  ) {
+    panic("The document carries an invalid paragraph-property source contract");
+  }
+  return binding;
 };
 
 export const getDocumentParagraphPropertySourceContract = (
   document: Document,
-): string | undefined => {
-  if (!Object.hasOwn(document, documentParagraphPropertySourceContract)) {
-    return undefined;
-  }
-  const contract = Reflect.get(document, documentParagraphPropertySourceContract);
-  if (typeof contract !== "string" || !fingerprintFromContract(contract)) {
-    panic("The document carries an invalid paragraph-property source contract");
-  }
-  return contract;
+): string | undefined => getDocumentParagraphPropertySourceBinding(document)?.contract;
+
+export const copyDocumentParagraphPropertySources = (
+  document: Document,
+): Map<string, Paragraph> | undefined => {
+  const sources = getDocumentParagraphPropertySourceBinding(document)?.sources;
+  return sources ? new Map(sources) : undefined;
+};
+
+export const paragraphPropertySourceBelongsToDocument = (
+  paragraph: Paragraph,
+  document: Document,
+): boolean => {
+  const owner = paragraphPropertySourceOwners.get(paragraph);
+  const binding = getDocumentParagraphPropertySourceBinding(document);
+  return owner !== undefined && binding !== undefined && binding.sourceOwners.has(owner);
 };
 
 export const getProseDocumentParagraphPropertySourceContract = (
@@ -193,9 +254,9 @@ export const copyDocumentParagraphPropertySourceContract = (
   target: Document,
   source: Document,
 ): void => {
-  const contract = getDocumentParagraphPropertySourceContract(source);
-  if (contract) {
-    setDocumentParagraphPropertySourceContract(target, contract);
+  const binding = getDocumentParagraphPropertySourceBinding(source);
+  if (binding) {
+    setDocumentParagraphPropertySourceBinding(target, binding);
   }
 };
 

--- a/packages/core/src/docx/paragraphPropertySource.ts
+++ b/packages/core/src/docx/paragraphPropertySource.ts
@@ -34,6 +34,8 @@ type DocumentParagraphPropertySourceBinding = Readonly<{
 
 export const PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR = "_docxParagraphSourceToken";
 export const PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR = "_docxParagraphSourceContract";
+/** Durable identity nested inside opaque collapsed-cell ProseMirror attrs; stripped on restore. */
+export const TABLE_CELL_PARAGRAPH_SOURCE_BINDING_ATTR = "_docxParagraphSourceBinding";
 
 const PARAGRAPH_SOURCE_TOKEN_VERSION = "folio-ppr-v1";
 const PARAGRAPH_SOURCE_TOKEN_PREFIX = "p1d";
@@ -329,6 +331,187 @@ const paragraphsInTableCells = (cells: TableCell[]): Paragraph[] => {
   return paragraphs;
 };
 
+type TableCellParagraphPropertySourceBinding =
+  | Readonly<{ type: "authored" }>
+  | Readonly<{ token: string; type: "source" }>;
+
+export type TableCellParagraphPropertySourceBindingInspection =
+  | { status: "absent" }
+  | { binding: Readonly<{ type: "authored" }>; status: "authored" }
+  | { binding: Readonly<{ token: string; type: "source" }>; status: "source" }
+  | { status: "invalid"; value: unknown };
+
+const isPropertySourceBindingRecord = (
+  value: unknown,
+): value is Record<PropertyKey, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const inspectTableCellParagraphPropertySourceBinding = (
+  paragraph: Paragraph,
+): TableCellParagraphPropertySourceBindingInspection => {
+  if (!Object.hasOwn(paragraph, TABLE_CELL_PARAGRAPH_SOURCE_BINDING_ATTR)) {
+    return { status: "absent" };
+  }
+  const value: unknown = Reflect.get(paragraph, TABLE_CELL_PARAGRAPH_SOURCE_BINDING_ATTR);
+  if (!isPropertySourceBindingRecord(value)) {
+    return { status: "invalid", value };
+  }
+  const keys = Reflect.ownKeys(value);
+  if (
+    keys.length === 1 &&
+    keys[0] === "type" &&
+    Object.hasOwn(value, "type") &&
+    value.type === "authored"
+  ) {
+    return { binding: { type: "authored" }, status: "authored" };
+  }
+  if (
+    keys.length === 2 &&
+    keys.includes("type") &&
+    keys.includes("token") &&
+    Object.hasOwn(value, "type") &&
+    value.type === "source" &&
+    Object.hasOwn(value, "token") &&
+    typeof value.token === "string"
+  ) {
+    return { binding: { token: value.token, type: "source" }, status: "source" };
+  }
+  return { status: "invalid", value };
+};
+
+const setTableCellParagraphPropertySourceBinding = (
+  paragraph: Paragraph,
+  binding: TableCellParagraphPropertySourceBinding,
+): void => {
+  if (
+    !Reflect.set(
+      paragraph,
+      TABLE_CELL_PARAGRAPH_SOURCE_BINDING_ATTR,
+      Object.freeze(binding),
+    )
+  ) {
+    panic("Cannot attach paragraph-property transport identity to a table cell.");
+  }
+};
+
+const tableCellParagraphPropertySourceBindingForTransport = (
+  paragraph: Paragraph,
+  inspection: TableCellParagraphPropertySourceBindingInspection,
+): TableCellParagraphPropertySourceBinding => {
+  const directToken = paragraphPropertySourceTokens.get(paragraph);
+  if (directToken !== undefined) {
+    if (!isParagraphPropertySourceToken(directToken)) {
+      panic("Cannot transport a malformed private paragraph-property source token.");
+    }
+    switch (inspection.status) {
+      case "absent":
+        return { token: directToken, type: "source" };
+      case "authored":
+        panic("A hidden paragraph-property source binding conflicts with its private owner.");
+      case "source":
+        if (inspection.binding.token !== directToken) {
+          panic("A hidden paragraph-property source binding conflicts with its private owner.");
+        }
+        return inspection.binding;
+      case "invalid":
+        panic("Cannot transport a malformed hidden paragraph-property source binding.");
+      default: {
+        const exhaustiveInspection: never = inspection;
+        return exhaustiveInspection;
+      }
+    }
+  }
+  switch (inspection.status) {
+    case "absent":
+      // Transport is the construction boundary where an unbound paragraph is
+      // explicitly classified as newly authored.
+      return { type: "authored" };
+    case "authored":
+      return inspection.binding;
+    case "source":
+      if (!isParagraphPropertySourceToken(inspection.binding.token)) {
+        panic("Cannot transport a malformed hidden paragraph-property source token.");
+      }
+      return inspection.binding;
+    case "invalid":
+      panic("Cannot transport a malformed hidden paragraph-property source binding.");
+    default: {
+      const exhaustiveInspection: never = inspection;
+      return exhaustiveInspection;
+    }
+  }
+};
+
+type CloneTableCellParagraphPropertySourcesMode = "restore" | "transport";
+
+const cloneTableCellsWithParagraphPropertySources = (
+  cells: TableCell[],
+  mode: CloneTableCellParagraphPropertySourcesMode,
+): TableCell[] => {
+  const cloned = structuredClone(cells);
+  const sources = paragraphsInTableCells(cells);
+  const targets = paragraphsInTableCells(cloned);
+  if (sources.length !== targets.length) {
+    panic("The cloned table cells changed paragraph graph ownership.");
+  }
+  for (const [index, source] of sources.entries()) {
+    const target = targets.at(index);
+    if (!target) {
+      panic("The cloned table cells lost a paragraph owner.");
+    }
+    copyParagraphPropertyCapture(target, source);
+    const inspection = inspectTableCellParagraphPropertySourceBinding(source);
+    if (mode === "transport") {
+      setTableCellParagraphPropertySourceBinding(
+        target,
+        tableCellParagraphPropertySourceBindingForTransport(source, inspection),
+      );
+      continue;
+    }
+    if (!Reflect.deleteProperty(target, TABLE_CELL_PARAGRAPH_SOURCE_BINDING_ATTR)) {
+      panic("Cannot detach paragraph-property transport identity from a table cell.");
+    }
+    switch (inspection.status) {
+      case "authored":
+        break;
+      case "source":
+        if (!isParagraphPropertySourceToken(inspection.binding.token)) {
+          panic("Cannot restore a malformed hidden paragraph-property source token.");
+        }
+        paragraphPropertySourceTokens.set(target, inspection.binding.token);
+        break;
+      case "absent":
+      case "invalid":
+        panic("Cannot restore a hidden paragraph without a valid source binding.");
+      default: {
+        const exhaustiveInspection: never = inspection;
+        return exhaustiveInspection;
+      }
+    }
+  }
+  return cloned;
+};
+
+/** Prepare opaque continuation cells for ProseMirror and Yjs transport. */
+export const transportTableCellsWithParagraphPropertySources = (
+  cells: TableCell[],
+): TableCell[] => cloneTableCellsWithParagraphPropertySources(cells, "transport");
+
+/** Restore transported identities privately and remove them from the document model. */
+export const restoreTableCellsWithParagraphPropertySources = (
+  cells: TableCell[],
+): TableCell[] => cloneTableCellsWithParagraphPropertySources(cells, "restore");
+
+/** Visit every transported hidden paragraph in canonical cell-story order. */
+export const visitTableCellParagraphPropertySourceBindings = (
+  cells: TableCell[],
+  visit: (inspection: TableCellParagraphPropertySourceBindingInspection) => void,
+): void => {
+  for (const paragraph of paragraphsInTableCells(cells)) {
+    visit(inspectTableCellParagraphPropertySourceBinding(paragraph));
+  }
+};
+
 /**
  * Clone package-crossing vertical-merge payloads with their captured `w:pPr`,
  * but without the durable paragraph tokens owned by the source package.
@@ -346,6 +529,7 @@ export const cloneTableCellsWithParagraphPropertyCaptures = (cells: TableCell[])
       panic("The cloned table cells lost a paragraph owner.");
     }
     copyParagraphPropertyCapture(target, source);
+    setTableCellParagraphPropertySourceBinding(target, { type: "authored" });
   }
   return cloned;
 };

--- a/packages/core/src/docx/paragraphPropertySource.ts
+++ b/packages/core/src/docx/paragraphPropertySource.ts
@@ -200,7 +200,7 @@ export const assignDocumentParagraphPropertySourceContract = (
       contract,
       sourceOwners: new Set(sources.values()),
       sources,
-    }),
+    } satisfies DocumentParagraphPropertySourceBinding),
   );
 };
 

--- a/packages/core/src/docx/paragraphPropertySource.ts
+++ b/packages/core/src/docx/paragraphPropertySource.ts
@@ -373,7 +373,7 @@ type TableCellParagraphPropertySourceBindingInspection =
   | { binding: Readonly<{ token: string; type: "source" }>; status: "source" }
   | { status: "invalid" };
 
-const isPropertySourceBindingRecord = (value: unknown): value is Record<PropertyKey, unknown> =>
+const isPropertySourceBindingRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
 const inspectTableCellParagraphPropertySourceBinding = (
@@ -391,7 +391,7 @@ const inspectTableCellParagraphPropertySourceBinding = (
     keys.length === 1 &&
     keys[0] === "type" &&
     Object.hasOwn(value, "type") &&
-    value.type === "authored"
+    value["type"] === "authored"
   ) {
     return { binding: { type: "authored" }, status: "authored" };
   }
@@ -400,11 +400,11 @@ const inspectTableCellParagraphPropertySourceBinding = (
     keys.includes("type") &&
     keys.includes("token") &&
     Object.hasOwn(value, "type") &&
-    value.type === "source" &&
+    value["type"] === "source" &&
     Object.hasOwn(value, "token") &&
-    typeof value.token === "string"
+    typeof value["token"] === "string"
   ) {
-    return { binding: { token: value.token, type: "source" }, status: "source" };
+    return { binding: { token: value["token"], type: "source" }, status: "source" };
   }
   return { status: "invalid" };
 };
@@ -553,17 +553,17 @@ const inspectTableCellParagraphSourceGraph = (
     return;
   }
   if (typeof value !== "object") {
-    invalidTableCellParagraphSourcePayload("invalid_graph_value", path);
+    return invalidTableCellParagraphSourcePayload("invalid_graph_value", path);
   }
   if (context.seen.has(value)) {
-    invalidTableCellParagraphSourcePayload("cyclic_or_aliased_graph", path);
+    return invalidTableCellParagraphSourcePayload("cyclic_or_aliased_graph", path);
   }
   context.seen.add(value);
   context.objects.push(value);
 
   const prototype = Object.getPrototypeOf(value);
   if (!Array.isArray(value) && prototype !== Object.prototype && prototype !== null) {
-    invalidTableCellParagraphSourcePayload("invalid_graph_value", path);
+    return invalidTableCellParagraphSourcePayload("invalid_graph_value", path);
   }
 
   for (const key of Reflect.ownKeys(value)) {
@@ -576,16 +576,16 @@ const inspectTableCellParagraphSourceGraph = (
     let childPath = `${path}.*`;
     if (Array.isArray(value)) {
       if (typeof key !== "string" || !ARRAY_INDEX.test(key)) {
-        invalidTableCellParagraphSourcePayload("invalid_graph_value", `${path}[*]`);
+        return invalidTableCellParagraphSourcePayload("invalid_graph_value", `${path}[*]`);
       }
       childPath = `${path}[${key}]`;
     }
     if (typeof key !== "string") {
-      invalidTableCellParagraphSourcePayload("invalid_graph_value", childPath);
+      return invalidTableCellParagraphSourcePayload("invalid_graph_value", childPath);
     }
     const descriptor = Object.getOwnPropertyDescriptor(value, key);
     if (descriptor === undefined || !descriptor.enumerable || !("value" in descriptor)) {
-      invalidTableCellParagraphSourcePayload("invalid_graph_value", childPath);
+      return invalidTableCellParagraphSourcePayload("invalid_graph_value", childPath);
     }
     inspectTableCellParagraphSourceGraph(descriptor.value, childPath, depth + 1, context);
   }
@@ -593,7 +593,7 @@ const inspectTableCellParagraphSourceGraph = (
 
 const tableCellParagraphSourceArray = (value: unknown, path: string): unknown[] => {
   if (!Array.isArray(value)) {
-    invalidTableCellParagraphSourcePayload("expected_array", path);
+    return invalidTableCellParagraphSourcePayload("expected_array", path);
   }
   return value;
 };
@@ -610,22 +610,22 @@ const tableCellParagraphSourceRecord = (
     | "expected_record"
     | "expected_row"
   >,
-): Record<PropertyKey, unknown> => {
+): Record<string, unknown> => {
   if (!isPropertySourceBindingRecord(value)) {
-    invalidTableCellParagraphSourcePayload(classification, path);
+    return invalidTableCellParagraphSourcePayload(classification, path);
   }
   return value;
 };
 
 const isDecodedTableCellParagraph = (value: unknown): value is Paragraph =>
   isPropertySourceBindingRecord(value) &&
-  value.type === "paragraph" &&
-  Array.isArray(value.content);
+  value["type"] === "paragraph" &&
+  Array.isArray(value["content"]);
 
 const isDecodedTableCell = (value: unknown): value is TableCell =>
   isPropertySourceBindingRecord(value) &&
-  value.type === "tableCell" &&
-  Array.isArray(value.content);
+  value["type"] === "tableCell" &&
+  Array.isArray(value["content"]);
 
 const visitDecodedTableCellRunContent = (
   value: unknown,
@@ -633,24 +633,22 @@ const visitDecodedTableCellRunContent = (
   context: TableCellParagraphSourceDecodeContext,
 ): void => {
   const content = tableCellParagraphSourceRecord(value, path, "expected_inline_content");
-  if (!isTableCellRunContentType(content.type)) {
-    invalidTableCellParagraphSourcePayload("invalid_inline_content_type", path);
+  const contentType = content["type"];
+  if (!isTableCellRunContentType(contentType)) {
+    return invalidTableCellParagraphSourcePayload("invalid_inline_content_type", path);
   }
-  const traversal = tableCellRunContentTraversalByType[content.type];
+  const traversal = tableCellRunContentTraversalByType[contentType];
   switch (traversal) {
     case "shape": {
       const shapePath = `${path}.shape`;
-      const shape = tableCellParagraphSourceRecord(content.shape, shapePath, "expected_record");
-      if (shape.textBody === undefined || shape.textBody === null) {
+      const shape = tableCellParagraphSourceRecord(content["shape"], shapePath, "expected_record");
+      const rawTextBody = shape["textBody"];
+      if (rawTextBody === undefined || rawTextBody === null) {
         return;
       }
       const textBodyPath = `${shapePath}.textBody`;
-      const textBody = tableCellParagraphSourceRecord(
-        shape.textBody,
-        textBodyPath,
-        "expected_record",
-      );
-      const blocks = tableCellParagraphSourceArray(textBody.content, `${textBodyPath}.content`);
+      const textBody = tableCellParagraphSourceRecord(rawTextBody, textBodyPath, "expected_record");
+      const blocks = tableCellParagraphSourceArray(textBody["content"], `${textBodyPath}.content`);
       for (const [index, block] of blocks.entries()) {
         visitDecodedTableCellBlock(block, `${textBodyPath}.content[${index}]`, context);
       }
@@ -666,11 +664,11 @@ const visitDecodedTableCellRunContent = (
 };
 
 const visitDecodedTableCellRun = (
-  run: Record<PropertyKey, unknown>,
+  run: Record<string, unknown>,
   path: string,
   context: TableCellParagraphSourceDecodeContext,
 ): void => {
-  const content = tableCellParagraphSourceArray(run.content, `${path}.content`);
+  const content = tableCellParagraphSourceArray(run["content"], `${path}.content`);
   for (const [index, item] of content.entries()) {
     visitDecodedTableCellRunContent(item, `${path}.content[${index}]`, context);
   }
@@ -682,23 +680,24 @@ const visitDecodedTableCellInlineContent = (
   context: TableCellParagraphSourceDecodeContext,
 ): void => {
   const content = tableCellParagraphSourceRecord(value, path, "expected_inline_content");
-  if (!isTableCellParagraphContentType(content.type)) {
-    invalidTableCellParagraphSourcePayload("invalid_inline_content_type", path);
+  const contentType = content["type"];
+  if (!isTableCellParagraphContentType(contentType)) {
+    return invalidTableCellParagraphSourcePayload("invalid_inline_content_type", path);
   }
-  const traversal = tableCellParagraphContentTraversalByType[content.type];
+  const traversal = tableCellParagraphContentTraversalByType[contentType];
   switch (traversal) {
     case "run":
       visitDecodedTableCellRun(content, path, context);
       return;
     case "children": {
-      const children = tableCellParagraphSourceArray(content.children, `${path}.children`);
+      const children = tableCellParagraphSourceArray(content["children"], `${path}.children`);
       for (const [index, child] of children.entries()) {
         visitDecodedTableCellInlineContent(child, `${path}.children[${index}]`, context);
       }
       return;
     }
     case "content": {
-      const children = tableCellParagraphSourceArray(content.content, `${path}.content`);
+      const children = tableCellParagraphSourceArray(content["content"], `${path}.content`);
       for (const [index, child] of children.entries()) {
         visitDecodedTableCellInlineContent(child, `${path}.content[${index}]`, context);
       }
@@ -710,8 +709,8 @@ const visitDecodedTableCellInlineContent = (
         for (const [index, runValue] of runs.entries()) {
           const runPath = `${path}.${field}[${index}]`;
           const run = tableCellParagraphSourceRecord(runValue, runPath, "expected_inline_content");
-          if (run.type !== "run") {
-            invalidTableCellParagraphSourcePayload("invalid_inline_content_type", runPath);
+          if (run["type"] !== "run") {
+            return invalidTableCellParagraphSourcePayload("invalid_inline_content_type", runPath);
           }
           visitDecodedTableCellRun(run, runPath, context);
         }
@@ -728,15 +727,15 @@ const visitDecodedTableCellInlineContent = (
 };
 
 const visitDecodedTableCellParagraph = (
-  paragraph: Record<PropertyKey, unknown>,
+  paragraph: Record<string, unknown>,
   path: string,
   context: TableCellParagraphSourceDecodeContext,
 ): void => {
-  if (paragraph.type !== "paragraph") {
-    invalidTableCellParagraphSourcePayload("invalid_paragraph_type", path);
+  if (paragraph["type"] !== "paragraph") {
+    return invalidTableCellParagraphSourcePayload("invalid_paragraph_type", path);
   }
   if (!isDecodedTableCellParagraph(paragraph)) {
-    invalidTableCellParagraphSourcePayload("expected_paragraph", path);
+    return invalidTableCellParagraphSourcePayload("expected_paragraph", path);
   }
   const inspection = inspectTableCellParagraphPropertySourceBinding(paragraph);
   switch (inspection.status) {
@@ -759,7 +758,7 @@ const visitDecodedTableCellParagraph = (
       break;
     case "absent":
     case "invalid":
-      invalidTableCellParagraphSourcePayload(
+      return invalidTableCellParagraphSourcePayload(
         "invalid_binding",
         `${path}.${TABLE_CELL_PARAGRAPH_SOURCE_BINDING_ATTR}`,
       );
@@ -780,15 +779,15 @@ const visitDecodedTableCell = (
   context: TableCellParagraphSourceDecodeContext,
 ): TableCell => {
   const cell = tableCellParagraphSourceRecord(value, path, "expected_cell");
-  if (cell.type !== "tableCell") {
-    invalidTableCellParagraphSourcePayload("invalid_cell_type", path);
+  if (cell["type"] !== "tableCell") {
+    return invalidTableCellParagraphSourcePayload("invalid_cell_type", path);
   }
-  const content = tableCellParagraphSourceArray(cell.content, `${path}.content`);
+  const content = tableCellParagraphSourceArray(cell["content"], `${path}.content`);
   for (const [index, block] of content.entries()) {
     visitDecodedTableCellBlock(block, `${path}.content[${index}]`, context);
   }
   if (!isDecodedTableCell(cell)) {
-    invalidTableCellParagraphSourcePayload("expected_cell", path);
+    return invalidTableCellParagraphSourcePayload("expected_cell", path);
   }
   return cell;
 };
@@ -799,10 +798,10 @@ const visitDecodedTableCellRow = (
   context: TableCellParagraphSourceDecodeContext,
 ): void => {
   const row = tableCellParagraphSourceRecord(value, path, "expected_row");
-  if (row.type !== "tableRow") {
-    invalidTableCellParagraphSourcePayload("invalid_row_type", path);
+  if (row["type"] !== "tableRow") {
+    return invalidTableCellParagraphSourcePayload("invalid_row_type", path);
   }
-  const cells = tableCellParagraphSourceArray(row.cells, `${path}.cells`);
+  const cells = tableCellParagraphSourceArray(row["cells"], `${path}.cells`);
   for (const [index, cell] of cells.entries()) {
     visitDecodedTableCell(cell, `${path}.cells[${index}]`, context);
   }
@@ -814,23 +813,24 @@ function visitDecodedTableCellBlock(
   context: TableCellParagraphSourceDecodeContext,
 ): void {
   const block = tableCellParagraphSourceRecord(value, path, "expected_block");
-  if (!isTableCellBlockContentType(block.type)) {
-    invalidTableCellParagraphSourcePayload("invalid_block_type", path);
+  const blockType = block["type"];
+  if (!isTableCellBlockContentType(blockType)) {
+    return invalidTableCellParagraphSourcePayload("invalid_block_type", path);
   }
-  const traversal = tableCellBlockTraversalByType[block.type];
+  const traversal = tableCellBlockTraversalByType[blockType];
   switch (traversal) {
     case "paragraph":
       visitDecodedTableCellParagraph(block, path, context);
       return;
     case "table": {
-      const rows = tableCellParagraphSourceArray(block.rows, `${path}.rows`);
+      const rows = tableCellParagraphSourceArray(block["rows"], `${path}.rows`);
       for (const [index, row] of rows.entries()) {
         visitDecodedTableCellRow(row, `${path}.rows[${index}]`, context);
       }
       return;
     }
     case "blockSdt": {
-      const content = tableCellParagraphSourceArray(block.content, `${path}.content`);
+      const content = tableCellParagraphSourceArray(block["content"], `${path}.content`);
       for (const [index, child] of content.entries()) {
         visitDecodedTableCellBlock(child, `${path}.content[${index}]`, context);
       }
@@ -940,7 +940,7 @@ export const decodeTableCellParagraphSourcePayload = (
     ) {
       throw error;
     }
-    invalidTableCellParagraphSourcePayload("invalid_graph_value", "continuationCells");
+    return invalidTableCellParagraphSourcePayload("invalid_graph_value", "continuationCells");
   }
 };
 

--- a/packages/core/src/docx/paragraphPropertySource.ts
+++ b/packages/core/src/docx/paragraphPropertySource.ts
@@ -2,7 +2,14 @@ import { panic, TaggedError } from "better-result";
 import type { Fragment, Mark, Node as PMNode, NodeType } from "prosemirror-model";
 import { PluginKey, type Transaction } from "prosemirror-state";
 
-import type { Document, Paragraph, TableCell } from "../types/document";
+import type {
+  BlockContent,
+  Document,
+  Paragraph,
+  ParagraphContent,
+  RunContent,
+  TableCell,
+} from "../types/document";
 import { visitDocxParagraphs } from "./paragraphTraversal";
 
 type ParagraphPropertySource = {
@@ -52,12 +59,37 @@ export const PARAGRAPH_PROPERTY_SOURCE_VALIDATION_CODES = [
 export type ParagraphPropertySourceValidationCode =
   (typeof PARAGRAPH_PROPERTY_SOURCE_VALIDATION_CODES)[number];
 
+export const TABLE_CELL_PARAGRAPH_SOURCE_PAYLOAD_ERROR_CLASSIFICATIONS = [
+  "complexity_limit",
+  "cyclic_or_aliased_graph",
+  "depth_limit",
+  "expected_array",
+  "expected_block",
+  "expected_cell",
+  "expected_inline_content",
+  "expected_paragraph",
+  "expected_record",
+  "expected_row",
+  "invalid_binding",
+  "invalid_block_type",
+  "invalid_cell_type",
+  "invalid_graph_value",
+  "invalid_inline_content_type",
+  "invalid_paragraph_type",
+  "invalid_row_type",
+  "malformed_source_token",
+] as const;
+
+export type TableCellParagraphSourcePayloadErrorClassification =
+  (typeof TABLE_CELL_PARAGRAPH_SOURCE_PAYLOAD_ERROR_CLASSIFICATIONS)[number];
+
 export class ParagraphPropertySourceValidationError extends TaggedError(
   "ParagraphPropertySourceValidationError",
 )<{
   code: ParagraphPropertySourceValidationCode;
+  classification?: TableCellParagraphSourcePayloadErrorClassification;
   message: string;
-  token?: unknown;
+  path?: string;
 }> {}
 
 const contractForDigest = (sourceDigest: string): string => {
@@ -321,7 +353,7 @@ export const cloneDocumentWithParagraphPropertySources = (document: Document): D
   return cloned;
 };
 
-const paragraphsInTableCells = (cells: TableCell[]): Paragraph[] => {
+const paragraphsInTableCells = (cells: readonly TableCell[]): Paragraph[] => {
   const paragraphs: Paragraph[] = [];
   for (const cell of cells) {
     visitDocxParagraphs({ documentBody: { content: cell.content } }, (paragraph) =>
@@ -331,19 +363,17 @@ const paragraphsInTableCells = (cells: TableCell[]): Paragraph[] => {
   return paragraphs;
 };
 
-type TableCellParagraphPropertySourceBinding =
+export type TableCellParagraphPropertySourceBinding =
   | Readonly<{ type: "authored" }>
   | Readonly<{ token: string; type: "source" }>;
 
-export type TableCellParagraphPropertySourceBindingInspection =
+type TableCellParagraphPropertySourceBindingInspection =
   | { status: "absent" }
   | { binding: Readonly<{ type: "authored" }>; status: "authored" }
   | { binding: Readonly<{ token: string; type: "source" }>; status: "source" }
-  | { status: "invalid"; value: unknown };
+  | { status: "invalid" };
 
-const isPropertySourceBindingRecord = (
-  value: unknown,
-): value is Record<PropertyKey, unknown> =>
+const isPropertySourceBindingRecord = (value: unknown): value is Record<PropertyKey, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
 const inspectTableCellParagraphPropertySourceBinding = (
@@ -354,7 +384,7 @@ const inspectTableCellParagraphPropertySourceBinding = (
   }
   const value: unknown = Reflect.get(paragraph, TABLE_CELL_PARAGRAPH_SOURCE_BINDING_ATTR);
   if (!isPropertySourceBindingRecord(value)) {
-    return { status: "invalid", value };
+    return { status: "invalid" };
   }
   const keys = Reflect.ownKeys(value);
   if (
@@ -376,20 +406,549 @@ const inspectTableCellParagraphPropertySourceBinding = (
   ) {
     return { binding: { token: value.token, type: "source" }, status: "source" };
   }
-  return { status: "invalid", value };
+  return { status: "invalid" };
+};
+
+const TABLE_CELL_PARAGRAPH_SOURCE_MAX_DEPTH = 128;
+const TABLE_CELL_PARAGRAPH_SOURCE_MAX_VALUES = 100_000;
+const ARRAY_INDEX = /^(?:0|[1-9][0-9]*)$/;
+
+const tableCellParagraphSourcePayloadMessages = {
+  complexity_limit: "The hidden table-cell payload exceeds its complexity limit.",
+  cyclic_or_aliased_graph: "The hidden table-cell payload contains a cyclic or aliased graph.",
+  depth_limit: "The hidden table-cell payload exceeds its nesting limit.",
+  expected_array: "The hidden table-cell payload field must be an array.",
+  expected_block: "The hidden table-cell payload contains a malformed block.",
+  expected_cell: "The hidden table-cell payload contains a malformed cell.",
+  expected_inline_content: "The hidden table-cell payload contains malformed inline content.",
+  expected_paragraph: "The hidden table-cell payload contains a malformed paragraph.",
+  expected_record: "The hidden table-cell payload contains a malformed object.",
+  expected_row: "The hidden table-cell payload contains a malformed row.",
+  invalid_binding: "A hidden table-cell paragraph has an invalid source binding.",
+  invalid_block_type: "The hidden table-cell payload contains an unsupported block type.",
+  invalid_cell_type: "The hidden table-cell payload contains an invalid cell type.",
+  invalid_graph_value: "The hidden table-cell payload contains an invalid graph value.",
+  invalid_inline_content_type:
+    "The hidden table-cell payload contains an unsupported inline content type.",
+  invalid_paragraph_type: "The hidden table-cell payload contains an invalid paragraph type.",
+  invalid_row_type: "The hidden table-cell payload contains an invalid row type.",
+  malformed_source_token: "A hidden table-cell paragraph has a malformed source token.",
+} as const satisfies Record<TableCellParagraphSourcePayloadErrorClassification, string>;
+const tableCellParagraphSourceValidationErrors =
+  new WeakSet<ParagraphPropertySourceValidationError>();
+
+const invalidTableCellParagraphSourcePayload = (
+  classification: TableCellParagraphSourcePayloadErrorClassification,
+  path: string,
+): never => {
+  const error = new ParagraphPropertySourceValidationError({
+    code: "invalid_token",
+    classification,
+    message: tableCellParagraphSourcePayloadMessages[classification],
+    path,
+  });
+  tableCellParagraphSourceValidationErrors.add(error);
+  throw error;
+};
+
+type TableCellParagraphSourceDecodeContext = {
+  paragraphs: Array<{
+    binding: TableCellParagraphPropertySourceBinding;
+    paragraph: Paragraph;
+    path: string;
+  }>;
+};
+
+type TableCellParagraphSourceGraphContext = {
+  objects: object[];
+  seen: WeakSet<object>;
+  values: number;
+};
+
+type TableCellBlockTraversal = "blockSdt" | "paragraph" | "table";
+
+const tableCellBlockTraversalByType = {
+  blockSdt: "blockSdt",
+  paragraph: "paragraph",
+  table: "table",
+} as const satisfies Record<BlockContent["type"], TableCellBlockTraversal>;
+
+type TableCellParagraphContentTraversal = "children" | "complexField" | "content" | "leaf" | "run";
+
+const tableCellParagraphContentTraversalByType = {
+  bookmarkEnd: "leaf",
+  bookmarkStart: "leaf",
+  commentRangeEnd: "leaf",
+  commentRangeStart: "leaf",
+  commentReference: "leaf",
+  complexField: "complexField",
+  deletion: "content",
+  hyperlink: "children",
+  inlineSdt: "content",
+  insertion: "content",
+  mathEquation: "leaf",
+  moveFrom: "content",
+  moveFromRangeEnd: "leaf",
+  moveFromRangeStart: "leaf",
+  moveTo: "content",
+  moveToRangeEnd: "leaf",
+  moveToRangeStart: "leaf",
+  run: "run",
+  simpleField: "content",
+} as const satisfies Record<ParagraphContent["type"], TableCellParagraphContentTraversal>;
+
+type TableCellRunContentTraversal = "leaf" | "shape";
+
+const tableCellRunContentTraversalByType = {
+  break: "leaf",
+  drawing: "leaf",
+  endnoteRef: "leaf",
+  fieldChar: "leaf",
+  footnoteRef: "leaf",
+  instrText: "leaf",
+  noBreakHyphen: "leaf",
+  renderedPageBreak: "leaf",
+  shape: "shape",
+  softHyphen: "leaf",
+  symbol: "leaf",
+  tab: "leaf",
+  text: "leaf",
+} as const satisfies Record<RunContent["type"], TableCellRunContentTraversal>;
+
+const isTableCellBlockContentType = (
+  value: unknown,
+): value is keyof typeof tableCellBlockTraversalByType =>
+  typeof value === "string" && Object.hasOwn(tableCellBlockTraversalByType, value);
+
+const isTableCellParagraphContentType = (
+  value: unknown,
+): value is keyof typeof tableCellParagraphContentTraversalByType =>
+  typeof value === "string" && Object.hasOwn(tableCellParagraphContentTraversalByType, value);
+
+const isTableCellRunContentType = (
+  value: unknown,
+): value is keyof typeof tableCellRunContentTraversalByType =>
+  typeof value === "string" && Object.hasOwn(tableCellRunContentTraversalByType, value);
+
+const inspectTableCellParagraphSourceGraph = (
+  value: unknown,
+  path: string,
+  depth: number,
+  context: TableCellParagraphSourceGraphContext,
+): void => {
+  if (depth > TABLE_CELL_PARAGRAPH_SOURCE_MAX_DEPTH) {
+    invalidTableCellParagraphSourcePayload("depth_limit", path);
+  }
+  context.values += 1;
+  if (context.values > TABLE_CELL_PARAGRAPH_SOURCE_MAX_VALUES) {
+    invalidTableCellParagraphSourcePayload("complexity_limit", path);
+  }
+  if (
+    value === null ||
+    value === undefined ||
+    typeof value === "boolean" ||
+    typeof value === "number" ||
+    typeof value === "string"
+  ) {
+    return;
+  }
+  if (typeof value !== "object") {
+    invalidTableCellParagraphSourcePayload("invalid_graph_value", path);
+  }
+  if (context.seen.has(value)) {
+    invalidTableCellParagraphSourcePayload("cyclic_or_aliased_graph", path);
+  }
+  context.seen.add(value);
+  context.objects.push(value);
+
+  const prototype = Object.getPrototypeOf(value);
+  if (!Array.isArray(value) && prototype !== Object.prototype && prototype !== null) {
+    invalidTableCellParagraphSourcePayload("invalid_graph_value", path);
+  }
+
+  for (const key of Reflect.ownKeys(value)) {
+    if (Array.isArray(value) && key === "length") {
+      if (value.length > TABLE_CELL_PARAGRAPH_SOURCE_MAX_VALUES) {
+        invalidTableCellParagraphSourcePayload("complexity_limit", path);
+      }
+      continue;
+    }
+    let childPath = `${path}.*`;
+    if (Array.isArray(value)) {
+      if (typeof key !== "string" || !ARRAY_INDEX.test(key)) {
+        invalidTableCellParagraphSourcePayload("invalid_graph_value", `${path}[*]`);
+      }
+      childPath = `${path}[${key}]`;
+    }
+    if (typeof key !== "string") {
+      invalidTableCellParagraphSourcePayload("invalid_graph_value", childPath);
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (descriptor === undefined || !descriptor.enumerable || !("value" in descriptor)) {
+      invalidTableCellParagraphSourcePayload("invalid_graph_value", childPath);
+    }
+    inspectTableCellParagraphSourceGraph(descriptor.value, childPath, depth + 1, context);
+  }
+};
+
+const tableCellParagraphSourceArray = (value: unknown, path: string): unknown[] => {
+  if (!Array.isArray(value)) {
+    invalidTableCellParagraphSourcePayload("expected_array", path);
+  }
+  return value;
+};
+
+const tableCellParagraphSourceRecord = (
+  value: unknown,
+  path: string,
+  classification: Extract<
+    TableCellParagraphSourcePayloadErrorClassification,
+    | "expected_block"
+    | "expected_cell"
+    | "expected_inline_content"
+    | "expected_paragraph"
+    | "expected_record"
+    | "expected_row"
+  >,
+): Record<PropertyKey, unknown> => {
+  if (!isPropertySourceBindingRecord(value)) {
+    invalidTableCellParagraphSourcePayload(classification, path);
+  }
+  return value;
+};
+
+const isDecodedTableCellParagraph = (value: unknown): value is Paragraph =>
+  isPropertySourceBindingRecord(value) &&
+  value.type === "paragraph" &&
+  Array.isArray(value.content);
+
+const isDecodedTableCell = (value: unknown): value is TableCell =>
+  isPropertySourceBindingRecord(value) &&
+  value.type === "tableCell" &&
+  Array.isArray(value.content);
+
+const visitDecodedTableCellRunContent = (
+  value: unknown,
+  path: string,
+  context: TableCellParagraphSourceDecodeContext,
+): void => {
+  const content = tableCellParagraphSourceRecord(value, path, "expected_inline_content");
+  if (!isTableCellRunContentType(content.type)) {
+    invalidTableCellParagraphSourcePayload("invalid_inline_content_type", path);
+  }
+  const traversal = tableCellRunContentTraversalByType[content.type];
+  switch (traversal) {
+    case "shape": {
+      const shapePath = `${path}.shape`;
+      const shape = tableCellParagraphSourceRecord(content.shape, shapePath, "expected_record");
+      if (shape.textBody === undefined || shape.textBody === null) {
+        return;
+      }
+      const textBodyPath = `${shapePath}.textBody`;
+      const textBody = tableCellParagraphSourceRecord(
+        shape.textBody,
+        textBodyPath,
+        "expected_record",
+      );
+      const blocks = tableCellParagraphSourceArray(textBody.content, `${textBodyPath}.content`);
+      for (const [index, block] of blocks.entries()) {
+        visitDecodedTableCellBlock(block, `${textBodyPath}.content[${index}]`, context);
+      }
+      return;
+    }
+    case "leaf":
+      return;
+    default: {
+      const exhaustiveTraversal: never = traversal;
+      return exhaustiveTraversal;
+    }
+  }
+};
+
+const visitDecodedTableCellRun = (
+  run: Record<PropertyKey, unknown>,
+  path: string,
+  context: TableCellParagraphSourceDecodeContext,
+): void => {
+  const content = tableCellParagraphSourceArray(run.content, `${path}.content`);
+  for (const [index, item] of content.entries()) {
+    visitDecodedTableCellRunContent(item, `${path}.content[${index}]`, context);
+  }
+};
+
+const visitDecodedTableCellInlineContent = (
+  value: unknown,
+  path: string,
+  context: TableCellParagraphSourceDecodeContext,
+): void => {
+  const content = tableCellParagraphSourceRecord(value, path, "expected_inline_content");
+  if (!isTableCellParagraphContentType(content.type)) {
+    invalidTableCellParagraphSourcePayload("invalid_inline_content_type", path);
+  }
+  const traversal = tableCellParagraphContentTraversalByType[content.type];
+  switch (traversal) {
+    case "run":
+      visitDecodedTableCellRun(content, path, context);
+      return;
+    case "children": {
+      const children = tableCellParagraphSourceArray(content.children, `${path}.children`);
+      for (const [index, child] of children.entries()) {
+        visitDecodedTableCellInlineContent(child, `${path}.children[${index}]`, context);
+      }
+      return;
+    }
+    case "content": {
+      const children = tableCellParagraphSourceArray(content.content, `${path}.content`);
+      for (const [index, child] of children.entries()) {
+        visitDecodedTableCellInlineContent(child, `${path}.content[${index}]`, context);
+      }
+      return;
+    }
+    case "complexField": {
+      for (const field of ["fieldCode", "fieldResult"] as const) {
+        const runs = tableCellParagraphSourceArray(content[field], `${path}.${field}`);
+        for (const [index, runValue] of runs.entries()) {
+          const runPath = `${path}.${field}[${index}]`;
+          const run = tableCellParagraphSourceRecord(runValue, runPath, "expected_inline_content");
+          if (run.type !== "run") {
+            invalidTableCellParagraphSourcePayload("invalid_inline_content_type", runPath);
+          }
+          visitDecodedTableCellRun(run, runPath, context);
+        }
+      }
+      return;
+    }
+    case "leaf":
+      return;
+    default: {
+      const exhaustiveTraversal: never = traversal;
+      return exhaustiveTraversal;
+    }
+  }
+};
+
+const visitDecodedTableCellParagraph = (
+  paragraph: Record<PropertyKey, unknown>,
+  path: string,
+  context: TableCellParagraphSourceDecodeContext,
+): void => {
+  if (paragraph.type !== "paragraph") {
+    invalidTableCellParagraphSourcePayload("invalid_paragraph_type", path);
+  }
+  if (!isDecodedTableCellParagraph(paragraph)) {
+    invalidTableCellParagraphSourcePayload("expected_paragraph", path);
+  }
+  const inspection = inspectTableCellParagraphPropertySourceBinding(paragraph);
+  switch (inspection.status) {
+    case "authored":
+    case "source":
+      if (
+        inspection.status === "source" &&
+        !isParagraphPropertySourceToken(inspection.binding.token)
+      ) {
+        invalidTableCellParagraphSourcePayload(
+          "malformed_source_token",
+          `${path}.${TABLE_CELL_PARAGRAPH_SOURCE_BINDING_ATTR}.token`,
+        );
+      }
+      context.paragraphs.push({
+        binding: inspection.binding,
+        paragraph,
+        path,
+      });
+      break;
+    case "absent":
+    case "invalid":
+      invalidTableCellParagraphSourcePayload(
+        "invalid_binding",
+        `${path}.${TABLE_CELL_PARAGRAPH_SOURCE_BINDING_ATTR}`,
+      );
+    default: {
+      const exhaustiveInspection: never = inspection;
+      return exhaustiveInspection;
+    }
+  }
+  const content = tableCellParagraphSourceArray(paragraph.content, `${path}.content`);
+  for (const [index, item] of content.entries()) {
+    visitDecodedTableCellInlineContent(item, `${path}.content[${index}]`, context);
+  }
+};
+
+const visitDecodedTableCell = (
+  value: unknown,
+  path: string,
+  context: TableCellParagraphSourceDecodeContext,
+): TableCell => {
+  const cell = tableCellParagraphSourceRecord(value, path, "expected_cell");
+  if (cell.type !== "tableCell") {
+    invalidTableCellParagraphSourcePayload("invalid_cell_type", path);
+  }
+  const content = tableCellParagraphSourceArray(cell.content, `${path}.content`);
+  for (const [index, block] of content.entries()) {
+    visitDecodedTableCellBlock(block, `${path}.content[${index}]`, context);
+  }
+  if (!isDecodedTableCell(cell)) {
+    invalidTableCellParagraphSourcePayload("expected_cell", path);
+  }
+  return cell;
+};
+
+const visitDecodedTableCellRow = (
+  value: unknown,
+  path: string,
+  context: TableCellParagraphSourceDecodeContext,
+): void => {
+  const row = tableCellParagraphSourceRecord(value, path, "expected_row");
+  if (row.type !== "tableRow") {
+    invalidTableCellParagraphSourcePayload("invalid_row_type", path);
+  }
+  const cells = tableCellParagraphSourceArray(row.cells, `${path}.cells`);
+  for (const [index, cell] of cells.entries()) {
+    visitDecodedTableCell(cell, `${path}.cells[${index}]`, context);
+  }
+};
+
+function visitDecodedTableCellBlock(
+  value: unknown,
+  path: string,
+  context: TableCellParagraphSourceDecodeContext,
+): void {
+  const block = tableCellParagraphSourceRecord(value, path, "expected_block");
+  if (!isTableCellBlockContentType(block.type)) {
+    invalidTableCellParagraphSourcePayload("invalid_block_type", path);
+  }
+  const traversal = tableCellBlockTraversalByType[block.type];
+  switch (traversal) {
+    case "paragraph":
+      visitDecodedTableCellParagraph(block, path, context);
+      return;
+    case "table": {
+      const rows = tableCellParagraphSourceArray(block.rows, `${path}.rows`);
+      for (const [index, row] of rows.entries()) {
+        visitDecodedTableCellRow(row, `${path}.rows[${index}]`, context);
+      }
+      return;
+    }
+    case "blockSdt": {
+      const content = tableCellParagraphSourceArray(block.content, `${path}.content`);
+      for (const [index, child] of content.entries()) {
+        visitDecodedTableCellBlock(child, `${path}.content[${index}]`, context);
+      }
+      return;
+    }
+    default: {
+      const exhaustiveTraversal: never = traversal;
+      return exhaustiveTraversal;
+    }
+  }
+}
+
+const decodedTableCellParagraphSourcePayloadBrand = Symbol(
+  "decodedTableCellParagraphSourcePayload",
+);
+
+export type DecodedTableCellParagraphSourcePayload = Readonly<{
+  [decodedTableCellParagraphSourcePayloadBrand]: true;
+  cells: readonly TableCell[];
+}>;
+
+type DecodedTableCellParagraphSourcePayloadState = Readonly<{
+  paragraphs: readonly Readonly<{
+    binding: TableCellParagraphPropertySourceBinding;
+    paragraph: Paragraph;
+    path: string;
+  }>[];
+}>;
+
+const decodedTableCellParagraphSourcePayloadStates = new WeakMap<
+  DecodedTableCellParagraphSourcePayload,
+  DecodedTableCellParagraphSourcePayloadState
+>();
+const decodedTableCellParagraphSourcePayloads = new WeakMap<
+  object,
+  DecodedTableCellParagraphSourcePayload
+>();
+
+const decodedTableCellParagraphSourcePayloadState = (
+  payload: DecodedTableCellParagraphSourcePayload,
+): DecodedTableCellParagraphSourcePayloadState => {
+  const state = decodedTableCellParagraphSourcePayloadStates.get(payload);
+  if (!state) {
+    panic("A collapsed-cell paragraph source payload bypassed its decoder.");
+  }
+  return state;
+};
+
+const decodeTableCellParagraphSourcePayloadUnchecked = (
+  value: unknown,
+): DecodedTableCellParagraphSourcePayload => {
+  const graphContext: TableCellParagraphSourceGraphContext = {
+    objects: [],
+    seen: new WeakSet(),
+    values: 0,
+  };
+  inspectTableCellParagraphSourceGraph(value, "continuationCells", 0, graphContext);
+
+  const context: TableCellParagraphSourceDecodeContext = {
+    paragraphs: [],
+  };
+  const rawCells = tableCellParagraphSourceArray(value, "continuationCells");
+  const cells: TableCell[] = [];
+  for (const [index, rawCell] of rawCells.entries()) {
+    cells.push(visitDecodedTableCell(rawCell, `continuationCells[${index}]`, context));
+  }
+
+  let object = graphContext.objects.pop();
+  while (object) {
+    Object.freeze(object);
+    object = graphContext.objects.pop();
+  }
+  const payload = Object.freeze({
+    [decodedTableCellParagraphSourcePayloadBrand]: true,
+    cells: Object.freeze(cells),
+  } satisfies DecodedTableCellParagraphSourcePayload);
+  decodedTableCellParagraphSourcePayloadStates.set(
+    payload,
+    Object.freeze({
+      paragraphs: Object.freeze(context.paragraphs.map((entry) => Object.freeze(entry))),
+    } satisfies DecodedTableCellParagraphSourcePayloadState),
+  );
+  decodedTableCellParagraphSourcePayloads.set(payload.cells, payload);
+  return payload;
+};
+
+/** Decode and freeze the opaque collapsed-cell wire payload before typed use. */
+export const decodeTableCellParagraphSourcePayload = (
+  value: unknown,
+): DecodedTableCellParagraphSourcePayload => {
+  if (typeof value === "object" && value !== null) {
+    const decoded = decodedTableCellParagraphSourcePayloads.get(value);
+    if (decoded) {
+      return decoded;
+    }
+  }
+  try {
+    const decoded = decodeTableCellParagraphSourcePayloadUnchecked(value);
+    if (typeof value === "object" && value !== null) {
+      decodedTableCellParagraphSourcePayloads.set(value, decoded);
+    }
+    return decoded;
+  } catch (error) {
+    if (
+      error instanceof ParagraphPropertySourceValidationError &&
+      tableCellParagraphSourceValidationErrors.has(error)
+    ) {
+      throw error;
+    }
+    invalidTableCellParagraphSourcePayload("invalid_graph_value", "continuationCells");
+  }
 };
 
 const setTableCellParagraphPropertySourceBinding = (
   paragraph: Paragraph,
   binding: TableCellParagraphPropertySourceBinding,
 ): void => {
-  if (
-    !Reflect.set(
-      paragraph,
-      TABLE_CELL_PARAGRAPH_SOURCE_BINDING_ATTR,
-      Object.freeze(binding),
-    )
-  ) {
+  if (!Reflect.set(paragraph, TABLE_CELL_PARAGRAPH_SOURCE_BINDING_ATTR, Object.freeze(binding))) {
     panic("Cannot attach paragraph-property transport identity to a table cell.");
   }
 };
@@ -442,11 +1001,9 @@ const tableCellParagraphPropertySourceBindingForTransport = (
   }
 };
 
-type CloneTableCellParagraphPropertySourcesMode = "restore" | "transport";
-
-const cloneTableCellsWithParagraphPropertySources = (
+/** Prepare opaque continuation cells for ProseMirror and Yjs transport. */
+export const transportTableCellsWithParagraphPropertySources = (
   cells: TableCell[],
-  mode: CloneTableCellParagraphPropertySourcesMode,
 ): TableCell[] => {
   const cloned = structuredClone(cells);
   const sources = paragraphsInTableCells(cells);
@@ -461,54 +1018,56 @@ const cloneTableCellsWithParagraphPropertySources = (
     }
     copyParagraphPropertyCapture(target, source);
     const inspection = inspectTableCellParagraphPropertySourceBinding(source);
-    if (mode === "transport") {
-      setTableCellParagraphPropertySourceBinding(
-        target,
-        tableCellParagraphPropertySourceBindingForTransport(source, inspection),
-      );
-      continue;
+    setTableCellParagraphPropertySourceBinding(
+      target,
+      tableCellParagraphPropertySourceBindingForTransport(source, inspection),
+    );
+  }
+  return cloned;
+};
+
+/** Restore decoded identities privately and remove them from the document model. */
+export const restoreTableCellsWithParagraphPropertySources = (
+  payload: DecodedTableCellParagraphSourcePayload,
+): TableCell[] => {
+  const sourceEntries = decodedTableCellParagraphSourcePayloadState(payload).paragraphs;
+  const cloned = structuredClone([...payload.cells]);
+  const targets = paragraphsInTableCells(cloned);
+  if (sourceEntries.length !== targets.length) {
+    panic("The cloned table cells changed paragraph graph ownership.");
+  }
+  for (const [index, sourceEntry] of sourceEntries.entries()) {
+    const target = targets.at(index);
+    if (!target) {
+      panic("The cloned table cells lost a paragraph owner.");
     }
+    const { paragraph: source } = sourceEntry;
+    copyParagraphPropertyCapture(target, source);
     if (!Reflect.deleteProperty(target, TABLE_CELL_PARAGRAPH_SOURCE_BINDING_ATTR)) {
       panic("Cannot detach paragraph-property transport identity from a table cell.");
     }
-    switch (inspection.status) {
+    switch (sourceEntry.binding.type) {
       case "authored":
         break;
       case "source":
-        if (!isParagraphPropertySourceToken(inspection.binding.token)) {
-          panic("Cannot restore a malformed hidden paragraph-property source token.");
-        }
-        paragraphPropertySourceTokens.set(target, inspection.binding.token);
+        paragraphPropertySourceTokens.set(target, sourceEntry.binding.token);
         break;
-      case "absent":
-      case "invalid":
-        panic("Cannot restore a hidden paragraph without a valid source binding.");
       default: {
-        const exhaustiveInspection: never = inspection;
-        return exhaustiveInspection;
+        const exhaustiveBinding: never = sourceEntry.binding;
+        return exhaustiveBinding;
       }
     }
   }
   return cloned;
 };
 
-/** Prepare opaque continuation cells for ProseMirror and Yjs transport. */
-export const transportTableCellsWithParagraphPropertySources = (
-  cells: TableCell[],
-): TableCell[] => cloneTableCellsWithParagraphPropertySources(cells, "transport");
-
-/** Restore transported identities privately and remove them from the document model. */
-export const restoreTableCellsWithParagraphPropertySources = (
-  cells: TableCell[],
-): TableCell[] => cloneTableCellsWithParagraphPropertySources(cells, "restore");
-
 /** Visit every transported hidden paragraph in canonical cell-story order. */
 export const visitTableCellParagraphPropertySourceBindings = (
-  cells: TableCell[],
-  visit: (inspection: TableCellParagraphPropertySourceBindingInspection) => void,
+  payload: DecodedTableCellParagraphSourcePayload,
+  visit: (binding: TableCellParagraphPropertySourceBinding, path: string) => void,
 ): void => {
-  for (const paragraph of paragraphsInTableCells(cells)) {
-    visit(inspectTableCellParagraphPropertySourceBinding(paragraph));
+  for (const { binding, path } of decodedTableCellParagraphSourcePayloadState(payload).paragraphs) {
+    visit(binding, path);
   }
 };
 
@@ -516,19 +1075,21 @@ export const visitTableCellParagraphPropertySourceBindings = (
  * Clone package-crossing vertical-merge payloads with their captured `w:pPr`,
  * but without the durable paragraph tokens owned by the source package.
  */
-export const cloneTableCellsWithParagraphPropertyCaptures = (cells: TableCell[]): TableCell[] => {
-  const cloned = structuredClone(cells);
-  const sources = paragraphsInTableCells(cells);
+export const cloneTableCellsWithParagraphPropertyCaptures = (
+  payload: DecodedTableCellParagraphSourcePayload,
+): TableCell[] => {
+  const sourceEntries = decodedTableCellParagraphSourcePayloadState(payload).paragraphs;
+  const cloned = structuredClone([...payload.cells]);
   const targets = paragraphsInTableCells(cloned);
-  if (sources.length !== targets.length) {
+  if (sourceEntries.length !== targets.length) {
     panic("The cloned table cells changed paragraph graph ownership.");
   }
-  for (const [index, source] of sources.entries()) {
+  for (const [index, sourceEntry] of sourceEntries.entries()) {
     const target = targets.at(index);
     if (!target) {
       panic("The cloned table cells lost a paragraph owner.");
     }
-    copyParagraphPropertyCapture(target, source);
+    copyParagraphPropertyCapture(target, sourceEntry.paragraph);
     setTableCellParagraphPropertySourceBinding(target, { type: "authored" });
   }
   return cloned;

--- a/packages/core/src/docx/parser.ts
+++ b/packages/core/src/docx/parser.ts
@@ -63,6 +63,7 @@ import { renderEmfSvg } from "./metafileSvg";
 import { enforcePackageVmlPreviewBudget } from "./vmlPreview";
 import { parseNumbering } from "./numberingParser";
 import { parseFontTable } from "./fontTableParser";
+import { assignDocumentParagraphPropertySourceContract } from "./paragraphPropertySource";
 import type { NumberingMap } from "./numberingParser";
 import { normalizeNumberingReferences } from "./numberingReferenceNormalization";
 import { parseRelationships, RELATIONSHIP_TYPES, resolveRelativePath } from "./relsParser";
@@ -79,6 +80,15 @@ import type { DocxUnzipOptions, RawDocxContent } from "./unzip";
 const EMF_MIME_TYPE = "image/x-emf";
 const SVG_MIME_TYPE = "image/svg+xml";
 const MAX_PACKAGE_EMF_PREVIEW_BYTES = 8 * 1024 * 1024;
+
+const sha256Hex = async (buffer: ArrayBuffer): Promise<string> => {
+  const bytes = new Uint8Array(await crypto.subtle.digest("SHA-256", buffer));
+  let digest = "";
+  for (const byte of bytes) {
+    digest += byte.toString(16).padStart(2, "0");
+  }
+  return digest;
+};
 
 // ============================================================================
 // PROGRESS CALLBACK
@@ -154,6 +164,8 @@ export async function parseDocx(input: DocxInput, options: ParseOptions = {}): P
     const timeStage = <T>(_name: string, fn: () => T): T => fn();
 
     const timeStageAsync = async <T>(_name: string, fn: () => Promise<T>): Promise<T> => await fn();
+
+    const paragraphPropertySourceDigest = sha256Hex(buffer);
 
     // ========================================================================
     // STAGE 1: Unzip DOCX package (0-10%)
@@ -439,6 +451,7 @@ export async function parseDocx(input: DocxInput, options: ParseOptions = {}): P
       ...(templateVariables !== undefined ? { templateVariables } : {}),
       ...(requiredFonts.length > 0 ? { requiredFonts } : {}),
     };
+    assignDocumentParagraphPropertySourceContract(document, await paragraphPropertySourceDigest);
     enforcePackageVmlPreviewBudget(document.package);
 
     const validation = validateFolioDocumentModel(document);

--- a/packages/core/src/docx/server/materializeYjsDocx.test.ts
+++ b/packages/core/src/docx/server/materializeYjsDocx.test.ts
@@ -1,20 +1,29 @@
 import { describe, expect, test } from "bun:test";
 import JSZip from "jszip";
+import { history, undo } from "prosemirror-history";
 import { EditorState } from "prosemirror-state";
+import { TableMap } from "prosemirror-tables";
 import { initProseMirrorDoc, prosemirrorToYXmlFragment } from "y-prosemirror";
 import * as Y from "yjs";
 
+import { splitTrackedVerticalTableCell } from "../../ai-edits/table-cell-mutations";
 import { toProseDoc } from "../../prosemirror/conversion/toProseDoc";
+import { fromProseDoc } from "../../prosemirror/conversion/fromProseDoc";
 import { expectTableCellAttrs } from "../../prosemirror/attrs";
 import { schema } from "../../prosemirror/schema";
-import { writeYjsParagraphSourceContract } from "../../prosemirror/yjsParagraphSourceContract";
+import {
+  readYjsParagraphSourceContract,
+  withParagraphSourceContract,
+  writeYjsParagraphSourceContract,
+} from "../../prosemirror/yjsParagraphSourceContract";
 import {
   ParagraphPropertySourceValidationError,
   PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR,
   TABLE_CELL_PARAGRAPH_SOURCE_BINDING_ATTR,
+  decodeTableCellParagraphSourcePayload,
 } from "../paragraphPropertySource";
 import { parseDocx } from "../parser";
-import { createDocx, createEmptyDocx } from "../rezip";
+import { createDocx, createEmptyDocx, repackDocx } from "../rezip";
 import { createEmptyDocument } from "../../utils/createDocument";
 import { extractDocxText } from "./extractDocxText";
 import {
@@ -36,10 +45,14 @@ const encodeCollaborativeDocument = (document: EditorState["doc"]): Uint8Array =
 const decodeCollaborativeDocument = (update: Uint8Array): EditorState["doc"] => {
   const ydoc = new Y.Doc();
   Y.applyUpdate(ydoc, update);
-  const document = initProseMirrorDoc(
-    ydoc.getXmlFragment(FOLIO_YJS_PROSEMIRROR_FRAGMENT_NAME),
-    schema,
-  ).doc;
+  const contract = readYjsParagraphSourceContract(ydoc);
+  if (!contract) {
+    throw new Error("Collaborative fixture lost its paragraph source contract");
+  }
+  const document = withParagraphSourceContract(
+    initProseMirrorDoc(ydoc.getXmlFragment(FOLIO_YJS_PROSEMIRROR_FRAGMENT_NAME), schema).doc,
+    contract,
+  );
   ydoc.destroy();
   return document;
 };
@@ -86,11 +99,11 @@ const sourceWithCollapsedVerticalMergeProperties = async (): Promise<ArrayBuffer
       .replace("<w:document", '<w:document xmlns:x="urn:folio:test:paragraph-source"')
       .replace(
         /<w:body>[\s\S]*<\/w:body>/u,
-        '<w:body><w:p><w:r><w:t>Before</w:t></w:r></w:p>' +
+        "<w:body><w:p><w:r><w:t>Before</w:t></w:r></w:p>" +
           '<w:tbl><w:tblPr/><w:tblGrid><w:gridCol w:w="3600"/><w:gridCol w:w="3600"/></w:tblGrid>' +
           '<w:tr><w:tc><w:tcPr><w:tcW w:w="3600" w:type="dxa"/><w:vMerge w:val="restart"/></w:tcPr><w:p><w:r><w:t>Visible</w:t></w:r></w:p></w:tc><w:tc><w:tcPr><w:tcW w:w="3600" w:type="dxa"/></w:tcPr><w:p><w:r><w:t>Top</w:t></w:r></w:p></w:tc></w:tr>' +
           '<w:tr><w:tc><w:tcPr><w:tcW w:w="3600" w:type="dxa"/><w:vMerge/></w:tcPr><w:p><w:pPr><w:ind w:left="1440"/><x:sentinel x:id="hidden-continuation"/></w:pPr></w:p></w:tc><w:tc><w:tcPr><w:tcW w:w="3600" w:type="dxa"/></w:tcPr><w:p><w:r><w:t>Bottom</w:t></w:r></w:p></w:tc></w:tr>' +
-          '</w:tbl><w:sectPr/></w:body>',
+          "</w:tbl><w:sectPr/></w:body>",
       ),
   );
   return await zip.generateAsync({ type: "arraybuffer" });
@@ -98,15 +111,21 @@ const sourceWithCollapsedVerticalMergeProperties = async (): Promise<ArrayBuffer
 
 const collapsedContinuation = (document: EditorState["doc"]) => {
   let result:
-    | { cellPos: number; cells: NonNullable<ReturnType<typeof expectTableCellAttrs>["_docxVMergeContinuationCells"]> }
+    | {
+        cellPos: number;
+        cells: ReturnType<typeof decodeTableCellParagraphSourcePayload>["cells"];
+      }
     | undefined;
   document.descendants((node, pos) => {
     if (node.type.name !== "tableCell" && node.type.name !== "tableHeader") {
       return true;
     }
-    const cells = expectTableCellAttrs(node)._docxVMergeContinuationCells;
-    if (cells && cells.length > 0) {
-      result = { cellPos: pos, cells };
+    const value = expectTableCellAttrs(node)._docxVMergeContinuationCells;
+    if (value !== undefined && value !== null) {
+      const { cells } = decodeTableCellParagraphSourcePayload(value);
+      if (cells.length > 0) {
+        result = { cellPos: pos, cells };
+      }
     }
     return false;
   });
@@ -138,7 +157,9 @@ const HIDDEN_SOURCE_BINDING_CORRUPTIONS = [
   { expectedCode: "invalid_token", type: "absent" },
   { expectedCode: "invalid_token", type: "sourceWithoutToken" },
   { expectedCode: "invalid_token", type: "sourceWithNonStringToken" },
+  { expectedCode: "invalid_token", type: "sourceWithExtraField" },
   { expectedCode: "invalid_token", type: "authoredWithToken" },
+  { expectedCode: "invalid_token", type: "authoredWithExtraField" },
   { expectedCode: "unknown_token", type: "foreignFingerprint" },
   { expectedCode: "unknown_token", type: "unknownOrdinal" },
   { expectedCode: "duplicate_token", type: "duplicateVisibleToken" },
@@ -169,8 +190,12 @@ const corruptedHiddenBinding = ({
       return { type: "source" };
     case "sourceWithNonStringToken":
       return { token: 1, type: "source" };
+    case "sourceWithExtraField":
+      return { extra: true, token: sourceToken, type: "source" };
     case "authoredWithToken":
       return { token: sourceToken, type: "authored" };
+    case "authoredWithExtraField":
+      return { extra: true, type: "authored" };
     case "foreignFingerprint": {
       const firstCharacter = fingerprint.at(0);
       if (!firstCharacter) {
@@ -189,6 +214,85 @@ const corruptedHiddenBinding = ({
     }
   }
 };
+
+const HIDDEN_PAYLOAD_CORRUPTIONS = [
+  {
+    classification: "expected_array",
+    payload: { type: "notAnArray" },
+    type: "nonArrayPayload",
+  },
+  {
+    classification: "expected_cell",
+    payload: [null],
+    type: "nullCell",
+  },
+  {
+    classification: "invalid_cell_type",
+    payload: [{ type: "paragraph", content: [] }],
+    type: "wrongCellType",
+  },
+  {
+    classification: "expected_array",
+    payload: [{ type: "tableCell" }],
+    type: "missingCellContent",
+  },
+  {
+    classification: "expected_array",
+    payload: [{ type: "tableCell", content: null }],
+    type: "nonArrayCellContent",
+  },
+  {
+    classification: "expected_block",
+    payload: [{ type: "tableCell", content: [null] }],
+    type: "nullBlock",
+  },
+  {
+    classification: "expected_paragraph",
+    payload: [
+      {
+        type: "tableCell",
+        content: [
+          {
+            [TABLE_CELL_PARAGRAPH_SOURCE_BINDING_ATTR]: { type: "authored" },
+            type: "paragraph",
+            content: null,
+          },
+        ],
+      },
+    ],
+    type: "malformedParagraph",
+  },
+  {
+    classification: "expected_row",
+    payload: [
+      {
+        type: "tableCell",
+        content: [{ type: "table", rows: [null] }],
+      },
+    ],
+    type: "nullNestedTableRow",
+  },
+  {
+    classification: "invalid_row_type",
+    payload: [
+      {
+        type: "tableCell",
+        content: [{ type: "table", rows: [{ type: "tableCell", cells: [] }] }],
+      },
+    ],
+    type: "wrongNestedTableRowType",
+  },
+  {
+    classification: "expected_cell",
+    payload: [
+      {
+        type: "tableCell",
+        content: [{ type: "table", rows: [{ type: "tableRow", cells: [null] }] }],
+      },
+    ],
+    type: "nullNestedTableCell",
+  },
+] as const;
 
 describe("materializeYjsDocx", () => {
   test("replaces body content while preserving the source DOCX package", async () => {
@@ -269,7 +373,69 @@ describe("materializeYjsDocx", () => {
         yjsUpdate: encodeCollaborativeDocument(toProseDoc(repeatedSource)),
       });
     }
-    const outputXml = await (await JSZip.loadAsync(output)).file("word/document.xml")?.async("text");
+    const outputXml = await (
+      await JSZip.loadAsync(output)
+    )
+      .file("word/document.xml")
+      ?.async("text");
+
+    expect(outputXml).toContain('<x:sentinel x:id="hidden-continuation"/>');
+    expect(outputXml).toContain('<w:ind w:left="1440"/>');
+    expect(outputXml).not.toContain(PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR);
+    expect(outputXml).not.toContain(TABLE_CELL_PARAGRAPH_SOURCE_BINDING_ATTR);
+  });
+
+  test("restores a serialized collapsed-cell undo after an intervening save", async () => {
+    const sourceDocx = await sourceWithCollapsedVerticalMergeProperties();
+    const sourceDocument = await parseDocx(sourceDocx, { preloadFonts: false });
+    const originalState = EditorState.create({
+      doc: toProseDoc(sourceDocument),
+      plugins: [history()],
+    });
+    const { cellPos } = collapsedContinuation(originalState.doc);
+    const table = originalState.doc.child(1);
+    const tablePosition = originalState.doc.child(0).nodeSize;
+    if (table.type.name !== "table") {
+      throw new Error("Collapsed-cell fixture did not contain its expected table");
+    }
+    const rectangle = TableMap.get(table).findCell(cellPos - tablePosition - 1);
+    const edit = splitTrackedVerticalTableCell({
+      tr: originalState.tr,
+      tablePosition,
+      table,
+      rectangle,
+      revisionId: 7,
+      author: "Reviewer",
+      date: "2026-09-08T08:07:06Z",
+    });
+    if (!edit) {
+      throw new Error("Collapsed-cell fixture could not apply its split edit");
+    }
+    const editedState = originalState.apply(edit);
+    expect(editedState.doc.child(1).child(0).child(0).attrs["rowspan"]).toBe(1);
+    expect(editedState.doc.child(1).child(1).childCount).toBe(2);
+    const afterSave = fromProseDoc(editedState.doc, sourceDocument);
+    await repackDocx(afterSave);
+
+    let undoneState: EditorState | undefined;
+    expect(
+      undo(editedState, (transaction) => {
+        undoneState = editedState.apply(transaction);
+      }),
+    ).toBe(true);
+    if (!undoneState) {
+      throw new Error("Collapsed-cell fixture could not undo its edit");
+    }
+    const serializedUndo = decodeCollaborativeDocument(
+      encodeCollaborativeDocument(undoneState.doc),
+    );
+    const restored = fromProseDoc(serializedUndo, afterSave);
+    const output = await repackDocx(restored);
+    const outputXml = await (
+      await JSZip.loadAsync(output)
+    )
+      .file("word/document.xml")
+      ?.async("text");
 
     expect(outputXml).toContain('<x:sentinel x:id="hidden-continuation"/>');
     expect(outputXml).toContain('<w:ind w:left="1440"/>');
@@ -320,6 +486,39 @@ describe("materializeYjsDocx", () => {
           throw new Error("Expected a paragraph source validation cause");
         }
         expect(error.cause.code).toBe(expectedCode);
+      }
+    },
+  );
+
+  test.each(HIDDEN_PAYLOAD_CORRUPTIONS)(
+    "rejects $type malformed hidden continuation payload",
+    async ({ classification, payload }) => {
+      const sourceDocx = await sourceWithCollapsedVerticalMergeProperties();
+      const sourceDocument = await parseDocx(sourceDocx, { preloadFonts: false });
+      const initialState = EditorState.create({ doc: toProseDoc(sourceDocument) });
+      const { cellPos } = collapsedContinuation(initialState.doc);
+      const corrupted = initialState.apply(
+        initialState.tr.setNodeAttribute(cellPos, "_docxVMergeContinuationCells", payload),
+      );
+
+      try {
+        await materializeYjsDocx({
+          sourceDocx,
+          yjsUpdate: encodeCollaborativeDocument(corrupted.doc),
+        });
+        throw new Error("Expected hidden paragraph source validation to fail");
+      } catch (error) {
+        if (!(error instanceof FolioYjsDocxMaterializationError)) {
+          throw error;
+        }
+        expect(error.code).toBe("source_mismatch");
+        if (!(error.cause instanceof ParagraphPropertySourceValidationError)) {
+          throw new Error("Expected a paragraph source validation cause");
+        }
+        expect(error.cause.code).toBe("invalid_token");
+        expect(error.cause.classification).toBe(classification);
+        expect(error.cause.path?.startsWith("continuationCells")).toBe(true);
+        expect(Object.hasOwn(error.cause, "token")).toBe(false);
       }
     },
   );

--- a/packages/core/src/docx/server/materializeYjsDocx.test.ts
+++ b/packages/core/src/docx/server/materializeYjsDocx.test.ts
@@ -5,8 +5,10 @@ import { prosemirrorToYXmlFragment } from "y-prosemirror";
 import * as Y from "yjs";
 
 import { toProseDoc } from "../../prosemirror/conversion/toProseDoc";
+import { writeYjsParagraphSourceContract } from "../../prosemirror/yjsParagraphSourceContract";
+import { PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR } from "../paragraphPropertySource";
 import { parseDocx } from "../parser";
-import { createDocx } from "../rezip";
+import { createDocx, createEmptyDocx } from "../rezip";
 import { createEmptyDocument } from "../../utils/createDocument";
 import { extractDocxText } from "./extractDocxText";
 import {
@@ -16,6 +18,15 @@ import {
   materializeYjsDocx,
 } from "./materializeYjsDocx";
 
+const encodeCollaborativeDocument = (document: EditorState["doc"]): Uint8Array => {
+  const ydoc = new Y.Doc();
+  prosemirrorToYXmlFragment(document, ydoc.getXmlFragment(FOLIO_YJS_PROSEMIRROR_FRAGMENT_NAME));
+  writeYjsParagraphSourceContract(ydoc, document);
+  const update = Y.encodeStateAsUpdate(ydoc);
+  ydoc.destroy();
+  return update;
+};
+
 const createCollaborativeUpdate = async (sourceDocx: ArrayBuffer, text: string) => {
   const sourceDocument = await parseDocx(sourceDocx, { preloadFonts: false });
   const initialState = EditorState.create({ doc: toProseDoc(sourceDocument) });
@@ -23,14 +34,27 @@ const createCollaborativeUpdate = async (sourceDocx: ArrayBuffer, text: string) 
   const nextState = initialState.apply(
     initialState.tr.replaceWith(1, bodyEnd, initialState.schema.text(text)),
   );
-  const ydoc = new Y.Doc();
-  prosemirrorToYXmlFragment(
-    nextState.doc,
-    ydoc.getXmlFragment(FOLIO_YJS_PROSEMIRROR_FRAGMENT_NAME),
+  return encodeCollaborativeDocument(nextState.doc);
+};
+
+const sourceWithDistinctParagraphProperties = async (): Promise<ArrayBuffer> => {
+  const zip = await JSZip.loadAsync(await createEmptyDocx());
+  const documentXml = await zip.file("word/document.xml")?.async("text");
+  if (!documentXml) {
+    throw new Error("Generated DOCX has no main document part");
+  }
+  const paragraph = (text: string, sentinel: string, left: number, paraId?: string) =>
+    `<w:p${paraId ? ` w14:paraId="${paraId}"` : ""}><w:pPr><w:ind w:left="${String(left)}"/><x:sentinel x:id="${sentinel}"/></w:pPr><w:r><w:t>${text}</w:t></w:r></w:p>`;
+  zip.file(
+    "word/document.xml",
+    documentXml
+      .replace("<w:document", '<w:document xmlns:x="urn:folio:test:paragraph-source"')
+      .replace(
+        /<w:body>[\s\S]*<\/w:body>/u,
+        `<w:body>${paragraph("Idless", "idless", 720)}<w:tbl><w:tblPr/><w:tblGrid><w:gridCol w:w="7200"/></w:tblGrid><w:tr><w:tc><w:tcPr><w:tcW w:w="7200" w:type="dxa"/></w:tcPr>${paragraph("Duplicate A", "duplicate-a", 1440, "12345678")}</w:tc></w:tr></w:tbl>${paragraph("Duplicate B", "duplicate-b", 2160, "12345678")}<w:sectPr/></w:body>`,
+      ),
   );
-  const update = Y.encodeStateAsUpdate(ydoc);
-  ydoc.destroy();
-  return update;
+  return await zip.generateAsync({ type: "arraybuffer" });
 };
 
 describe("materializeYjsDocx", () => {
@@ -52,6 +76,42 @@ describe("materializeYjsDocx", () => {
     );
   });
 
+  test("rebinds id-less and duplicate-id paragraph properties after Yjs reconstruction", async () => {
+    const sourceDocx = await sourceWithDistinctParagraphProperties();
+    const sourceDocument = await parseDocx(sourceDocx, { preloadFonts: false });
+    const initialState = EditorState.create({ doc: toProseDoc(sourceDocument) });
+    const paragraphPositions: number[] = [];
+    initialState.doc.descendants((node, pos) => {
+      if (node.type.name === "paragraph") {
+        paragraphPositions.push(pos);
+        return false;
+      }
+      return true;
+    });
+    const transaction = initialState.tr;
+    for (const pos of paragraphPositions.toReversed()) {
+      transaction.insertText("!", pos + 1);
+    }
+    const yjsUpdate = encodeCollaborativeDocument(initialState.apply(transaction).doc);
+
+    const output = await materializeYjsDocx({ sourceDocx, yjsUpdate });
+    const outputXml = await (
+      await JSZip.loadAsync(output)
+    )
+      .file("word/document.xml")
+      ?.async("text");
+
+    expect(outputXml).toContain('<x:sentinel x:id="idless"/>');
+    expect(outputXml).toContain('<x:sentinel x:id="duplicate-a"/>');
+    expect(outputXml).toContain('<x:sentinel x:id="duplicate-b"/>');
+    expect(outputXml).toContain('<w:ind w:left="720"/>');
+    expect(outputXml).toContain('<w:ind w:left="1440"/>');
+    expect(outputXml).toContain('<w:ind w:left="2160"/>');
+    expect(outputXml).not.toContain("_docxParagraphSource");
+    expect(outputXml).not.toContain("folio-ppr-v1");
+    expect(outputXml).not.toContain("p1d:");
+  });
+
   test("rejects a state update without Folio's document fragment", async () => {
     const sourceDocx = await createDocx(createEmptyDocument());
     const ydoc = new Y.Doc();
@@ -62,6 +122,96 @@ describe("materializeYjsDocx", () => {
     await expect(materializeYjsDocx({ sourceDocx, yjsUpdate })).rejects.toMatchObject({
       _tag: "FolioYjsDocxMaterializationError",
       code: "missing_document",
+    } satisfies Partial<FolioYjsDocxMaterializationError>);
+  });
+
+  test("rejects collaboration state without its source contract", async () => {
+    const sourceDocx = await createDocx(createEmptyDocument({ initialText: "Original" }));
+    const sourceDocument = await parseDocx(sourceDocx, { preloadFonts: false });
+    const ydoc = new Y.Doc();
+    prosemirrorToYXmlFragment(
+      toProseDoc(sourceDocument),
+      ydoc.getXmlFragment(FOLIO_YJS_PROSEMIRROR_FRAGMENT_NAME),
+    );
+    const yjsUpdate = Y.encodeStateAsUpdate(ydoc);
+    ydoc.destroy();
+
+    await expect(materializeYjsDocx({ sourceDocx, yjsUpdate })).rejects.toMatchObject({
+      _tag: "FolioYjsDocxMaterializationError",
+      code: "source_mismatch",
+    } satisfies Partial<FolioYjsDocxMaterializationError>);
+  });
+
+  test("rejects collaboration state paired with a different source package", async () => {
+    const sourceDocx = await createDocx(createEmptyDocument({ initialText: "Source A" }));
+    const otherSourceDocx = await createDocx(createEmptyDocument({ initialText: "Source B" }));
+    const yjsUpdate = await createCollaborativeUpdate(sourceDocx, "Edited A");
+
+    await expect(
+      materializeYjsDocx({ sourceDocx: otherSourceDocx, yjsUpdate }),
+    ).rejects.toMatchObject({
+      _tag: "FolioYjsDocxMaterializationError",
+      code: "source_mismatch",
+    } satisfies Partial<FolioYjsDocxMaterializationError>);
+  });
+
+  test("rejects duplicated paragraph-property source tokens", async () => {
+    const sourceDocx = await sourceWithDistinctParagraphProperties();
+    const sourceDocument = await parseDocx(sourceDocx, { preloadFonts: false });
+    const initialState = EditorState.create({ doc: toProseDoc(sourceDocument) });
+    const paragraphPositions: number[] = [];
+    initialState.doc.descendants((node, pos) => {
+      if (node.type.name === "paragraph") {
+        paragraphPositions.push(pos);
+        return false;
+      }
+      return true;
+    });
+    const firstPos = paragraphPositions.at(0);
+    const secondPos = paragraphPositions.at(1);
+    if (firstPos === undefined || secondPos === undefined) {
+      throw new Error("Source fixture must contain two paragraphs");
+    }
+    const first = initialState.doc.nodeAt(firstPos);
+    const second = initialState.doc.nodeAt(secondPos);
+    if (!first || !second) {
+      throw new Error("Source fixture lost a paragraph");
+    }
+    const duplicated = initialState.apply(
+      initialState.tr.setNodeMarkup(secondPos, undefined, {
+        ...second.attrs,
+        [PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR]: first.attrs[PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR],
+      }),
+    );
+    const yjsUpdate = encodeCollaborativeDocument(duplicated.doc);
+
+    await expect(materializeYjsDocx({ sourceDocx, yjsUpdate })).rejects.toMatchObject({
+      _tag: "FolioYjsDocxMaterializationError",
+      code: "source_mismatch",
+    } satisfies Partial<FolioYjsDocxMaterializationError>);
+  });
+
+  test("rejects a well-formed token absent from the exact source", async () => {
+    const sourceDocx = await sourceWithDistinctParagraphProperties();
+    const sourceDocument = await parseDocx(sourceDocx, { preloadFonts: false });
+    const initialState = EditorState.create({ doc: toProseDoc(sourceDocument) });
+    const first = initialState.doc.child(0);
+    const sourceToken = first.attrs[PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR];
+    if (typeof sourceToken !== "string") {
+      throw new Error("Source fixture paragraph must carry a source token");
+    }
+    const unknownToken = `${sourceToken.slice(0, sourceToken.lastIndexOf(":"))}:zz`;
+    const spoofed = initialState.apply(
+      initialState.tr.setNodeMarkup(0, undefined, {
+        ...first.attrs,
+        [PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR]: unknownToken,
+      }),
+    );
+    const yjsUpdate = encodeCollaborativeDocument(spoofed.doc);
+
+    await expect(materializeYjsDocx({ sourceDocx, yjsUpdate })).rejects.toMatchObject({
+      _tag: "FolioYjsDocxMaterializationError",
+      code: "source_mismatch",
     } satisfies Partial<FolioYjsDocxMaterializationError>);
   });
 

--- a/packages/core/src/docx/server/materializeYjsDocx.test.ts
+++ b/packages/core/src/docx/server/materializeYjsDocx.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, test } from "bun:test";
 import JSZip from "jszip";
 import { EditorState } from "prosemirror-state";
-import { prosemirrorToYXmlFragment } from "y-prosemirror";
+import { initProseMirrorDoc, prosemirrorToYXmlFragment } from "y-prosemirror";
 import * as Y from "yjs";
 
 import { toProseDoc } from "../../prosemirror/conversion/toProseDoc";
+import { expectTableCellAttrs } from "../../prosemirror/attrs";
+import { schema } from "../../prosemirror/schema";
 import { writeYjsParagraphSourceContract } from "../../prosemirror/yjsParagraphSourceContract";
-import { PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR } from "../paragraphPropertySource";
+import {
+  ParagraphPropertySourceValidationError,
+  PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR,
+  TABLE_CELL_PARAGRAPH_SOURCE_BINDING_ATTR,
+} from "../paragraphPropertySource";
 import { parseDocx } from "../parser";
 import { createDocx, createEmptyDocx } from "../rezip";
 import { createEmptyDocument } from "../../utils/createDocument";
@@ -25,6 +31,17 @@ const encodeCollaborativeDocument = (document: EditorState["doc"]): Uint8Array =
   const update = Y.encodeStateAsUpdate(ydoc);
   ydoc.destroy();
   return update;
+};
+
+const decodeCollaborativeDocument = (update: Uint8Array): EditorState["doc"] => {
+  const ydoc = new Y.Doc();
+  Y.applyUpdate(ydoc, update);
+  const document = initProseMirrorDoc(
+    ydoc.getXmlFragment(FOLIO_YJS_PROSEMIRROR_FRAGMENT_NAME),
+    schema,
+  ).doc;
+  ydoc.destroy();
+  return document;
 };
 
 const createCollaborativeUpdate = async (sourceDocx: ArrayBuffer, text: string) => {
@@ -55,6 +72,122 @@ const sourceWithDistinctParagraphProperties = async (): Promise<ArrayBuffer> => 
       ),
   );
   return await zip.generateAsync({ type: "arraybuffer" });
+};
+
+const sourceWithCollapsedVerticalMergeProperties = async (): Promise<ArrayBuffer> => {
+  const zip = await JSZip.loadAsync(await createEmptyDocx());
+  const documentXml = await zip.file("word/document.xml")?.async("text");
+  if (!documentXml) {
+    throw new Error("Generated DOCX has no main document part");
+  }
+  zip.file(
+    "word/document.xml",
+    documentXml
+      .replace("<w:document", '<w:document xmlns:x="urn:folio:test:paragraph-source"')
+      .replace(
+        /<w:body>[\s\S]*<\/w:body>/u,
+        '<w:body><w:p><w:r><w:t>Before</w:t></w:r></w:p>' +
+          '<w:tbl><w:tblPr/><w:tblGrid><w:gridCol w:w="3600"/><w:gridCol w:w="3600"/></w:tblGrid>' +
+          '<w:tr><w:tc><w:tcPr><w:tcW w:w="3600" w:type="dxa"/><w:vMerge w:val="restart"/></w:tcPr><w:p><w:r><w:t>Visible</w:t></w:r></w:p></w:tc><w:tc><w:tcPr><w:tcW w:w="3600" w:type="dxa"/></w:tcPr><w:p><w:r><w:t>Top</w:t></w:r></w:p></w:tc></w:tr>' +
+          '<w:tr><w:tc><w:tcPr><w:tcW w:w="3600" w:type="dxa"/><w:vMerge/></w:tcPr><w:p><w:pPr><w:ind w:left="1440"/><x:sentinel x:id="hidden-continuation"/></w:pPr></w:p></w:tc><w:tc><w:tcPr><w:tcW w:w="3600" w:type="dxa"/></w:tcPr><w:p><w:r><w:t>Bottom</w:t></w:r></w:p></w:tc></w:tr>' +
+          '</w:tbl><w:sectPr/></w:body>',
+      ),
+  );
+  return await zip.generateAsync({ type: "arraybuffer" });
+};
+
+const collapsedContinuation = (document: EditorState["doc"]) => {
+  let result:
+    | { cellPos: number; cells: NonNullable<ReturnType<typeof expectTableCellAttrs>["_docxVMergeContinuationCells"]> }
+    | undefined;
+  document.descendants((node, pos) => {
+    if (node.type.name !== "tableCell" && node.type.name !== "tableHeader") {
+      return true;
+    }
+    const cells = expectTableCellAttrs(node)._docxVMergeContinuationCells;
+    if (cells && cells.length > 0) {
+      result = { cellPos: pos, cells };
+    }
+    return false;
+  });
+  if (!result) {
+    throw new Error("Fixture did not collapse its vertical continuation cell");
+  }
+  return result;
+};
+
+const collapsedContinuationSourceToken = (paragraph: unknown): string => {
+  if (typeof paragraph !== "object" || paragraph === null) {
+    throw new Error("Fixture did not retain its hidden continuation paragraph");
+  }
+  const binding = Reflect.get(paragraph, TABLE_CELL_PARAGRAPH_SOURCE_BINDING_ATTR);
+  if (
+    typeof binding !== "object" ||
+    binding === null ||
+    !("type" in binding) ||
+    binding.type !== "source" ||
+    !("token" in binding) ||
+    typeof binding.token !== "string"
+  ) {
+    throw new Error("Fixture hidden continuation paragraph has no source binding");
+  }
+  return binding.token;
+};
+
+const HIDDEN_SOURCE_BINDING_CORRUPTIONS = [
+  { expectedCode: "invalid_token", type: "absent" },
+  { expectedCode: "invalid_token", type: "sourceWithoutToken" },
+  { expectedCode: "invalid_token", type: "sourceWithNonStringToken" },
+  { expectedCode: "invalid_token", type: "authoredWithToken" },
+  { expectedCode: "unknown_token", type: "foreignFingerprint" },
+  { expectedCode: "unknown_token", type: "unknownOrdinal" },
+  { expectedCode: "duplicate_token", type: "duplicateVisibleToken" },
+] as const;
+
+type HiddenSourceBindingCorruption = (typeof HIDDEN_SOURCE_BINDING_CORRUPTIONS)[number]["type"];
+
+type CorruptedHiddenBindingOptions = {
+  corruption: HiddenSourceBindingCorruption;
+  sourceToken: string;
+  visibleToken: string;
+};
+
+const corruptedHiddenBinding = ({
+  corruption,
+  sourceToken,
+  visibleToken,
+}: CorruptedHiddenBindingOptions): unknown => {
+  const separator = sourceToken.lastIndexOf(":");
+  const ordinal = sourceToken.slice(separator + 1);
+  const tokenPrefix = sourceToken.slice(0, separator);
+  const fingerprintStart = tokenPrefix.indexOf(":") + 1;
+  const fingerprint = tokenPrefix.slice(fingerprintStart);
+  switch (corruption) {
+    case "absent":
+      return undefined;
+    case "sourceWithoutToken":
+      return { type: "source" };
+    case "sourceWithNonStringToken":
+      return { token: 1, type: "source" };
+    case "authoredWithToken":
+      return { token: sourceToken, type: "authored" };
+    case "foreignFingerprint": {
+      const firstCharacter = fingerprint.at(0);
+      if (!firstCharacter) {
+        throw new Error("Fixture source token has no fingerprint");
+      }
+      const foreignFingerprint = `${firstCharacter === "0" ? "1" : "0"}${fingerprint.slice(1)}`;
+      return { token: `p1d:${foreignFingerprint}:${ordinal}`, type: "source" };
+    }
+    case "unknownOrdinal":
+      return { token: `${tokenPrefix}:zz`, type: "source" };
+    case "duplicateVisibleToken":
+      return { token: visibleToken, type: "source" };
+    default: {
+      const exhaustiveCorruption: never = corruption;
+      return exhaustiveCorruption;
+    }
+  }
 };
 
 describe("materializeYjsDocx", () => {
@@ -111,6 +244,85 @@ describe("materializeYjsDocx", () => {
     expect(outputXml).not.toContain("folio-ppr-v1");
     expect(outputXml).not.toContain("p1d:");
   });
+
+  test("rebinds a collapsed vertical-merge paragraph capture across repeated Yjs saves", async () => {
+    const sourceDocx = await sourceWithCollapsedVerticalMergeProperties();
+    const sourceDocument = await parseDocx(sourceDocx, { preloadFonts: false });
+    const proseDocument = toProseDoc(sourceDocument);
+    const { cells } = collapsedContinuation(proseDocument);
+    const hiddenParagraph = cells.at(0)?.content.at(0);
+    if (hiddenParagraph?.type !== "paragraph") {
+      throw new Error("Fixture did not retain its hidden continuation paragraph");
+    }
+    const sourceToken = collapsedContinuationSourceToken(hiddenParagraph);
+
+    const yjsUpdate = encodeCollaborativeDocument(proseDocument);
+    const reconstructed = decodeCollaborativeDocument(yjsUpdate);
+    const reconstructedParagraph = collapsedContinuation(reconstructed).cells.at(0)?.content.at(0);
+    expect(collapsedContinuationSourceToken(reconstructedParagraph)).toBe(sourceToken);
+
+    let output = await materializeYjsDocx({ sourceDocx, yjsUpdate });
+    for (let repeatedSave = 0; repeatedSave < 2; repeatedSave += 1) {
+      const repeatedSource = await parseDocx(output, { preloadFonts: false });
+      output = await materializeYjsDocx({
+        sourceDocx: output,
+        yjsUpdate: encodeCollaborativeDocument(toProseDoc(repeatedSource)),
+      });
+    }
+    const outputXml = await (await JSZip.loadAsync(output)).file("word/document.xml")?.async("text");
+
+    expect(outputXml).toContain('<x:sentinel x:id="hidden-continuation"/>');
+    expect(outputXml).toContain('<w:ind w:left="1440"/>');
+    expect(outputXml).not.toContain(PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR);
+    expect(outputXml).not.toContain(TABLE_CELL_PARAGRAPH_SOURCE_BINDING_ATTR);
+  });
+
+  test.each(HIDDEN_SOURCE_BINDING_CORRUPTIONS)(
+    "rejects $type hidden continuation source binding",
+    async ({ expectedCode, type }) => {
+      const sourceDocx = await sourceWithCollapsedVerticalMergeProperties();
+      const sourceDocument = await parseDocx(sourceDocx, { preloadFonts: false });
+      const initialState = EditorState.create({ doc: toProseDoc(sourceDocument) });
+      const { cellPos, cells } = collapsedContinuation(initialState.doc);
+      const visibleToken = initialState.doc.child(0).attrs[PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR];
+      const copiedCells = structuredClone(cells);
+      const hiddenParagraph = copiedCells.at(0)?.content.at(0);
+      if (typeof visibleToken !== "string" || hiddenParagraph?.type !== "paragraph") {
+        throw new Error("Fixture did not expose both paragraph source identities");
+      }
+      const sourceToken = collapsedContinuationSourceToken(hiddenParagraph);
+      const nextParagraph = { ...hiddenParagraph };
+      const binding = corruptedHiddenBinding({ corruption: type, sourceToken, visibleToken });
+      if (binding === undefined) {
+        if (!Reflect.deleteProperty(nextParagraph, TABLE_CELL_PARAGRAPH_SOURCE_BINDING_ATTR)) {
+          throw new Error("Fixture could not remove the hidden source binding");
+        }
+      } else if (!Reflect.set(nextParagraph, TABLE_CELL_PARAGRAPH_SOURCE_BINDING_ATTR, binding)) {
+        throw new Error("Fixture could not replace the hidden source binding");
+      }
+      copiedCells[0]!.content[0] = nextParagraph;
+      const corrupted = initialState.apply(
+        initialState.tr.setNodeAttribute(cellPos, "_docxVMergeContinuationCells", copiedCells),
+      );
+
+      try {
+        await materializeYjsDocx({
+          sourceDocx,
+          yjsUpdate: encodeCollaborativeDocument(corrupted.doc),
+        });
+        throw new Error("Expected hidden paragraph source validation to fail");
+      } catch (error) {
+        if (!(error instanceof FolioYjsDocxMaterializationError)) {
+          throw error;
+        }
+        expect(error.code).toBe("source_mismatch");
+        if (!(error.cause instanceof ParagraphPropertySourceValidationError)) {
+          throw new Error("Expected a paragraph source validation cause");
+        }
+        expect(error.cause.code).toBe(expectedCode);
+      }
+    },
+  );
 
   test("rejects a state update without Folio's document fragment", async () => {
     const sourceDocx = await createDocx(createEmptyDocument());

--- a/packages/core/src/docx/server/materializeYjsDocx.ts
+++ b/packages/core/src/docx/server/materializeYjsDocx.ts
@@ -4,7 +4,12 @@ import * as Y from "yjs";
 
 import { fromProseDoc } from "../../prosemirror/conversion/fromProseDoc";
 import { schema } from "../../prosemirror/schema";
+import {
+  readYjsParagraphSourceContract,
+  withParagraphSourceContract,
+} from "../../prosemirror/yjsParagraphSourceContract";
 import { parseDocx } from "../parser";
+import { ParagraphPropertySourceValidationError } from "../paragraphPropertySource";
 import { repackDocx } from "../rezip";
 
 /** Yjs fragment that stores Folio's canonical ProseMirror document. */
@@ -18,6 +23,7 @@ export const FOLIO_YJS_DOCX_MATERIALIZATION_ERROR_CODES = [
   "empty_update",
   "invalid_update",
   "missing_document",
+  "source_mismatch",
   "update_too_large",
 ] as const;
 
@@ -67,7 +73,14 @@ const readProseMirrorDocument = (yjsUpdate: Uint8Array) => {
           message: "Yjs update does not contain a Folio document.",
         });
       }
-      return initProseMirrorDoc(fragment, schema).doc;
+      const contract = readYjsParagraphSourceContract(ydoc);
+      if (!contract) {
+        throw new FolioYjsDocxMaterializationError({
+          code: "source_mismatch",
+          message: "Yjs update does not identify its paragraph-property source document.",
+        });
+      }
+      return withParagraphSourceContract(initProseMirrorDoc(fragment, schema).doc, contract);
     },
     catch: (cause) =>
       cause instanceof FolioYjsDocxMaterializationError
@@ -96,5 +109,19 @@ export const materializeYjsDocx = async ({
 }: MaterializeYjsDocxOptions): Promise<ArrayBuffer> => {
   const proseMirrorDocument = readProseMirrorDocument(yjsUpdate);
   const baseDocument = await parseDocx(sourceDocx, { preloadFonts: false });
-  return await repackDocx(fromProseDoc(proseMirrorDocument, baseDocument));
+  const converted = Result.try({
+    try: () => fromProseDoc(proseMirrorDocument, baseDocument),
+    catch: (cause) =>
+      cause instanceof ParagraphPropertySourceValidationError
+        ? new FolioYjsDocxMaterializationError({
+            code: "source_mismatch",
+            message: "The collaboration snapshot belongs to a different source document.",
+            cause,
+          })
+        : cause,
+  });
+  if (converted.isErr()) {
+    throw converted.error;
+  }
+  return await repackDocx(converted.value);
 };

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -301,6 +301,12 @@ export const readParagraphAttrs = (node: PMNode): ReadProseMirrorAttrsResult<Par
   expectNodeType(node, "paragraph", issues);
 
   optionalString(attrs, "paraId", "paragraph.attrs.paraId", issues);
+  optionalString(
+    attrs,
+    "_docxParagraphSourceToken",
+    "paragraph.attrs._docxParagraphSourceToken",
+    issues,
+  );
   optionalString(attrs, "textId", "paragraph.attrs.textId", issues);
   optionalOneOf(
     attrs,

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -685,13 +685,6 @@ export const readTableCellAttrs = (node: PMNode): ReadProseMirrorAttrsResult<Tab
     "tableCell.attrs._preserveVMergeRestart",
     issues,
   );
-  optionalArray(
-    attrs,
-    "_docxVMergeContinuationCells",
-    "tableCell.attrs._docxVMergeContinuationCells",
-    issues,
-  );
-
   return attrsResult(attrs, issues);
 };
 
@@ -2146,18 +2139,6 @@ const optionalAutospacingBase = (
 
   optionalNumber(value, "before", `${path}.before`, issues);
   optionalNumber(value, "after", `${path}.after`, issues);
-};
-
-const optionalArray = (
-  attrs: Record<string, unknown>,
-  key: string,
-  path: string,
-  issues: ProseMirrorAttrIssue[],
-): void => {
-  const value = attrs[key];
-  if (value !== undefined && value !== null && !Array.isArray(value)) {
-    issues.push({ path, message: "Expected an array." });
-  }
 };
 
 const optionalBorderMap = (

--- a/packages/core/src/prosemirror/commands/comments.test.ts
+++ b/packages/core/src/prosemirror/commands/comments.test.ts
@@ -861,6 +861,7 @@ describe("table cell structural revision resolution", () => {
       },
       content: [
         {
+          _docxParagraphSourceBinding: { type: "authored" as const },
           type: "paragraph" as const,
           content: [
             {
@@ -879,7 +880,13 @@ describe("table cell structural revision resolution", () => {
         info: { id: 80, author: "Reviewer" },
         verticalMerge: "continue" as const,
       },
-      content: [{ type: "paragraph" as const, content: [] }],
+      content: [
+        {
+          _docxParagraphSourceBinding: { type: "authored" as const },
+          type: "paragraph" as const,
+          content: [],
+        },
+      ],
     };
     const view = dispatcher(
       EditorState.create({
@@ -934,7 +941,13 @@ describe("table cell structural revision resolution", () => {
         info: { id: 81, author: "Reviewer" },
         verticalMerge: "continue" as const,
       },
-      content: [{ type: "paragraph" as const, content: [] }],
+      content: [
+        {
+          _docxParagraphSourceBinding: { type: "authored" as const },
+          type: "paragraph" as const,
+          content: [],
+        },
+      ],
     };
     const view = dispatcher(
       EditorState.create({
@@ -964,7 +977,13 @@ describe("table cell structural revision resolution", () => {
       {
         type: "tableCell",
         formatting: { vMerge: "continue" },
-        content: [{ type: "paragraph", content: [] }],
+        content: [
+          {
+            _docxParagraphSourceBinding: { type: "authored" },
+            type: "paragraph",
+            content: [],
+          },
+        ],
       },
     ]);
   });
@@ -1056,6 +1075,7 @@ describe("table cell structural revision resolution", () => {
         formatting: { vMerge: "continue" },
         content: [
           {
+            _docxParagraphSourceBinding: { type: "authored" },
             type: "paragraph",
             content: [
               {

--- a/packages/core/src/prosemirror/commands/comments.ts
+++ b/packages/core/src/prosemirror/commands/comments.ts
@@ -8,6 +8,8 @@ import type { Mark, MarkType, Node as PMNode } from "prosemirror-model";
 import type { Command, EditorState, Transaction } from "prosemirror-state";
 import { removeRow, TableMap } from "prosemirror-tables";
 
+import { joinProseParagraphsWithRightPropertySource } from "../../docx/paragraphPropertySource";
+
 import {
   appendHeadlessInlineResolution,
   type HeadlessInlineChangeTracking,
@@ -493,8 +495,16 @@ function resolveChange(
           _sectionProperties: nextNode.attrs["_sectionProperties"],
         };
         try {
-          tr.join(joinPos);
-          tr.setNodeMarkup(mappedPos, undefined, joinedAttrs);
+          if (emptyFirstParagraph) {
+            joinProseParagraphsWithRightPropertySource({
+              attrs: joinedAttrs,
+              pos: joinPos,
+              transaction: tr,
+            });
+          } else {
+            tr.join(joinPos);
+            tr.setNodeMarkup(mappedPos, undefined, joinedAttrs);
+          }
           if (ownsSectionEndpoint(paragraph)) {
             removedSectionEndpointCount++;
             removedSectionReferences.push(...sectionReferencesOf(paragraph));

--- a/packages/core/src/prosemirror/commands/suggestionFinalParagraph.test.ts
+++ b/packages/core/src/prosemirror/commands/suggestionFinalParagraph.test.ts
@@ -8,6 +8,7 @@ import { FolioDocxReviewer } from "../../ai-edits/headless";
 import { getTrackedChangesFromDoc } from "../../ai-edits/read";
 import { createDocx } from "../../docx/rezip";
 import { revisedFinalParagraphMarks } from "../../compare/verification";
+import type { Document } from "../../types/document";
 import { expectParagraphAttrs } from "../attrs";
 import { fromProseDoc } from "../conversion/fromProseDoc";
 import { toProseDoc } from "../conversion/toProseDoc";
@@ -43,6 +44,8 @@ const EMPTY_CARRIER_FORMATTING = {
   numPr: { numId: 1, ilvl: 1 },
   alignment: "both",
 } as const;
+
+const sourceDocuments = new WeakMap<PMNode, Document>();
 
 type ContainerKind = "body" | "table cell";
 type SuggestionAcceptance = "targeted" | "all";
@@ -187,7 +190,11 @@ const dispatcher = (state: EditorState) => {
   const view = {
     state,
     dispatch(transaction: Transaction) {
+      const sourceDocument = sourceDocuments.get(view.state.doc);
       view.state = view.state.apply(transaction);
+      if (sourceDocument) {
+        sourceDocuments.set(view.state.doc, sourceDocument);
+      }
     },
   };
   return view;
@@ -217,8 +224,11 @@ const paragraphsInChangedContainer = (
   return Array.from({ length: cell.childCount }, (_, index) => cell.child(index));
 };
 
+const documentModel = (state: EditorState): Document =>
+  fromProseDoc(state.doc, sourceDocuments.get(state.doc));
+
 const documentBuffer = async (state: EditorState): Promise<Uint8Array> =>
-  await createDocx(fromProseDoc(state.doc));
+  await createDocx(documentModel(state));
 
 const documentXml = async (state: EditorState): Promise<string> => {
   const buffer = await documentBuffer(state);
@@ -231,7 +241,10 @@ const documentXml = async (state: EditorState): Promise<string> => {
 
 const reopenedState = async (state: EditorState): Promise<EditorState> => {
   const reviewer = await FolioDocxReviewer.fromBuffer(await documentBuffer(state));
-  return EditorState.create({ schema, doc: toProseDoc(reviewer.toDocument()) });
+  const sourceDocument = reviewer.toDocument();
+  const doc = toProseDoc(sourceDocument);
+  sourceDocuments.set(doc, sourceDocument);
+  return EditorState.create({ schema, doc });
 };
 
 const paragraphXmlContaining = (xml: string, text: string): string => {
@@ -434,7 +447,7 @@ const resolveAdjacentSuggestions = (
     expect(applySuggestionDecision(view, suggestionId, decision)).toBe(true);
   }
   expect(getSuggestions(view.state)).toEqual([]);
-  expect(revisedFinalParagraphMarks(fromProseDoc(view.state.doc))).toEqual([]);
+  expect(revisedFinalParagraphMarks(documentModel(view.state))).toEqual([]);
   return view;
 };
 
@@ -456,7 +469,7 @@ describe("accepted suggested container-final paragraphs", () => {
             ).toBe(true);
           }
           expect(getSuggestions(view.state)).toEqual([]);
-          expect(revisedFinalParagraphMarks(fromProseDoc(view.state.doc))).toEqual([]);
+          expect(revisedFinalParagraphMarks(documentModel(view.state))).toEqual([]);
           expect(terminalChainState(view.state, containerKind)).toEqual(
             expectedTerminalChainState(decisions),
           );
@@ -517,7 +530,7 @@ describe("accepted suggested container-final paragraphs", () => {
             expectParagraphAttrs(paragraphs.at(-1) ?? panic("expected a final paragraph"))
               .pPrMark ?? null,
           ).toBeNull();
-          expect(revisedFinalParagraphMarks(fromProseDoc(view.state.doc))).toEqual([]);
+          expect(revisedFinalParagraphMarks(documentModel(view.state))).toEqual([]);
 
           if (canonical === undefined) {
             canonical = view.state.doc.toJSON();
@@ -572,7 +585,7 @@ describe("accepted suggested container-final paragraphs", () => {
         }
 
         expect(getTrackedChangesFromDoc(view.state.doc)).toEqual([]);
-        expect(revisedFinalParagraphMarks(fromProseDoc(view.state.doc))).toEqual([]);
+        expect(revisedFinalParagraphMarks(documentModel(view.state))).toEqual([]);
         expect(terminalChainState(view.state, containerKind)).toEqual([
           {
             text: CARRIER_TEXT,
@@ -620,7 +633,7 @@ describe("accepted suggested container-final paragraphs", () => {
       const reopenedChanges = getTrackedChangesFromDoc(reopenedTracked.doc);
       expect(reopenedChanges).toHaveLength(9);
       expect(new Set(reopenedChanges.map(({ id }) => id)).size).toBe(9);
-      expect(revisedFinalParagraphMarks(fromProseDoc(reopenedTracked.doc))).toEqual([]);
+      expect(revisedFinalParagraphMarks(documentModel(reopenedTracked))).toEqual([]);
 
       const accepting = dispatcher(EditorState.create({ schema, doc: reopenedTracked.doc }));
       expect(acceptAllChanges()(accepting.state, accepting.dispatch)).toBe(true);
@@ -640,10 +653,10 @@ describe("accepted suggested container-final paragraphs", () => {
       expect(suggestions.state.doc.textContent).toBe(CARRIER_TEXT);
 
       for (const resolved of [accepting, rejecting, suggestions]) {
-        expect(revisedFinalParagraphMarks(fromProseDoc(resolved.state.doc))).toEqual([]);
+        expect(revisedFinalParagraphMarks(documentModel(resolved.state))).toEqual([]);
         const reopened = await reopenedState(resolved.state);
         expect(reopened.doc.textContent).toBe(resolved.state.doc.textContent);
-        expect(revisedFinalParagraphMarks(fromProseDoc(reopened.doc))).toEqual([]);
+        expect(revisedFinalParagraphMarks(documentModel(reopened))).toEqual([]);
       }
     },
   );
@@ -683,7 +696,7 @@ describe("accepted suggested container-final paragraphs", () => {
       });
       expect(inserted.attrs["pPrMark"]).toBeNull();
 
-      const model = fromProseDoc(view.state.doc);
+      const model = documentModel(view.state);
       expect(revisedFinalParagraphMarks(model)).toEqual([]);
       const xml = await documentXml(view.state);
       expectAtMostOneParagraphPropertyChange(xml);
@@ -701,7 +714,7 @@ describe("accepted suggested container-final paragraphs", () => {
       expect(paragraphProperties(insertedXml)).not.toContain("<w:rPr>");
 
       const reopened = await reopenedState(view.state);
-      expect(revisedFinalParagraphMarks(fromProseDoc(reopened.doc))).toEqual([]);
+      expect(revisedFinalParagraphMarks(documentModel(reopened))).toEqual([]);
       expect(
         paragraphsInChangedContainer(reopened, containerKind).map((node) => ({
           alignment: expectParagraphAttrs(node).alignment,
@@ -806,7 +819,7 @@ describe("accepted suggested container-final paragraphs", () => {
               ],
         );
 
-        const model = fromProseDoc(view.state.doc);
+        const model = documentModel(view.state);
         expect(revisedFinalParagraphMarks(model)).toEqual([]);
         const xml = await documentXml(view.state);
         expect(xml).not.toMatch(/<w:(?:ins|del|pPrChange)\b/u);
@@ -825,7 +838,7 @@ describe("accepted suggested container-final paragraphs", () => {
         expect(reopened.doc.textContent).toBe(
           rejectsInsertion ? CARRIER_TEXT : `${CARRIER_TEXT}${INSERTED_TEXT}`,
         );
-        expect(revisedFinalParagraphMarks(fromProseDoc(reopened.doc))).toEqual([]);
+        expect(revisedFinalParagraphMarks(documentModel(reopened))).toEqual([]);
       }
     },
   );
@@ -880,7 +893,7 @@ describe("accepted suggested container-final paragraphs", () => {
           previousFormatting: { alignment: "center" },
         },
       ]);
-      expect(revisedFinalParagraphMarks(fromProseDoc(mixed.state.doc))).toEqual([]);
+      expect(revisedFinalParagraphMarks(documentModel(mixed.state))).toEqual([]);
 
       const rejected = dispatcher(makeAdjacentSuggestedTailState(containerKind));
       expect(rejectAllSuggestions()(rejected.state, rejected.dispatch)).toBe(true);
@@ -929,11 +942,11 @@ describe("accepted suggested container-final paragraphs", () => {
         expect(rejecting.state.doc.textContent).toBe(CARRIER_TEXT);
         for (const resolved of [accepting, rejecting]) {
           expect(getSuggestions(resolved.state)).toEqual([]);
-          expect(revisedFinalParagraphMarks(fromProseDoc(resolved.state.doc))).toEqual([]);
+          expect(revisedFinalParagraphMarks(documentModel(resolved.state))).toEqual([]);
           expect(await documentXml(resolved.state)).not.toMatch(/<w:(?:ins|del|pPrChange)\b/u);
           const reopened = await reopenedState(resolved.state);
           expect(getSuggestions(reopened)).toEqual([]);
-          expect(revisedFinalParagraphMarks(fromProseDoc(reopened.doc))).toEqual([]);
+          expect(revisedFinalParagraphMarks(documentModel(reopened))).toEqual([]);
           expect(reopened.doc.textContent).toBe(resolved.state.doc.textContent);
         }
       }

--- a/packages/core/src/prosemirror/commands/tableCellMergeResolution.ts
+++ b/packages/core/src/prosemirror/commands/tableCellMergeResolution.ts
@@ -3,6 +3,10 @@ import type { Node as PMNode } from "prosemirror-model";
 import type { Transaction } from "prosemirror-state";
 import { TableMap } from "prosemirror-tables";
 
+import {
+  restoreTableCellsWithParagraphPropertySources,
+  transportTableCellsWithParagraphPropertySources,
+} from "../../docx/paragraphPropertySource";
 import type { TableCell, TableCellFormatting } from "../../types/document";
 import { standaloneTableCellFromProseMirror } from "../conversion/fromProseDoc";
 import { standaloneTableCellToProseMirror } from "../conversion/toProseDoc";
@@ -155,7 +159,8 @@ const mergeTableCellWithCellAbove = (tr: Transaction, cellPos: number): boolean 
   tr.setNodeMarkup(abovePos, undefined, {
     ...aboveCell.attrs,
     rowspan: aboveRowspan + cellRowspan,
-    _docxVMergeContinuationCells: continuationCells,
+    _docxVMergeContinuationCells:
+      transportTableCellsWithParagraphPropertySources(continuationCells),
   });
   return true;
 };
@@ -285,15 +290,23 @@ export const resolveCollapsedTableCellMerge = (
 };
 
 const createRestoredTableCell = (origin: PMNode, source: TableCell): PMNode | null => {
-  const formatting = source.formatting ? { ...source.formatting } : undefined;
+  const restoredSourceCell = restoreTableCellsWithParagraphPropertySources([source]).at(0);
+  if (!restoredSourceCell) {
+    return null;
+  }
+  const formatting = restoredSourceCell.formatting
+    ? { ...restoredSourceCell.formatting }
+    : undefined;
   if (formatting) {
     delete formatting.vMerge;
   }
   const restoredSource: TableCell = {
     type: "tableCell",
     ...(formatting ? { formatting } : {}),
-    ...(source.propertyChanges ? { propertyChanges: source.propertyChanges } : {}),
-    content: source.content,
+    ...(restoredSourceCell.propertyChanges
+      ? { propertyChanges: restoredSourceCell.propertyChanges }
+      : {}),
+    content: restoredSourceCell.content,
   };
   const restored = standaloneTableCellToProseMirror(
     restoredSource,

--- a/packages/core/src/prosemirror/commands/tableCellMergeResolution.ts
+++ b/packages/core/src/prosemirror/commands/tableCellMergeResolution.ts
@@ -4,6 +4,8 @@ import type { Transaction } from "prosemirror-state";
 import { TableMap } from "prosemirror-tables";
 
 import {
+  type DecodedTableCellParagraphSourcePayload,
+  decodeTableCellParagraphSourcePayload,
   restoreTableCellsWithParagraphPropertySources,
   transportTableCellsWithParagraphPropertySources,
 } from "../../docx/paragraphPropertySource";
@@ -12,18 +14,27 @@ import { standaloneTableCellFromProseMirror } from "../conversion/fromProseDoc";
 import { standaloneTableCellToProseMirror } from "../conversion/toProseDoc";
 import { getTableCellMergeChange } from "../tableCellMergeRevision";
 
+const tableCellContinuationPayload = (
+  node: PMNode,
+): DecodedTableCellParagraphSourcePayload | null => {
+  const value = node.attrs["_docxVMergeContinuationCells"];
+  return value === undefined || value === null
+    ? null
+    : decodeTableCellParagraphSourcePayload(value);
+};
+
 export const hasMatchingCollapsedTableCellMerge = (
   node: PMNode,
   revisionSet: Set<number> | null,
 ): boolean => {
-  const continuationCells = node.attrs["_docxVMergeContinuationCells"];
-  if (!Array.isArray(continuationCells)) {
-    return false;
-  }
-  return continuationCells.some((cell) => {
-    const change = getTableCellMergeChange(cell);
-    return change !== null && (revisionSet === null || revisionSet.has(change.info.id));
-  });
+  const payload = tableCellContinuationPayload(node);
+  return (
+    payload !== null &&
+    payload.cells.some((cell) => {
+      const change = getTableCellMergeChange(cell);
+      return change !== null && (revisionSet === null || revisionSet.has(change.info.id));
+    })
+  );
 };
 
 type TableCellRevisionAttr = {
@@ -150,9 +161,9 @@ const mergeTableCellWithCellAbove = (tr: Transaction, cellPos: number): boolean 
 
   const continuationCells = tableCellContinuationCells(aboveCell, aboveRowspan);
   continuationCells.push(tableCellContinuationFromNode(cell));
-  const nestedContinuations = cell.attrs["_docxVMergeContinuationCells"];
-  if (Array.isArray(nestedContinuations)) {
-    continuationCells.push(...nestedContinuations);
+  const nestedPayload = tableCellContinuationPayload(cell);
+  if (nestedPayload) {
+    continuationCells.push(...nestedPayload.cells);
   }
 
   tr.delete(cellPos, cellPos + cell.nodeSize);
@@ -166,8 +177,8 @@ const mergeTableCellWithCellAbove = (tr: Transaction, cellPos: number): boolean 
 };
 
 const tableCellContinuationCells = (cell: PMNode, rowspan: number): TableCell[] => {
-  const stored = cell.attrs["_docxVMergeContinuationCells"];
-  const cells: TableCell[] = Array.isArray(stored) ? [...stored] : [];
+  const payload = tableCellContinuationPayload(cell);
+  const cells = payload ? [...payload.cells] : [];
   while (cells.length < rowspan - 1) {
     cells.push(emptyVerticalMergeContinuation());
   }
@@ -202,10 +213,14 @@ export const resolveCollapsedTableCellMerge = (
   revisionSet: Set<number> | null,
 ): boolean => {
   const cell = tr.doc.nodeAt(cellPos);
-  const stored = cell?.attrs["_docxVMergeContinuationCells"];
-  if (!cell || !Array.isArray(stored)) {
+  if (!cell) {
     return false;
   }
+  const payload = tableCellContinuationPayload(cell);
+  if (!payload) {
+    return false;
+  }
+  const stored = payload.cells;
 
   const matchingIndices: number[] = [];
   const nextCells = stored.map((continuationCell, index) => {
@@ -261,8 +276,9 @@ export const resolveCollapsedTableCellMerge = (
   }
 
   const restorations: { index: number; cell: PMNode }[] = [];
+  const restoredCells = restoreTableCellsWithParagraphPropertySources(payload);
   for (const index of splitIndices) {
-    const source = nextCells[index];
+    const source = restoredCells[index];
     if (!source) {
       return false;
     }
@@ -290,23 +306,15 @@ export const resolveCollapsedTableCellMerge = (
 };
 
 const createRestoredTableCell = (origin: PMNode, source: TableCell): PMNode | null => {
-  const restoredSourceCell = restoreTableCellsWithParagraphPropertySources([source]).at(0);
-  if (!restoredSourceCell) {
-    return null;
-  }
-  const formatting = restoredSourceCell.formatting
-    ? { ...restoredSourceCell.formatting }
-    : undefined;
+  const formatting = source.formatting ? { ...source.formatting } : undefined;
   if (formatting) {
     delete formatting.vMerge;
   }
   const restoredSource: TableCell = {
     type: "tableCell",
     ...(formatting ? { formatting } : {}),
-    ...(restoredSourceCell.propertyChanges
-      ? { propertyChanges: restoredSourceCell.propertyChanges }
-      : {}),
-    content: restoredSourceCell.content,
+    ...(source.propertyChanges ? { propertyChanges: source.propertyChanges } : {}),
+    content: source.content,
   };
   const restored = standaloneTableCellToProseMirror(
     restoredSource,

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -24,6 +24,7 @@ import {
   ParagraphPropertySourceValidationError,
   type ParagraphPropertySourceValidationCode,
   copyDocumentParagraphPropertySourceContract,
+  copyDocumentParagraphPropertySources,
   copyParagraphPropertyCapture,
   copyParagraphPropertySource,
   getDocumentParagraphPropertySourceContract,
@@ -36,6 +37,7 @@ import {
   isParagraphPropertySourceToken,
   linkParagraphPropertySourceCandidate,
   paragraphPropertySourceTokenMatchesContract,
+  paragraphPropertySourceBelongsToDocument,
   recreateProseNodeWithParagraphPropertySource,
   visitDocumentStoryParagraphs,
 } from "../../docx/paragraphPropertySource";
@@ -366,27 +368,47 @@ const sourceValidationError = (
 
 const validateParagraphPropertySourceTokens = (
   pmDoc: PMNode,
-  baseContent: BlockContent[],
+  baseDocument: Document,
   contract: string,
 ): Map<string, Paragraph> => {
-  const baseParagraphs = new Map<string, Paragraph>();
-  visitDocumentStoryParagraphs(baseContent, (paragraph) => {
+  const sourceParagraphs = copyDocumentParagraphPropertySources(baseDocument);
+  if (!sourceParagraphs) {
+    panic("A paragraph-property source contract lost its source registry");
+  }
+  const currentTokens = new Set<string>();
+  visitDocumentStoryParagraphs(baseDocument.package.document.content, (paragraph) => {
     const token = getParagraphPropertySourceToken(paragraph);
-    if (!token || !paragraphPropertySourceTokenMatchesContract(token, contract)) {
+    if (!token) {
+      if (paragraphPropertySourceBelongsToDocument(paragraph, baseDocument)) {
+        throw sourceValidationError(
+          "invalid_token",
+          "A source-bound paragraph is missing its paragraph-property token.",
+        );
+      }
+      return;
+    }
+    if (!paragraphPropertySourceTokenMatchesContract(token, contract)) {
       throw sourceValidationError(
         "invalid_token",
         "The source document contains an invalid paragraph-property token.",
         token,
       );
     }
-    if (baseParagraphs.has(token)) {
+    if (!sourceParagraphs.has(token)) {
+      throw sourceValidationError(
+        "unknown_token",
+        "The source document contains an unknown paragraph-property token.",
+        token,
+      );
+    }
+    if (currentTokens.has(token)) {
       throw sourceValidationError(
         "duplicate_token",
         "The source document contains a duplicate paragraph-property token.",
         token,
       );
     }
-    baseParagraphs.set(token, paragraph);
+    currentTokens.add(token);
   });
 
   const seen = new Set<string>();
@@ -419,7 +441,7 @@ const validateParagraphPropertySourceTokens = (
         token,
       );
     }
-    if (!baseParagraphs.has(token)) {
+    if (!sourceParagraphs.has(token)) {
       throw sourceValidationError(
         "unknown_token",
         "A paragraph-property token is not present in the source document.",
@@ -429,7 +451,7 @@ const validateParagraphPropertySourceTokens = (
     seen.add(token);
     return false;
   });
-  return baseParagraphs;
+  return sourceParagraphs;
 };
 
 const restoreParagraphPropertySourcesByToken = (
@@ -507,11 +529,7 @@ export function fromProseDoc(pmDoc: PMNode, baseDocument?: Document): Document {
   }
   const tokenSources =
     baseContract && proseContract && baseDocument
-      ? validateParagraphPropertySourceTokens(
-          pmDoc,
-          baseDocument.package.document.content,
-          baseContract,
-        )
+      ? validateParagraphPropertySourceTokens(pmDoc, baseDocument, baseContract)
       : null;
 
   const blocks = extractBlocks(

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -23,6 +23,7 @@ import {
   PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR,
   ParagraphPropertySourceValidationError,
   type ParagraphPropertySourceValidationCode,
+  type TableCellParagraphPropertySourceBindingInspection,
   copyDocumentParagraphPropertySourceContract,
   copyDocumentParagraphPropertySources,
   copyParagraphPropertyCapture,
@@ -39,7 +40,9 @@ import {
   paragraphPropertySourceTokenMatchesContract,
   paragraphPropertySourceBelongsToDocument,
   recreateProseNodeWithParagraphPropertySource,
+  restoreTableCellsWithParagraphPropertySources,
   visitDocumentStoryParagraphs,
+  visitTableCellParagraphPropertySourceBindings,
 } from "../../docx/paragraphPropertySource";
 import { canonicalJson } from "../../utils/canonicalJson";
 import { normalizeHorizontalScalePercent } from "../../utils/horizontalScale";
@@ -412,13 +415,9 @@ const validateParagraphPropertySourceTokens = (
   });
 
   const seen = new Set<string>();
-  pmDoc.descendants((node) => {
-    if (node.type.name !== "paragraph") {
-      return true;
-    }
-    const token = getProseParagraphPropertySourceToken(node);
+  const validateToken = (token: unknown): void => {
     if (token === null || token === undefined) {
-      return false;
+      return;
     }
     if (!isParagraphPropertySourceToken(token)) {
       throw sourceValidationError(
@@ -449,6 +448,43 @@ const validateParagraphPropertySourceTokens = (
       );
     }
     seen.add(token);
+  };
+  const validateTableCellBinding = (
+    inspection: TableCellParagraphPropertySourceBindingInspection,
+  ): void => {
+    switch (inspection.status) {
+      case "absent":
+      case "invalid":
+        throw sourceValidationError(
+          "invalid_token",
+          "A hidden table-cell paragraph has an invalid paragraph-property source binding.",
+          inspection.status === "invalid" ? inspection.value : undefined,
+        );
+      case "authored":
+        return;
+      case "source":
+        validateToken(inspection.binding.token);
+        return;
+      default: {
+        const exhaustiveInspection: never = inspection;
+        return exhaustiveInspection;
+      }
+    }
+  };
+  pmDoc.descendants((node) => {
+    if (node.type.name === "tableCell" || node.type.name === "tableHeader") {
+      const continuationCells = expectTableCellAttrs(node)._docxVMergeContinuationCells;
+      if (continuationCells) {
+        visitTableCellParagraphPropertySourceBindings(continuationCells, (inspection) =>
+          validateTableCellBinding(inspection),
+        );
+      }
+      return true;
+    }
+    if (node.type.name !== "paragraph") {
+      return true;
+    }
+    validateToken(getProseParagraphPropertySourceToken(node));
     return false;
   });
   return sourceParagraphs;
@@ -4795,7 +4831,11 @@ function convertPMTableRow(
       const colspan = Math.max(cellAttrs.colspan, 1);
       cells.push(convertPMTableCell(cellNode, documentCounts, styleResolver));
       if (cellAttrs.rowspan > 1) {
-        const continuationCells = cellAttrs._docxVMergeContinuationCells;
+        const continuationCells = cellAttrs._docxVMergeContinuationCells
+          ? restoreTableCellsWithParagraphPropertySources(
+              cellAttrs._docxVMergeContinuationCells,
+            )
+          : undefined;
         activeVerticalMerges?.set(gridColumn, {
           remainingRows: cellAttrs.rowspan - 1,
           colspan,

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -20,12 +20,24 @@ import { visitDocxParagraphs } from "../../docx/paragraphTraversal";
 import { DATE_UTC_ATTRIBUTE } from "../../docx/trackedChangeInfo";
 import { createStyleEngine, type StyleEngine } from "../../style-engine";
 import {
+  PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR,
+  ParagraphPropertySourceValidationError,
+  type ParagraphPropertySourceValidationCode,
+  copyDocumentParagraphPropertySourceContract,
+  copyParagraphPropertyCapture,
   copyParagraphPropertySource,
+  getDocumentParagraphPropertySourceContract,
   getParagraphPropertySource,
   getParagraphPropertySourceCandidate,
+  getParagraphPropertySourceToken,
   getParagraphPropertySourceTransferId,
+  getProseDocumentParagraphPropertySourceContract,
+  getProseParagraphPropertySourceToken,
+  isParagraphPropertySourceToken,
   linkParagraphPropertySourceCandidate,
+  paragraphPropertySourceTokenMatchesContract,
   recreateProseNodeWithParagraphPropertySource,
+  visitDocumentStoryParagraphs,
 } from "../../docx/paragraphPropertySource";
 import { canonicalJson } from "../../utils/canonicalJson";
 import { normalizeHorizontalScalePercent } from "../../utils/horizontalScale";
@@ -301,6 +313,24 @@ const uniqueParagraphsById = (
   return paragraphs;
 };
 
+const restoreParagraphPropertySource = (paragraph: Paragraph, baseParagraph: Paragraph): void => {
+  copyParagraphPropertySource(paragraph, baseParagraph);
+
+  const baseFormatting = baseParagraph.formatting;
+  if (
+    !baseFormatting?.numPr ||
+    !baseFormatting.numPrFromStyle ||
+    !numPrEqual(baseFormatting.numPr, baseFormatting.numPrFromStyle)
+  ) {
+    return;
+  }
+  const { numPr, numPrFromStyle, ...authoredFormatting } = baseFormatting;
+  if (canonicalJson(paragraph.formatting ?? {}) !== canonicalJson(authoredFormatting)) {
+    return;
+  }
+  paragraph.formatting = { ...paragraph.formatting, numPr, numPrFromStyle };
+};
+
 const restoreParagraphPropertySources = (
   content: BlockContent[],
   baseContent: BlockContent[],
@@ -319,22 +349,104 @@ const restoreParagraphPropertySources = (
     ) {
       continue;
     }
-    copyParagraphPropertySource(paragraph, baseParagraph);
-
-    const baseFormatting = baseParagraph.formatting;
-    if (
-      !baseFormatting?.numPr ||
-      !baseFormatting.numPrFromStyle ||
-      !numPrEqual(baseFormatting.numPr, baseFormatting.numPrFromStyle)
-    ) {
-      continue;
-    }
-    const { numPr, numPrFromStyle, ...authoredFormatting } = baseFormatting;
-    if (canonicalJson(paragraph.formatting ?? {}) !== canonicalJson(authoredFormatting)) {
-      continue;
-    }
-    paragraph.formatting = { ...paragraph.formatting, numPr, numPrFromStyle };
+    restoreParagraphPropertySource(paragraph, baseParagraph);
   }
+};
+
+const sourceValidationError = (
+  code: ParagraphPropertySourceValidationCode,
+  message: string,
+  token?: unknown,
+): ParagraphPropertySourceValidationError =>
+  new ParagraphPropertySourceValidationError({
+    code,
+    message,
+    ...(token !== undefined ? { token } : {}),
+  });
+
+const validateParagraphPropertySourceTokens = (
+  pmDoc: PMNode,
+  baseContent: BlockContent[],
+  contract: string,
+): Map<string, Paragraph> => {
+  const baseParagraphs = new Map<string, Paragraph>();
+  visitDocumentStoryParagraphs(baseContent, (paragraph) => {
+    const token = getParagraphPropertySourceToken(paragraph);
+    if (!token || !paragraphPropertySourceTokenMatchesContract(token, contract)) {
+      throw sourceValidationError(
+        "invalid_token",
+        "The source document contains an invalid paragraph-property token.",
+        token,
+      );
+    }
+    if (baseParagraphs.has(token)) {
+      throw sourceValidationError(
+        "duplicate_token",
+        "The source document contains a duplicate paragraph-property token.",
+        token,
+      );
+    }
+    baseParagraphs.set(token, paragraph);
+  });
+
+  const seen = new Set<string>();
+  pmDoc.descendants((node) => {
+    if (node.type.name !== "paragraph") {
+      return true;
+    }
+    const token = getProseParagraphPropertySourceToken(node);
+    if (token === null || token === undefined) {
+      return false;
+    }
+    if (!isParagraphPropertySourceToken(token)) {
+      throw sourceValidationError(
+        "invalid_token",
+        "A paragraph contains a malformed paragraph-property token.",
+        token,
+      );
+    }
+    if (!paragraphPropertySourceTokenMatchesContract(token, contract)) {
+      throw sourceValidationError(
+        "unknown_token",
+        "A paragraph-property token belongs to a different source document.",
+        token,
+      );
+    }
+    if (seen.has(token)) {
+      throw sourceValidationError(
+        "duplicate_token",
+        "A paragraph-property token is attached to more than one paragraph.",
+        token,
+      );
+    }
+    if (!baseParagraphs.has(token)) {
+      throw sourceValidationError(
+        "unknown_token",
+        "A paragraph-property token is not present in the source document.",
+        token,
+      );
+    }
+    seen.add(token);
+    return false;
+  });
+  return baseParagraphs;
+};
+
+const restoreParagraphPropertySourcesByToken = (
+  content: BlockContent[],
+  baseParagraphs: ReadonlyMap<string, Paragraph>,
+): void => {
+  visitDocumentStoryParagraphs(content, (paragraph) => {
+    const token = getParagraphPropertySourceToken(paragraph);
+    if (!token) {
+      return;
+    }
+    const baseParagraph = baseParagraphs.get(token);
+    if (!baseParagraph) {
+      panic("Validated paragraph-property token lost its source owner");
+    }
+    restoreParagraphPropertySource(paragraph, baseParagraph);
+  });
 };
 
 type LinkedParagraphPropertySources = {
@@ -364,7 +476,7 @@ const restoreLinkedParagraphPropertySources = (
     if (targets.length === 1) {
       const target = targets.at(0);
       if (target) {
-        copyParagraphPropertySource(target, source);
+        copyParagraphPropertyCapture(target, source);
       }
     }
   }
@@ -378,13 +490,39 @@ export function fromProseDoc(pmDoc: PMNode, baseDocument?: Document): Document {
     "Cannot convert invalid ProseMirror document to DOCX model",
   );
 
+  const baseContract = baseDocument
+    ? getDocumentParagraphPropertySourceContract(baseDocument)
+    : undefined;
+  const proseContractAttribute = pmDoc.attrs[PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR];
+  const proseContract = getProseDocumentParagraphPropertySourceContract(pmDoc);
+  const proseCarriesInvalidContract =
+    proseContractAttribute !== null &&
+    proseContractAttribute !== undefined &&
+    proseContract === null;
+  if (proseCarriesInvalidContract || (baseContract ?? null) !== proseContract) {
+    throw sourceValidationError(
+      "contract_mismatch",
+      "The ProseMirror document does not match its paragraph-property source document.",
+    );
+  }
+  const tokenSources =
+    baseContract && proseContract && baseDocument
+      ? validateParagraphPropertySourceTokens(
+          pmDoc,
+          baseDocument.package.document.content,
+          baseContract,
+        )
+      : null;
+
   const blocks = extractBlocks(
     pmDoc,
     "resolve",
     baseDocument?.package.styles ? createStyleEngine(baseDocument.package.styles) : null,
   );
   const linkedSources = restoreLinkedParagraphPropertySources(blocks);
-  if (baseDocument) {
+  if (tokenSources) {
+    restoreParagraphPropertySourcesByToken(blocks, tokenSources);
+  } else if (baseDocument) {
     restoreParagraphPropertySources(
       blocks,
       baseDocument.package.document.content,
@@ -407,13 +545,15 @@ export function fromProseDoc(pmDoc: PMNode, baseDocument?: Document): Document {
 
   // If we have a base document, preserve its package structure
   if (baseDocument) {
-    return {
+    const updatedDocument: Document = {
       ...baseDocument,
       package: {
         ...baseDocument.package,
         document: documentBody,
       },
     };
+    copyDocumentParagraphPropertySourceContract(updatedDocument, baseDocument);
+    return updatedDocument;
   }
 
   // Create a minimal document structure

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -23,11 +23,12 @@ import {
   PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR,
   ParagraphPropertySourceValidationError,
   type ParagraphPropertySourceValidationCode,
-  type TableCellParagraphPropertySourceBindingInspection,
+  type TableCellParagraphPropertySourceBinding,
   copyDocumentParagraphPropertySourceContract,
   copyDocumentParagraphPropertySources,
   copyParagraphPropertyCapture,
   copyParagraphPropertySource,
+  decodeTableCellParagraphSourcePayload,
   getDocumentParagraphPropertySourceContract,
   getParagraphPropertySource,
   getParagraphPropertySourceCandidate,
@@ -361,12 +362,10 @@ const restoreParagraphPropertySources = (
 const sourceValidationError = (
   code: ParagraphPropertySourceValidationCode,
   message: string,
-  token?: unknown,
 ): ParagraphPropertySourceValidationError =>
   new ParagraphPropertySourceValidationError({
     code,
     message,
-    ...(token !== undefined ? { token } : {}),
   });
 
 const validateParagraphPropertySourceTokens = (
@@ -394,21 +393,18 @@ const validateParagraphPropertySourceTokens = (
       throw sourceValidationError(
         "invalid_token",
         "The source document contains an invalid paragraph-property token.",
-        token,
       );
     }
     if (!sourceParagraphs.has(token)) {
       throw sourceValidationError(
         "unknown_token",
         "The source document contains an unknown paragraph-property token.",
-        token,
       );
     }
     if (currentTokens.has(token)) {
       throw sourceValidationError(
         "duplicate_token",
         "The source document contains a duplicate paragraph-property token.",
-        token,
       );
     }
     currentTokens.add(token);
@@ -423,60 +419,48 @@ const validateParagraphPropertySourceTokens = (
       throw sourceValidationError(
         "invalid_token",
         "A paragraph contains a malformed paragraph-property token.",
-        token,
       );
     }
     if (!paragraphPropertySourceTokenMatchesContract(token, contract)) {
       throw sourceValidationError(
         "unknown_token",
         "A paragraph-property token belongs to a different source document.",
-        token,
       );
     }
     if (seen.has(token)) {
       throw sourceValidationError(
         "duplicate_token",
         "A paragraph-property token is attached to more than one paragraph.",
-        token,
       );
     }
     if (!sourceParagraphs.has(token)) {
       throw sourceValidationError(
         "unknown_token",
         "A paragraph-property token is not present in the source document.",
-        token,
       );
     }
     seen.add(token);
   };
-  const validateTableCellBinding = (
-    inspection: TableCellParagraphPropertySourceBindingInspection,
-  ): void => {
-    switch (inspection.status) {
-      case "absent":
-      case "invalid":
-        throw sourceValidationError(
-          "invalid_token",
-          "A hidden table-cell paragraph has an invalid paragraph-property source binding.",
-          inspection.status === "invalid" ? inspection.value : undefined,
-        );
+  const validateTableCellBinding = (binding: TableCellParagraphPropertySourceBinding): void => {
+    switch (binding.type) {
       case "authored":
         return;
       case "source":
-        validateToken(inspection.binding.token);
+        validateToken(binding.token);
         return;
       default: {
-        const exhaustiveInspection: never = inspection;
-        return exhaustiveInspection;
+        const exhaustiveBinding: never = binding;
+        return exhaustiveBinding;
       }
     }
   };
   pmDoc.descendants((node) => {
     if (node.type.name === "tableCell" || node.type.name === "tableHeader") {
       const continuationCells = expectTableCellAttrs(node)._docxVMergeContinuationCells;
-      if (continuationCells) {
-        visitTableCellParagraphPropertySourceBindings(continuationCells, (inspection) =>
-          validateTableCellBinding(inspection),
+      if (continuationCells !== undefined && continuationCells !== null) {
+        visitTableCellParagraphPropertySourceBindings(
+          decodeTableCellParagraphSourcePayload(continuationCells),
+          (binding) => validateTableCellBinding(binding),
         );
       }
       return true;
@@ -4831,11 +4815,13 @@ function convertPMTableRow(
       const colspan = Math.max(cellAttrs.colspan, 1);
       cells.push(convertPMTableCell(cellNode, documentCounts, styleResolver));
       if (cellAttrs.rowspan > 1) {
-        const continuationCells = cellAttrs._docxVMergeContinuationCells
-          ? restoreTableCellsWithParagraphPropertySources(
-              cellAttrs._docxVMergeContinuationCells,
-            )
-          : undefined;
+        const continuationCells =
+          cellAttrs._docxVMergeContinuationCells !== undefined &&
+          cellAttrs._docxVMergeContinuationCells !== null
+            ? restoreTableCellsWithParagraphPropertySources(
+                decodeTableCellParagraphSourcePayload(cellAttrs._docxVMergeContinuationCells),
+              )
+            : undefined;
         activeVerticalMerges?.set(gridColumn, {
           remainingRows: cellAttrs.rowspan - 1,
           colspan,

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -61,6 +61,7 @@ import {
   createProseParagraphWithPropertySource,
   getDocumentParagraphPropertySourceContract,
   recreateProseNodeWithParagraphPropertySource,
+  transportTableCellsWithParagraphPropertySources,
 } from "../../docx/paragraphPropertySource";
 import {
   buildPageBreakRunSourceDescendantIndex,
@@ -2350,7 +2351,8 @@ function convertTableCell({
     attrs._preserveVMergeRestart = true;
   }
   if (vMergeContinuationCells && vMergeContinuationCells.length > 0) {
-    attrs._docxVMergeContinuationCells = vMergeContinuationCells;
+    attrs._docxVMergeContinuationCells =
+      transportTableCellsWithParagraphPropertySources(vMergeContinuationCells);
   }
 
   // Convert cell content (paragraphs and nested tables)

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -57,7 +57,9 @@ import {
 } from "../../utils/paragraphFormattingMerge";
 import { resolveColorValueToHex } from "../../docx/drawingUtils";
 import {
-  linkProseParagraphPropertySource,
+  PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR,
+  createProseParagraphWithPropertySource,
+  getDocumentParagraphPropertySourceContract,
   recreateProseNodeWithParagraphPropertySource,
 } from "../../docx/paragraphPropertySource";
 import {
@@ -363,6 +365,8 @@ export function toProseDoc(document: Document, options?: ToProseDocOptions): PMN
     schema.node(
       "doc",
       {
+        [PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR]:
+          getDocumentParagraphPropertySourceContract(document) ?? null,
         _finalSectionStart: finalSectionStart,
         _adjustLineHeightInTable: adjustLineHeightInTable,
       },
@@ -732,9 +736,10 @@ function convertParagraph(
     attrs._emptyHyperlinks = emptyHyperlinks;
   }
 
-  const proseParagraph = schema.node("paragraph", attrs, inlineNodes);
-  linkProseParagraphPropertySource(proseParagraph, paragraph);
-  return proseParagraph;
+  return createProseParagraphWithPropertySource(schema.nodes["paragraph"], paragraph, {
+    attrs,
+    content: inlineNodes,
+  });
 }
 
 const withoutFontFamily = (formatting: TextFormatting | undefined): TextFormatting | undefined => {

--- a/packages/core/src/prosemirror/extensions/core/DocExtension.ts
+++ b/packages/core/src/prosemirror/extensions/core/DocExtension.ts
@@ -3,12 +3,14 @@
  */
 
 import { createNodeExtension } from "../create";
+import { PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR } from "../../../docx/paragraphPropertySource";
 
 export const DocExtension = createNodeExtension({
   name: "doc",
   schemaNodeName: "doc",
   nodeSpec: {
     attrs: {
+      [PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR]: { default: null },
       _finalSectionStart: { default: null },
       _adjustLineHeightInTable: { default: false },
     },

--- a/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
@@ -10,6 +10,8 @@ import { Fragment } from "prosemirror-model";
 import type { Mark, Node as PMNode, NodeSpec, Schema } from "prosemirror-model";
 import type { Command, EditorState, Transaction } from "prosemirror-state";
 
+import { PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR } from "../../../docx/paragraphPropertySource";
+
 import type { NumberingMap } from "../../../docx/numberingParser";
 import type {
   ParagraphAlignment,
@@ -326,6 +328,7 @@ const paragraphNodeSpec: NodeSpec = {
   group: "block",
   attrs: {
     paraId: { default: null },
+    [PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR]: { default: null },
     // Internal provenance for comparison alignment. It is intentionally not
     // parsed from or rendered to HTML/OOXML.
     idStability: { default: undefined },

--- a/packages/core/src/prosemirror/extensions/features/ParaIdAllocatorExtension.test.ts
+++ b/packages/core/src/prosemirror/extensions/features/ParaIdAllocatorExtension.test.ts
@@ -19,6 +19,11 @@ import { EditorState } from "prosemirror-state";
 import type { Command } from "prosemirror-state";
 
 import {
+  PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR,
+  PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR,
+  joinProseParagraphsWithRightPropertySource,
+} from "../../../docx/paragraphPropertySource";
+import {
   getChangedParagraphIds,
   ParagraphChangeTrackerExtension,
 } from "./ParagraphChangeTrackerExtension";
@@ -30,7 +35,10 @@ import {
 
 const schema = new Schema({
   nodes: {
-    doc: { content: "block+" },
+    doc: {
+      content: "block+",
+      attrs: { [PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR]: { default: null } },
+    },
     blockquote: { group: "block", content: "block+" },
     paragraph: {
       group: "block",
@@ -38,11 +46,13 @@ const schema = new Schema({
       attrs: {
         paraId: { default: null },
         textId: { default: null },
+        [PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR]: { default: null },
       },
       toDOM: () => ["p", 0],
     },
     text: { group: "inline" },
   },
+  marks: { strong: {} },
 });
 
 const ext = ParaIdAllocatorExtension();
@@ -62,9 +72,26 @@ if (!changeTrackerPlugin) {
 const para = (text: string, paraId: string | null = null) =>
   schema.node("paragraph", { paraId }, text.length > 0 ? [schema.text(text)] : []);
 
+const SOURCE_DIGEST = "a".repeat(64);
+const SOURCE_CONTRACT = `folio-ppr-v1:${SOURCE_DIGEST}`;
+const sourceToken = (ordinal: number, fingerprint = SOURCE_DIGEST.slice(0, 32)) =>
+  `p1d:${fingerprint}:${ordinal.toString(36)}`;
+const sourcedPara = (text: string, paraId: string, ordinal: number) =>
+  schema.node(
+    "paragraph",
+    { paraId, [PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR]: sourceToken(ordinal) },
+    text.length > 0 ? [schema.text(text)] : [],
+  );
+
 const createState = (...paras: ReturnType<typeof para>[]) =>
   EditorState.create({
     doc: schema.node("doc", null, paras),
+    plugins: [plugin],
+  });
+
+const createSourcedState = (...paras: ReturnType<typeof sourcedPara>[]) =>
+  EditorState.create({
+    doc: schema.node("doc", { [PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR]: SOURCE_CONTRACT }, paras),
     plugins: [plugin],
   });
 
@@ -95,6 +122,19 @@ const collectParaIds = (state: EditorState): (string | null)[] => {
     if (node.type.name === "paragraph") {
       const id = node.attrs["paraId"];
       out.push(typeof id === "string" ? id : null);
+      return false;
+    }
+    return true;
+  });
+  return out;
+};
+
+const collectSourceTokens = (state: EditorState): (string | null)[] => {
+  const out: (string | null)[] = [];
+  state.doc.descendants((node) => {
+    if (node.type.name === "paragraph") {
+      const token = node.attrs[PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR];
+      out.push(typeof token === "string" ? token : null);
       return false;
     }
     return true;
@@ -331,5 +371,129 @@ describe("ParaIdAllocatorExtension", () => {
     expect(changed.has("ED17ED01")).toBe(true);
     // SAFETY: asserted 8-hex above
     expect(changed.has(ids[0]!)).toBe(false);
+  });
+
+  test("native text and mark mutations retain the seeded source token", () => {
+    const token = sourceToken(0);
+    const initial = createSourcedState(sourcedPara("Hello", "AAAA1111", 0));
+    const inserted = initial.apply(initial.tr.insertText("!", 3));
+    const marked = inserted.apply(
+      inserted.tr.addMark(1, inserted.doc.content.size - 1, schema.mark("strong")),
+    );
+    const unmarked = marked.apply(
+      marked.tr.removeMark(1, marked.doc.content.size - 1, schema.marks.strong),
+    );
+
+    expect(collectSourceTokens(inserted)).toEqual([token]);
+    expect(collectSourceTokens(marked)).toEqual([token]);
+    expect(collectSourceTokens(unmarked)).toEqual([token]);
+  });
+
+  test.each(["", "Hello"])(
+    "an attribute-only paragraph recreation restores an omitted seeded source token for %j",
+    (text) => {
+      const initial = createSourcedState(sourcedPara(text, "AAAA1111", 0));
+      const next = initial.apply(
+        initial.tr.setNodeMarkup(0, undefined, {
+          paraId: "AAAA1111",
+          textId: "BBBB2222",
+        }),
+      );
+
+      expect(collectSourceTokens(next)).toEqual([sourceToken(0)]);
+    },
+  );
+
+  test("a nested paragraph recreation restores an omitted seeded source token", () => {
+    const initial = EditorState.create({
+      doc: schema.node("doc", { [PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR]: SOURCE_CONTRACT }, [
+        schema.node("blockquote", null, [sourcedPara("Nested", "AAAA1111", 0)]),
+      ]),
+      plugins: [plugin],
+    });
+    const next = initial.apply(
+      initial.tr.setNodeMarkup(1, undefined, {
+        paraId: "AAAA1111",
+        textId: "BBBB2222",
+      }),
+    );
+
+    expect(collectSourceTokens(next)).toEqual([sourceToken(0)]);
+  });
+
+  test.each([0, 2, 5])(
+    "split at offset %i retains the token only on the mapped original half",
+    (offset) => {
+      const initial = createSourcedState(sourcedPara("Hello", "AAAA1111", 0));
+      const next = initial.apply(initial.tr.split(offset + 1));
+
+      expect(collectSourceTokens(next)).toEqual([sourceToken(0), null]);
+    },
+  );
+
+  test("pasting a duplicate above the source cannot steal its token", () => {
+    const original = sourcedPara("Original", "AAAA1111", 0);
+    const initial = createSourcedState(original);
+    const copy = original.type.create(
+      { ...original.attrs, paraId: "BBBB2222" },
+      schema.text("Copy"),
+    );
+    const next = initial.apply(initial.tr.replace(0, 0, new Slice(Fragment.from(copy), 0, 0)));
+
+    expect(collectSourceTokens(next)).toEqual([null, sourceToken(0)]);
+  });
+
+  test("a token from a different source fingerprint is cleared", () => {
+    const initial = createSourcedState(sourcedPara("Original", "AAAA1111", 0));
+    const foreign = schema.node(
+      "paragraph",
+      {
+        paraId: "BBBB2222",
+        [PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR]: sourceToken(0, "b".repeat(32)),
+      },
+      schema.text("Foreign"),
+    );
+    const next = initial.apply(
+      initial.tr.replace(
+        initial.doc.content.size,
+        initial.doc.content.size,
+        new Slice(Fragment.from(foreign), 0, 0),
+      ),
+    );
+
+    expect(collectSourceTokens(next)).toEqual([sourceToken(0), null]);
+  });
+
+  test("a uniquely seeded token survives delete then paste", () => {
+    const original = sourcedPara("Original", "AAAA1111", 0);
+    const sibling = sourcedPara("Sibling", "BBBB2222", 1);
+    const initial = createSourcedState(original, sibling);
+    const deleted = initial.apply(initial.tr.delete(0, original.nodeSize));
+    const restored = deleted.apply(
+      deleted.tr.replace(
+        deleted.doc.content.size,
+        deleted.doc.content.size,
+        new Slice(Fragment.from(original), 0, 0),
+      ),
+    );
+
+    expect(collectSourceTokens(deleted)).toEqual([sourceToken(1)]);
+    expect(collectSourceTokens(restored)).toEqual([sourceToken(1), sourceToken(0)]);
+  });
+
+  test("the explicit revision join can select the right paragraph owner", () => {
+    const initial = createSourcedState(
+      sourcedPara("", "AAAA1111", 0),
+      sourcedPara("Right", "BBBB2222", 1),
+    );
+    const transaction = initial.tr;
+    joinProseParagraphsWithRightPropertySource({
+      attrs: transaction.doc.child(1).attrs,
+      pos: transaction.doc.child(0).nodeSize,
+      transaction,
+    });
+    const next = initial.apply(transaction);
+
+    expect(collectSourceTokens(next)).toEqual([sourceToken(1)]);
   });
 });

--- a/packages/core/src/prosemirror/extensions/features/ParaIdAllocatorExtension.ts
+++ b/packages/core/src/prosemirror/extensions/features/ParaIdAllocatorExtension.ts
@@ -35,12 +35,18 @@
  *   split therefore restores the same allocated id instead of minting
  *   another one.
  */
+import { panic } from "better-result";
 import { Fragment, type Node as PMNode } from "prosemirror-model";
 import { Plugin, PluginKey } from "prosemirror-state";
 import type { EditorState, Transaction } from "prosemirror-state";
 
 import { deterministicHexId, generateHexId } from "../../../utils/hexId";
 import {
+  PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR,
+  getExplicitParagraphPropertySourceTransfers,
+  getProseDocumentParagraphPropertySourceContract,
+  getProseParagraphPropertySourceToken,
+  paragraphPropertySourceTokenMatchesContract,
   recreateProseNodeWithParagraphPropertySource,
   setProseParagraphMarkupWithPropertySource,
   transferProseParagraphPropertySource,
@@ -49,7 +55,12 @@ import { createExtension } from "../create";
 import type { ExtensionRuntime } from "../types";
 import { ignoreTrackedChanges } from "./ParagraphChangeTrackerExtension";
 
-export const paraIdAllocatorKey = new PluginKey("paraIdAllocator");
+type ParagraphPropertySourceSeed = {
+  contract: string | null;
+  tokens: ReadonlySet<string>;
+};
+
+export const paraIdAllocatorKey = new PluginKey<ParagraphPropertySourceSeed>("paraIdAllocator");
 
 /**
  * Transaction meta asking this plugin to derive the ids it mints from a
@@ -101,81 +112,156 @@ type ParagraphOccurrence = {
 const isUsableParaId = (value: unknown): value is string =>
   typeof value === "string" && value.length > 0 && value !== "00000000";
 
-/**
- * For every valid paraId in the pre-transaction doc, the position its
- * paragraph ends up at after `transactions` — the occurrence that
- * rightfully keeps the id when the new doc holds duplicates. Ids whose
- * paragraph start was deleted by the steps are left out.
- */
-const mapKeeperPositions = (
+const collectParagraphPropertySourceSeed = (doc: PMNode): ParagraphPropertySourceSeed => {
+  const contract = getProseDocumentParagraphPropertySourceContract(doc);
+  if (!contract) {
+    return { contract: null, tokens: new Set() };
+  }
+  const counts = new Map<string, number>();
+  doc.descendants((node) => {
+    if (node.type.name !== "paragraph") {
+      return true;
+    }
+    const token = getProseParagraphPropertySourceToken(node);
+    if (paragraphPropertySourceTokenMatchesContract(token, contract)) {
+      counts.set(token, (counts.get(token) ?? 0) + 1);
+    }
+    return false;
+  });
+  return {
+    contract,
+    tokens: new Set([...counts].filter(([, count]) => count === 1).map(([token]) => token)),
+  };
+};
+
+type ParagraphPropertySourceKeeper =
+  | { status: "ambiguous" }
+  | { pos: number; status: "deleted" | "mapped" };
+
+type MappedParagraphKeepers = {
+  paraIds: Map<string, number>;
+  sourceTokens: Map<string, ParagraphPropertySourceKeeper>;
+};
+
+const mapParagraphKeepers = (
   oldDoc: PMNode,
   transactions: readonly Transaction[],
-): Map<string, number> => {
-  const keepers = new Map<string, number>();
+  sourceSeed: ParagraphPropertySourceSeed,
+): MappedParagraphKeepers => {
+  const paraIds = new Map<string, number>();
+  const sourceTokens = new Map<string, ParagraphPropertySourceKeeper>();
   oldDoc.descendants((node, pos) => {
     if (node.type.name !== "paragraph") {
       return true;
     }
     const id = node.attrs["paraId"];
-    if (!isUsableParaId(id) || keepers.has(id)) {
+    const token = getProseParagraphPropertySourceToken(node);
+    const mapsParaId = isUsableParaId(id) && !paraIds.has(id);
+    const mapsSourceToken = typeof token === "string" && sourceSeed.tokens.has(token);
+    if (!mapsParaId && !mapsSourceToken) {
       return false;
     }
+
     let mapped = pos;
+    let mappedInterior = pos + 1;
     let deleted = false;
-    for (const tr of transactions) {
-      const result = tr.mapping.mapResult(mapped);
-      if (result.deleted) {
-        deleted = true;
-        break;
-      }
-      mapped = result.pos;
+    for (const transaction of transactions) {
+      const ownerResult = transaction.mapping.mapResult(mapped);
+      const interiorResult = transaction.mapping.mapResult(mappedInterior, -1);
+      deleted ||= interiorResult.deletedAcross;
+      mapped = ownerResult.pos;
+      mappedInterior = interiorResult.pos;
     }
-    if (!deleted) {
-      keepers.set(id, mapped);
+    if (mapsParaId && !deleted) {
+      paraIds.set(id, mapped);
+    }
+    if (mapsSourceToken) {
+      sourceTokens.set(
+        token,
+        sourceTokens.has(token)
+          ? { status: "ambiguous" }
+          : { pos: mapped, status: deleted ? "deleted" : "mapped" },
+      );
     }
     return false;
   });
-  return keepers;
+  return { paraIds, sourceTokens };
 };
 
-const collectParaIdUpdates = (
+type ParagraphCensus = {
+  invalidSourceTokens: ParagraphOccurrence[];
+  missingParaIds: ParagraphOccurrence[];
+  paragraphs: Map<number, ParagraphOccurrence>;
+  paraIds: Map<string, ParagraphOccurrence[]>;
+  sourceTokens: Map<string, ParagraphOccurrence[]>;
+};
+
+const collectParagraphCensus = (
   doc: PMNode,
-  keeperPositions?: Map<string, number>,
-  deterministicSeed: string | null = null,
-): ParaIdUpdate[] => {
-  // Pass 1: paragraphs without a usable id, and occurrences per id.
-  const missing: ParagraphOccurrence[] = [];
-  const occurrencesById = new Map<string, ParagraphOccurrence[]>();
+  sourceSeed?: ParagraphPropertySourceSeed,
+): ParagraphCensus => {
+  const census: ParagraphCensus = {
+    invalidSourceTokens: [],
+    missingParaIds: [],
+    paragraphs: new Map(),
+    paraIds: new Map(),
+    sourceTokens: new Map(),
+  };
+  const contractMatchesSeed =
+    sourceSeed?.contract !== null &&
+    sourceSeed?.contract !== undefined &&
+    getProseDocumentParagraphPropertySourceContract(doc) === sourceSeed.contract;
 
   doc.descendants((node, pos) => {
-    // Non-paragraph: recurse — paragraphs nested in tables / cells
-    // are still in scope.
     if (node.type.name !== "paragraph") {
       return true;
     }
+    const occurrence = { pos, attrs: node.attrs };
+    census.paragraphs.set(pos, occurrence);
     const id = node.attrs["paraId"];
-    if (!isUsableParaId(id)) {
-      missing.push({ pos, attrs: node.attrs });
+    if (isUsableParaId(id)) {
+      const occurrences = census.paraIds.get(id) ?? [];
+      occurrences.push(occurrence);
+      census.paraIds.set(id, occurrences);
     } else {
-      const occurrences = occurrencesById.get(id) ?? [];
-      occurrences.push({ pos, attrs: node.attrs });
-      occurrencesById.set(id, occurrences);
+      census.missingParaIds.push(occurrence);
     }
-    // Paragraphs only contain inline content (text / runs) — nothing
-    // we'd ever paraId. Skip the subtree.
+
+    if (sourceSeed) {
+      const token = getProseParagraphPropertySourceToken(node);
+      if (token !== null && token !== undefined) {
+        if (
+          typeof token !== "string" ||
+          !contractMatchesSeed ||
+          !sourceSeed.contract ||
+          !sourceSeed.tokens.has(token) ||
+          !paragraphPropertySourceTokenMatchesContract(token, sourceSeed.contract)
+        ) {
+          census.invalidSourceTokens.push(occurrence);
+        } else {
+          const occurrences = census.sourceTokens.get(token) ?? [];
+          occurrences.push(occurrence);
+          census.sourceTokens.set(token, occurrences);
+        }
+      }
+    }
     return false;
   });
+  return census;
+};
 
-  // Pass 2: keeper resolution. A unique id always stays put; among
-  // duplicates, the occurrence at the id's mapped pre-transaction
-  // position keeps it, falling back to document order.
-  const needFreshId: ParagraphOccurrence[] = [...missing];
-  for (const [id, occurrences] of occurrencesById) {
+const collectParaIdUpdatesFromCensus = (
+  census: ParagraphCensus,
+  keeperPositions?: ReadonlyMap<string, number>,
+  deterministicSeed: string | null = null,
+): ParaIdUpdate[] => {
+  const needFreshId = [...census.missingParaIds];
+  for (const [id, occurrences] of census.paraIds) {
     if (occurrences.length === 1) {
       continue;
     }
     const keeperPos = keeperPositions?.get(id);
-    const keeper = occurrences.find((occurrence) => occurrence.pos === keeperPos) ?? occurrences[0];
+    const keeper = occurrences.find(({ pos }) => pos === keeperPos) ?? occurrences[0];
     for (const occurrence of occurrences) {
       if (occurrence !== keeper) {
         needFreshId.push(occurrence);
@@ -183,17 +269,99 @@ const collectParaIdUpdates = (
     }
   }
 
-  const taken = new Set(occurrencesById.keys());
+  const taken = new Set(census.paraIds.keys());
   const updates: ParaIdUpdate[] = [];
   for (const { pos, attrs } of needFreshId) {
     const newId = mintParaId(taken, deterministicSeed, pos);
     taken.add(newId);
     updates.push({ pos, attrs: { ...attrs, paraId: newId } });
   }
-
-  // Document order keeps transaction step order deterministic.
-  updates.sort((a, b) => a.pos - b.pos);
+  updates.sort((left, right) => left.pos - right.pos);
   return updates;
+};
+
+const collectParaIdUpdates = (doc: PMNode): ParaIdUpdate[] =>
+  collectParaIdUpdatesFromCensus(collectParagraphCensus(doc));
+
+type ParagraphPropertySourceUpdate = {
+  pos: number;
+  token: string | null;
+};
+
+const collectParagraphPropertySourceUpdates = (
+  census: ParagraphCensus,
+  keeperPositions: ReadonlyMap<string, ParagraphPropertySourceKeeper>,
+  transactions: readonly Transaction[],
+): ParagraphPropertySourceUpdate[] => {
+  const updates = new Map<number, string | null>();
+  for (const { pos } of census.invalidSourceTokens) {
+    updates.set(pos, null);
+  }
+  const explicitTransfers = transactions.flatMap((transaction) => [
+    ...getExplicitParagraphPropertySourceTransfers(transaction),
+  ]);
+  const explicitlySelected = new Set(
+    explicitTransfers
+      .map(({ selectedToken }) => selectedToken)
+      .filter((token): token is string => token !== null),
+  );
+  const explicitlyDisplaced = new Set(
+    explicitTransfers
+      .map(({ displacedToken }) => displacedToken)
+      .filter((token): token is string => token !== null),
+  );
+  const keptPositions = new Set<number>();
+  const keptTokens = new Set<string>();
+  for (const [token, occurrences] of census.sourceTokens) {
+    const mappedOwner = keeperPositions.get(token);
+    const mappedKeeper =
+      mappedOwner?.status === "mapped"
+        ? occurrences.find(({ pos }) => pos === mappedOwner.pos)
+        : undefined;
+    const transferredKeeper =
+      !mappedKeeper && explicitlySelected.has(token) && occurrences.length === 1
+        ? occurrences.at(0)
+        : undefined;
+    const detachedKeeper =
+      !mappedKeeper &&
+      !transferredKeeper &&
+      occurrences.length === 1 &&
+      (mappedOwner === undefined ||
+        (mappedOwner.status === "deleted" && mappedOwner.pos === occurrences.at(0)?.pos))
+        ? occurrences.at(0)
+        : undefined;
+    const keeper = mappedKeeper ?? transferredKeeper ?? detachedKeeper;
+    if (keeper) {
+      keptPositions.add(keeper.pos);
+      keptTokens.add(token);
+    }
+    for (const occurrence of occurrences) {
+      if (occurrence !== keeper) {
+        updates.set(occurrence.pos, null);
+      }
+    }
+  }
+
+  // Attribute-only node replacement preserves the paragraph's content gap but
+  // callers may accidentally omit its private token. Restore only the mapped
+  // surviving owner. Whole-paragraph deletion marks the interior boundary as
+  // deleted-across, so a replacement paragraph cannot borrow the old source.
+  for (const [token, mappedOwner] of keeperPositions) {
+    if (
+      mappedOwner.status !== "mapped" ||
+      keptTokens.has(token) ||
+      explicitlyDisplaced.has(token) ||
+      keptPositions.has(mappedOwner.pos) ||
+      !census.paragraphs.has(mappedOwner.pos)
+    ) {
+      continue;
+    }
+    updates.set(mappedOwner.pos, token);
+  }
+
+  return [...updates]
+    .map(([pos, token]) => ({ pos, token }))
+    .sort((left, right) => left.pos - right.pos);
 };
 
 type InitialParaIds = {
@@ -297,9 +465,13 @@ export const ensureParaIdsInState = (state: EditorState): EditorState => {
   return state.apply(tr);
 };
 
-const createParaIdAllocatorPlugin = (): Plugin =>
+const createParaIdAllocatorPlugin = (): Plugin<ParagraphPropertySourceSeed> =>
   new Plugin({
     key: paraIdAllocatorKey,
+    state: {
+      init: (_config, state) => collectParagraphPropertySourceSeed(state.doc),
+      apply: (_transaction, seed) => seed,
+    },
     appendTransaction(transactions, oldState, newState) {
       // Skip selection-only / mark-only transactions — they can't have
       // created or duplicated a paragraph.
@@ -307,13 +479,27 @@ const createParaIdAllocatorPlugin = (): Plugin =>
         return null;
       }
 
-      const keeperPositions = mapKeeperPositions(oldState.doc, transactions);
-      const seed =
+      const paragraphSourceSeed = paraIdAllocatorKey.getState(oldState);
+      if (!paragraphSourceSeed) {
+        panic("ParaId allocator lost its paragraph-property source seed");
+      }
+      const keeperPositions = mapParagraphKeepers(oldState.doc, transactions, paragraphSourceSeed);
+      const deterministicSeed =
         transactions
           .map((transaction) => transaction.getMeta(deterministicParaIdSeedKey))
           .find((value) => typeof value === "string") ?? null;
-      const updates = collectParaIdUpdates(newState.doc, keeperPositions, seed);
-      if (updates.length === 0) {
+      const census = collectParagraphCensus(newState.doc, paragraphSourceSeed);
+      const updates = collectParaIdUpdatesFromCensus(
+        census,
+        keeperPositions.paraIds,
+        deterministicSeed,
+      );
+      const paragraphSourceUpdates = collectParagraphPropertySourceUpdates(
+        census,
+        keeperPositions.sourceTokens,
+        transactions,
+      );
+      if (updates.length === 0 && paragraphSourceUpdates.length === 0) {
         return null;
       }
 
@@ -323,6 +509,18 @@ const createParaIdAllocatorPlugin = (): Plugin =>
           attrs: u.attrs,
           ownership: "transfer-allocated-id",
           pos: u.pos,
+          transaction: tr,
+        });
+      }
+      for (const { pos, token } of paragraphSourceUpdates) {
+        const paragraph = tr.doc.nodeAt(pos);
+        if (!paragraph || paragraph.type.name !== "paragraph") {
+          panic("Paragraph-property token update lost its paragraph");
+        }
+        setProseParagraphMarkupWithPropertySource({
+          attrs: { ...paragraph.attrs, [PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR]: token },
+          ownership: "preserve",
+          pos,
           transaction: tr,
         });
       }

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -87,8 +87,6 @@ export type ParagraphAttrs = {
   // Identity
   paraId?: string;
   textId?: string;
-  /** Private token used to rebind preserved paragraph properties after collaboration. */
-  _docxParagraphSourceToken?: string;
 
   // Alignment
   alignment?: ParagraphAlignment;

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -31,7 +31,6 @@ import type {
   TablePropertyChange,
   TableRowFormatting,
   TableRowPropertyChange,
-  TableCell,
   TableCellFormatting,
   TableCellPropertyChange,
   TableWidthType,
@@ -880,5 +879,5 @@ export type TableCellAttrs = {
   /** Preserve a DOCX vMerge restart even when PM cannot model it as a rowspan. */
   _preserveVMergeRestart?: boolean;
   /** Original DOCX vMerge continuation cells skipped into this PM rowspan. */
-  _docxVMergeContinuationCells?: TableCell[];
+  _docxVMergeContinuationCells?: unknown;
 };

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -88,6 +88,8 @@ export type ParagraphAttrs = {
   // Identity
   paraId?: string;
   textId?: string;
+  /** Private token used to rebind preserved paragraph properties after collaboration. */
+  _docxParagraphSourceToken?: string;
 
   // Alignment
   alignment?: ParagraphAlignment;

--- a/packages/core/src/prosemirror/yjsParagraphSourceContract.ts
+++ b/packages/core/src/prosemirror/yjsParagraphSourceContract.ts
@@ -1,0 +1,39 @@
+import { panic } from "better-result";
+import type { Node as PMNode } from "prosemirror-model";
+import type * as Y from "yjs";
+
+import {
+  PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR,
+  getProseDocumentParagraphPropertySourceContract,
+} from "../docx/paragraphPropertySource";
+
+const FOLIO_YJS_METADATA_MAP_NAME = "folio:document-metadata";
+const PARAGRAPH_SOURCE_CONTRACT_KEY = "paragraphSourceContract";
+
+export const proseDocumentParagraphSourceContract = (document: PMNode): string | null => {
+  return getProseDocumentParagraphPropertySourceContract(document);
+};
+
+export const writeYjsParagraphSourceContract = (ydoc: Y.Doc, document: PMNode): void => {
+  const contract = proseDocumentParagraphSourceContract(document);
+  if (!contract) {
+    panic("Cannot seed collaboration without a paragraph-property source contract");
+  }
+  ydoc.getMap(FOLIO_YJS_METADATA_MAP_NAME).set(PARAGRAPH_SOURCE_CONTRACT_KEY, contract);
+};
+
+export const readYjsParagraphSourceContract = (ydoc: Y.Doc): string | null => {
+  const contract = ydoc.getMap(FOLIO_YJS_METADATA_MAP_NAME).get(PARAGRAPH_SOURCE_CONTRACT_KEY);
+  return typeof contract === "string" ? contract : null;
+};
+
+export const withParagraphSourceContract = (document: PMNode, contract: string): PMNode => {
+  if (document.type.name !== "doc") {
+    panic("A paragraph-property source contract can only attach to a document node");
+  }
+  return document.type.create(
+    { ...document.attrs, [PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR]: contract },
+    document.content,
+    document.marks,
+  );
+};

--- a/scripts/paragraph-property-source-ownership.test.ts
+++ b/scripts/paragraph-property-source-ownership.test.ts
@@ -50,6 +50,22 @@ const containsParagraph = (type: ts.Type, location: ts.Node, checker: ts.TypeChe
   return discriminatorType.isStringLiteral() && discriminatorType.value === "paragraph";
 };
 
+type ParagraphProvenanceRebuild = "copy" | "setNodeMarkup" | "type.create";
+
+const paragraphProvenanceRebuild = (node: ts.CallExpression): ParagraphProvenanceRebuild | null => {
+  if (!ts.isPropertyAccessExpression(node.expression)) {
+    return null;
+  }
+  if (node.expression.name.text === "copy" || node.expression.name.text === "setNodeMarkup") {
+    return node.expression.name.text;
+  }
+  if (node.expression.name.text !== "create") {
+    return null;
+  }
+  const owner = node.expression.expression;
+  return ts.isPropertyAccessExpression(owner) && owner.name.text === "type" ? "type.create" : null;
+};
+
 const containsDocument = (type: ts.Type, location: ts.Node, checker: ts.TypeChecker): boolean => {
   if (type.isUnionOrIntersection()) {
     return type.types.some((part) => containsDocument(part, location, checker));
@@ -207,14 +223,12 @@ const cloneOwnershipViolations = (): string[] => {
           const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
           violations.add(`${file}:${String(line + 1)} calls structuredClone on a Document`);
         }
-        if (
-          ts.isCallExpression(node) &&
-          ts.isPropertyAccessExpression(node.expression) &&
-          node.expression.name.text === "setNodeMarkup" &&
-          PM_PARAGRAPH_PROVENANCE_FILES.has(file)
-        ) {
+        const provenanceRebuild = ts.isCallExpression(node)
+          ? paragraphProvenanceRebuild(node)
+          : null;
+        if (provenanceRebuild && PM_PARAGRAPH_PROVENANCE_FILES.has(file)) {
           const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
-          violations.add(`${file}:${String(line + 1)} calls PM setNodeMarkup directly`);
+          violations.add(`${file}:${String(line + 1)} calls PM ${provenanceRebuild} directly`);
         }
         ts.forEachChild(node, visit);
       };
@@ -273,6 +287,34 @@ const scanPackageSources = (): { contract: string[]; token: string[] } => {
 setDefaultTimeout(30_000);
 
 describe("paragraph property source ownership", () => {
+  test("recognizes every direct ProseMirror paragraph reconstruction form", () => {
+    const sourceFile = ts.createSourceFile(
+      "probe.ts",
+      [
+        "node.copy(content);",
+        "transaction.setNodeMarkup(position, undefined, attrs);",
+        "node.type.create(attrs, content, marks);",
+        "node.create(attrs);",
+      ].join("\n"),
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    );
+    const rebuilds: ParagraphProvenanceRebuild[] = [];
+    const visit = (node: ts.Node): void => {
+      if (ts.isCallExpression(node)) {
+        const rebuild = paragraphProvenanceRebuild(node);
+        if (rebuild) {
+          rebuilds.push(rebuild);
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+
+    expect(rebuilds).toEqual(["copy", "setNodeMarkup", "type.create"]);
+  });
+
   test("every production story save supplies its property-source base", () => {
     expect(proseConversionViolations()).toEqual([]);
   });

--- a/scripts/paragraph-property-source-ownership.test.ts
+++ b/scripts/paragraph-property-source-ownership.test.ts
@@ -12,12 +12,27 @@ const TYPECHECK_CONFIGS = [
   "packages/react/tsconfig.build.json",
   "packages/vue/tsconfig.build.json",
 ] as const;
-const PM_PROVENANCE_FILES = new Set([
+const PM_PARAGRAPH_PROVENANCE_FILES = new Set([
   "packages/core/src/ai-edits/headless.ts",
   "packages/core/src/prosemirror/conversion/fromProseDoc.ts",
   "packages/core/src/prosemirror/conversion/toProseDoc.ts",
   "packages/core/src/prosemirror/extensions/features/AutoBidiDetectionExtension.ts",
   "packages/core/src/prosemirror/extensions/features/ParaIdAllocatorExtension.ts",
+]);
+const TOKEN_OWNER_FILES = new Set([
+  OWNER,
+  "packages/core/src/prosemirror/attrs/index.ts",
+  "packages/core/src/prosemirror/conversion/fromProseDoc.ts",
+  "packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts",
+  "packages/core/src/prosemirror/extensions/features/ParaIdAllocatorExtension.ts",
+  "packages/core/src/prosemirror/schema/nodes.ts",
+]);
+const CONTRACT_OWNER_FILES = new Set([
+  OWNER,
+  "packages/core/src/prosemirror/conversion/fromProseDoc.ts",
+  "packages/core/src/prosemirror/conversion/toProseDoc.ts",
+  "packages/core/src/prosemirror/extensions/core/DocExtension.ts",
+  "packages/core/src/prosemirror/yjsParagraphSourceContract.ts",
 ]);
 
 const relativePath = (sourceFile: ts.SourceFile): string =>
@@ -35,21 +50,6 @@ const containsParagraph = (type: ts.Type, location: ts.Node, checker: ts.TypeChe
   return discriminatorType.isStringLiteral() && discriminatorType.value === "paragraph";
 };
 
-const calledMemberName = (node: ts.CallExpression): string | null => {
-  if (!ts.isPropertyAccessExpression(node.expression)) {
-    return null;
-  }
-  return node.expression.name.text;
-};
-
-const isPmNodeTypeCreate = (node: ts.CallExpression): boolean => {
-  if (!ts.isPropertyAccessExpression(node.expression) || node.expression.name.text !== "create") {
-    return false;
-  }
-  const owner = node.expression.expression;
-  return ts.isPropertyAccessExpression(owner) && owner.name.text === "type";
-};
-
 const containsDocument = (type: ts.Type, location: ts.Node, checker: ts.TypeChecker): boolean => {
   if (type.isUnionOrIntersection()) {
     return type.types.some((part) => containsDocument(part, location, checker));
@@ -65,8 +65,11 @@ const containsDocument = (type: ts.Type, location: ts.Node, checker: ts.TypeChec
 const isProductionSource = (file: string): boolean =>
   file.startsWith("packages/") &&
   file.includes("/src/") &&
+  !file.includes("/node_modules/") &&
   !file.endsWith(".test.ts") &&
   !file.endsWith(".test.tsx") &&
+  !file.endsWith(".spec.ts") &&
+  !file.endsWith(".spec.tsx") &&
   !file.includes("/__tests__/") &&
   !file.includes("/generated/");
 
@@ -193,25 +196,25 @@ const cloneOwnershipViolations = (): string[] => {
           const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
           violations.add(`${file}:${String(line + 1)} spreads a Paragraph`);
         }
-        if (ts.isCallExpression(node)) {
-          if (
-            ts.isIdentifier(node.expression) &&
-            node.expression.text === "structuredClone" &&
-            node.arguments.some((argument) =>
-              containsDocument(checker.getTypeAtLocation(argument), argument, checker),
-            )
-          ) {
-            const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
-            violations.add(`${file}:${String(line + 1)} calls structuredClone on a Document`);
-          }
-          const member = calledMemberName(node);
-          if (
-            PM_PROVENANCE_FILES.has(file) &&
-            (member === "copy" || member === "setNodeMarkup" || isPmNodeTypeCreate(node))
-          ) {
-            const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
-            violations.add(`${file}:${String(line + 1)} calls PM ${member ?? "clone"}`);
-          }
+        if (
+          ts.isCallExpression(node) &&
+          ts.isIdentifier(node.expression) &&
+          node.expression.text === "structuredClone" &&
+          node.arguments.some((argument) =>
+            containsDocument(checker.getTypeAtLocation(argument), argument, checker),
+          )
+        ) {
+          const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+          violations.add(`${file}:${String(line + 1)} calls structuredClone on a Document`);
+        }
+        if (
+          ts.isCallExpression(node) &&
+          ts.isPropertyAccessExpression(node.expression) &&
+          node.expression.name.text === "setNodeMarkup" &&
+          PM_PARAGRAPH_PROVENANCE_FILES.has(file)
+        ) {
+          const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+          violations.add(`${file}:${String(line + 1)} calls PM setNodeMarkup directly`);
         }
         ts.forEachChild(node, visit);
       };
@@ -221,6 +224,52 @@ const cloneOwnershipViolations = (): string[] => {
   return [...violations].toSorted();
 };
 
+const tokenOwnershipViolation = (file: string, sourceText: string): string | null => {
+  if (!isProductionSource(file) || TOKEN_OWNER_FILES.has(file)) {
+    return null;
+  }
+  return sourceText.includes("_docxParagraphSourceToken") ||
+    sourceText.includes("PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR")
+    ? `${file} references the private paragraph-source token`
+    : null;
+};
+
+const contractOwnershipViolation = (file: string, sourceText: string): string | null => {
+  if (!isProductionSource(file) || CONTRACT_OWNER_FILES.has(file)) {
+    return null;
+  }
+  return sourceText.includes("_docxParagraphSourceContract") ||
+    sourceText.includes("PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR")
+    ? `${file} references the private paragraph-source contract`
+    : null;
+};
+
+const scanPackageSources = (): { contract: string[]; token: string[] } => {
+  const contract: string[] = [];
+  const token: string[] = [];
+  const sourcePaths = ts.sys.readDirectory(path.join(REPO_ROOT, "packages"), [
+    ".ts",
+    ".tsx",
+    ".vue",
+  ]);
+  for (const sourcePath of sourcePaths) {
+    const file = path.relative(REPO_ROOT, sourcePath).replaceAll("\\", "/");
+    const sourceText = ts.sys.readFile(sourcePath);
+    if (sourceText === undefined) {
+      panic(`Cannot read ${file}.`);
+    }
+    const tokenViolation = tokenOwnershipViolation(file, sourceText);
+    if (tokenViolation) {
+      token.push(tokenViolation);
+    }
+    const contractViolation = contractOwnershipViolation(file, sourceText);
+    if (contractViolation) {
+      contract.push(contractViolation);
+    }
+  }
+  return { contract: contract.toSorted(), token: token.toSorted() };
+};
+
 setDefaultTimeout(30_000);
 
 describe("paragraph property source ownership", () => {
@@ -228,7 +277,37 @@ describe("paragraph property source ownership", () => {
     expect(proseConversionViolations()).toEqual([]);
   });
 
-  test("every typed clone keeps an explicit property-source owner", () => {
+  test("every typed clone and paragraph markup rebuild keeps an explicit source owner", () => {
     expect(cloneOwnershipViolations()).toEqual([]);
+  });
+
+  test("only the provenance kernel and lifecycle boundary can reference source metadata", () => {
+    const violations = scanPackageSources();
+    expect(violations.token).toEqual([]);
+    expect(violations.contract).toEqual([]);
+    expect(
+      tokenOwnershipViolation(
+        "packages/react/src/unsafe.ts",
+        'attrs["_docxParagraphSourceToken"] = copied;',
+      ),
+    ).toContain("private paragraph-source token");
+    expect(
+      tokenOwnershipViolation(
+        "packages/core/src/docx/paragraphPropertySource.ts",
+        'attrs["_docxParagraphSourceToken"] = seeded;',
+      ),
+    ).toBeNull();
+    expect(
+      contractOwnershipViolation(
+        "packages/react/src/unsafe.ts",
+        'attrs["_docxParagraphSourceContract"] = copied;',
+      ),
+    ).toContain("private paragraph-source contract");
+    expect(
+      contractOwnershipViolation(
+        "packages/core/src/prosemirror/yjsParagraphSourceContract.ts",
+        'attrs["_docxParagraphSourceContract"] = seeded;',
+      ),
+    ).toBeNull();
   });
 });

--- a/scripts/typecheck-budget.json
+++ b/scripts/typecheck-budget.json
@@ -25,7 +25,7 @@
   },
   "playground": {
     "types": 151388,
-    "instantiations": 208668
+    "instantiations": 219329
   },
   "playground-vue": {
     "types": 179192,


### PR DESCRIPTION
## Summary

- bind collaborative paragraph-property provenance to the exact source package
- preserve one deterministic paragraph owner across edits, splits, joins, paste, and Yjs reconstruction
- reject malformed, duplicated, unknown, or mismatched source identity instead of falling back to paragraph IDs
- keep private provenance and captured property XML out of serialized documents

## Validation

- paragraph source and round-trip tests: 98/98
- materialization and allocator tests: 35/35
- ownership ratchet and mutation cases included
- diff check clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved paragraph properties during collaborative DOCX editing, including when paragraph identifiers are missing, duplicated, regenerated, or affected by document reconstruction.
  * Improved paragraph-property retention across edits such as splitting, joining, copying, deleting, and pasting content.
  * Added validation for mismatched, missing, duplicated, or invalid paragraph sources during collaboration, reporting a clear source-mismatch error.
* **Tests**
  * Expanded coverage for paragraph-property preservation across editing and collaboration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->