### PR TITLE
fix: preserve document surface and footer fidelity

### DIFF
--- a/.changeset/adapt-document-surfaces.md
+++ b/.changeset/adapt-document-surfaces.md
@@ -1,0 +1,6 @@
+---
+"@stll/folio-core": patch
+"@stll/folio-react": patch
+---
+
+Adapt authored document fills in dark mode and fit oversized header and footer tables to their content frame.

--- a/packages/core/src/layout-bridge/convert/headerFooterLayout.test.ts
+++ b/packages/core/src/layout-bridge/convert/headerFooterLayout.test.ts
@@ -17,6 +17,7 @@ import {
   calculateHeaderFooterVisualBounds,
   convertHeaderFooterPmDocToContent,
   convertHeaderFooterToContent,
+  fitHeaderFooterTablesToContentWidth,
   normalizeHeaderFooterMeasureBlocks,
   reserveHeaderFooterFullWidthWrapBands,
 } from "./headerFooterLayout";
@@ -882,6 +883,26 @@ describe("header/footer layout conversion", () => {
 
     expect(calibri?.height).toBe(cambria?.height);
     expect(calibri?.textSig).not.toBe(cambria?.textSig);
+  });
+
+  test("fits an oversized auto-width furniture table inside the content frame", () => {
+    const oversized = table();
+    oversized.width = 0;
+    oversized.widthType = "auto";
+    oversized.columnWidths = [360, 180, 360];
+
+    const [fitted] = fitHeaderFooterTablesToContentWidth([oversized], 600);
+
+    expect(fitted).toMatchObject({ columnWidths: [240, 120, 240] });
+    expect(oversized.columnWidths).toEqual([360, 180, 360]);
+  });
+
+  test("does not resize a fixed-width furniture table", () => {
+    const fixed = table();
+    fixed.layout = "fixed";
+    fixed.columnWidths = [700];
+
+    expect(fitHeaderFooterTablesToContentWidth([fixed], 600)[0]).toBe(fixed);
   });
 
   test("normalizes inherited spacing inside table-cell paragraphs", () => {

--- a/packages/core/src/layout-bridge/convert/headerFooterLayout.ts
+++ b/packages/core/src/layout-bridge/convert/headerFooterLayout.ts
@@ -37,6 +37,7 @@ import {
   isFloatingImageRun,
   isFloatingTextBoxBlock,
   isTextWrappingFloatingImageRun,
+  tableColumnsArePinned,
 } from "../../layout-engine/types";
 import { headerFooterToProseDoc } from "../../prosemirror/conversion/toProseDoc";
 import { cloneParagraphWithPropertySource } from "../../docx/paragraphPropertySource";
@@ -151,6 +152,35 @@ export function normalizeHeaderFooterMeasureBlocks(
   section: HeaderFooterMetrics["section"] = "header",
 ): FlowBlock[] {
   return normalizeFlowBlockArray(blocks, { suppressTrailingEmptyAfterTable: section === "header" });
+}
+
+/**
+ * Header/footer auto-fit tables use `w:tblGrid` as a provisional ratio, not a
+ * license to paint beyond the page furniture frame. Scale an oversized grid
+ * for measurement while leaving the authored block untouched for round trips.
+ */
+export function fitHeaderFooterTablesToContentWidth(
+  blocks: FlowBlock[],
+  contentWidth: number,
+): FlowBlock[] {
+  return blocks.map((block) => {
+    if (
+      block.kind !== "table" ||
+      block.floating !== undefined ||
+      tableColumnsArePinned(block) ||
+      block.columnWidths === undefined
+    ) {
+      return block;
+    }
+
+    const totalWidth = block.columnWidths.reduce((sum, width) => sum + width, 0);
+    if (totalWidth <= contentWidth || totalWidth <= 0) {
+      return block;
+    }
+
+    const scale = contentWidth / totalWidth;
+    return { ...block, columnWidths: block.columnWidths.map((width) => width * scale) };
+  });
 }
 
 type HeaderFooterMeasureNormalization = {
@@ -948,7 +978,8 @@ function finalizeHeaderFooterContent(
     return undefined;
   }
 
-  const blocksForMeasure = normalizeHeaderFooterMeasureBlocks(blocks, metrics.section);
+  const normalizedBlocks = normalizeHeaderFooterMeasureBlocks(blocks, metrics.section);
+  const blocksForMeasure = fitHeaderFooterTablesToContentWidth(normalizedBlocks, contentWidth);
   const measuredBlocks = options.measureBlocks(blocksForMeasure, contentWidth);
   const measures = reserveHeaderFooterFullWidthWrapBands({
     blocks,

--- a/packages/core/src/layout-painter/documentColors.test.ts
+++ b/packages/core/src/layout-painter/documentColors.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import { getAutomaticTextColorForBackground } from "./documentColors";
+import {
+  AUTHORED_BACKGROUND_COLOR_VAR,
+  getAutomaticTextColorForBackground,
+  setAuthoredBackgroundColor,
+} from "./documentColors";
 
 describe("document automatic text color", () => {
   test("uses black automatic text on explicit white document shading", () => {
@@ -18,5 +22,22 @@ describe("document automatic text color", () => {
   test("leaves automatic text theme-adaptive when shading is not a concrete color", () => {
     expect(getAutomaticTextColorForBackground("auto")).toBeUndefined();
     expect(getAutomaticTextColorForBackground(undefined)).toBeUndefined();
+  });
+});
+
+describe("authored document backgrounds", () => {
+  test("retains the source color for stylesheet dark-mode adaptation", () => {
+    const values: Record<string, string> = {};
+    const style = {
+      backgroundColor: "",
+      setProperty: (name: string, value: string) => {
+        values[name] = value;
+      },
+    } as CSSStyleDeclaration;
+
+    setAuthoredBackgroundColor(style, "#F8F2EB");
+
+    expect(style.backgroundColor).toBe("#F8F2EB");
+    expect(values[AUTHORED_BACKGROUND_COLOR_VAR]).toBe("#F8F2EB");
   });
 });

--- a/packages/core/src/layout-painter/documentColors.test.ts
+++ b/packages/core/src/layout-painter/documentColors.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, test } from "bun:test";
 
 import {
   AUTHORED_BACKGROUND_COLOR_VAR,
+  AUTHORED_TEXT_COLOR_VAR,
   getAutomaticTextColorForBackground,
   setAuthoredBackgroundColor,
+  setAuthoredTextColor,
 } from "./documentColors";
 
 describe("document automatic text color", () => {
@@ -39,5 +41,22 @@ describe("authored document backgrounds", () => {
 
     expect(style.backgroundColor).toBe("#F8F2EB");
     expect(values[AUTHORED_BACKGROUND_COLOR_VAR]).toBe("#F8F2EB");
+  });
+});
+
+describe("authored document text", () => {
+  test("retains the source color for stylesheet dark-mode adaptation", () => {
+    const values: Record<string, string> = {};
+    const style = {
+      color: "",
+      setProperty: (name: string, value: string) => {
+        values[name] = value;
+      },
+    } as CSSStyleDeclaration;
+
+    setAuthoredTextColor(style, "#000000");
+
+    expect(style.color).toBe("#000000");
+    expect(values[AUTHORED_TEXT_COLOR_VAR]).toBe("#000000");
   });
 });

--- a/packages/core/src/layout-painter/documentColors.ts
+++ b/packages/core/src/layout-painter/documentColors.ts
@@ -6,6 +6,13 @@ const WHITE_LUMINANCE = 1;
 const CONTRAST_OFFSET = 0.05;
 
 export const AUTHORED_BACKGROUND_COLOR_VAR = "--doc-authored-background-color";
+export const AUTHORED_TEXT_COLOR_VAR = "--doc-run-color";
+
+/** Paint a document text color and expose it to the dark-mode color transform. */
+export const setAuthoredTextColor = (style: CSSStyleDeclaration, color: string): void => {
+  style.color = color;
+  style.setProperty(AUTHORED_TEXT_COLOR_VAR, color);
+};
 
 /**
  * Paint an OOXML background and retain its authored color for dark-mode adaptation.

--- a/packages/core/src/layout-painter/documentColors.ts
+++ b/packages/core/src/layout-painter/documentColors.ts
@@ -5,6 +5,17 @@ const BLACK_LUMINANCE = 0;
 const WHITE_LUMINANCE = 1;
 const CONTRAST_OFFSET = 0.05;
 
+export const AUTHORED_BACKGROUND_COLOR_VAR = "--doc-authored-background-color";
+
+/**
+ * Paint an OOXML background and retain its authored color for dark-mode adaptation.
+ * The custom property is presentation-only; serialization still uses the model value.
+ */
+export const setAuthoredBackgroundColor = (style: CSSStyleDeclaration, color: string): void => {
+  style.backgroundColor = color;
+  style.setProperty(AUTHORED_BACKGROUND_COLOR_VAR, color);
+};
+
 function normalizeHexColor(color: string): string | null {
   const trimmed = color.trim();
   if (!HEX_COLOR_RE.test(trimmed)) {

--- a/packages/core/src/layout-painter/registry/modules/textBox.test.ts
+++ b/packages/core/src/layout-painter/registry/modules/textBox.test.ts
@@ -10,10 +10,28 @@ import { TEXTBOX_CLASS_NAMES } from "../../renderTextBox";
 import type { RenderContext } from "../../renderUtils";
 import { textBoxModule } from "./textBox";
 
+function createFakeStyle(): Record<string, string> {
+  const store: Record<string, string> = {};
+  return new Proxy(store, {
+    get(target, prop: string) {
+      if (prop === "setProperty") {
+        return (key: string, value: string) => {
+          target[key] = value;
+        };
+      }
+      return target[prop];
+    },
+    set(target, prop: string, value: string) {
+      target[prop] = value;
+      return true;
+    },
+  }) as unknown as Record<string, string>;
+}
+
 class FakeElement {
   className = "";
   dataset: Record<string, string> = {};
-  style: Record<string, string> = {};
+  style: Record<string, string> = createFakeStyle();
   children: FakeElement[] = [];
   classList = {
     add: (...tokens: string[]) => {

--- a/packages/core/src/layout-painter/renderParagraph-inline-image.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-inline-image.test.ts
@@ -508,8 +508,9 @@ describe("renderLine text styling", () => {
 
     expect(textEl?.style.backgroundColor).toBe(TEST_HIGHLIGHT_COLOR);
     expect(textEl?.style.color).toBe("#000000");
-    expect(textEl?.className).toContain("docx-run-background-text");
-    expect(textEl?.style.getPropertyValue("--doc-run-background-text-color")).toBe("#000000");
+    expect(textEl?.style.getPropertyValue("--doc-authored-background-color")).toBe(
+      TEST_HIGHLIGHT_COLOR,
+    );
   });
 
   test("keeps automatic text readable on dark DOCX highlights", () => {
@@ -540,7 +541,9 @@ describe("renderLine text styling", () => {
 
     expect(textEl?.style.backgroundColor).toBe(TEST_DARK_HIGHLIGHT_COLOR);
     expect(textEl?.style.color).toBe("#FFFFFF");
-    expect(textEl?.style.getPropertyValue("--doc-run-background-text-color")).toBe("#FFFFFF");
+    expect(textEl?.style.getPropertyValue("--doc-authored-background-color")).toBe(
+      TEST_DARK_HIGHLIGHT_COLOR,
+    );
   });
 
   test("keeps inherited default-black text readable on dark DOCX highlights", () => {
@@ -606,7 +609,6 @@ describe("renderLine text styling", () => {
     expect(textEl?.style.backgroundColor).toBe(TEST_DARK_HIGHLIGHT_COLOR);
     expect(textEl?.style.color).toBe("#FFFFFF");
     expect(anchorEl?.style.color).toBe("#FFFFFF");
-    expect(anchorEl?.style.getPropertyValue("--doc-run-background-text-color")).toBe("#FFFFFF");
   });
 
   test("keeps inherited default-black hyperlink text readable on dark DOCX highlights", () => {
@@ -642,7 +644,6 @@ describe("renderLine text styling", () => {
     expect(textEl?.style.backgroundColor).toBe(TEST_DARK_HIGHLIGHT_COLOR);
     expect(textEl?.style.color).toBe("#FFFFFF");
     expect(anchorEl?.style.color).toBe("#FFFFFF");
-    expect(anchorEl?.style.getPropertyValue("--doc-run-background-text-color")).toBe("#FFFFFF");
   });
 
   test("preserves direct black hyperlink text without DOCX highlights", () => {
@@ -805,8 +806,8 @@ describe("renderLine text styling", () => {
 
     expect(textEl?.style.backgroundColor).toBe(TEST_HIGHLIGHT_COLOR);
     expect(textEl?.style.color).toBe(TEST_EXPLICIT_TEXT_COLOR);
-    expect(textEl?.style.getPropertyValue("--doc-run-background-text-color")).toBe(
-      TEST_EXPLICIT_TEXT_COLOR,
+    expect(textEl?.style.getPropertyValue("--doc-authored-background-color")).toBe(
+      TEST_HIGHLIGHT_COLOR,
     );
   });
 
@@ -839,8 +840,8 @@ describe("renderLine text styling", () => {
     const textEl = lineEl.children[0] as HTMLElement | undefined;
 
     expect(textEl?.style.color).toBe(TEST_EXPLICIT_TEXT_COLOR);
-    expect(textEl?.style.getPropertyValue("--doc-run-background-text-color")).toBe(
-      TEST_EXPLICIT_TEXT_COLOR,
+    expect(textEl?.style.getPropertyValue("--doc-authored-background-color")).toBe(
+      TEST_HIGHLIGHT_COLOR,
     );
   });
 
@@ -899,7 +900,9 @@ describe("renderLine text styling", () => {
 
     expect(textEl?.style.backgroundColor).toBe(TEST_DARK_HIGHLIGHT_COLOR);
     expect(textEl?.style.color).toBe("#000000");
-    expect(textEl?.style.getPropertyValue("--doc-run-background-text-color")).toBe("#000000");
+    expect(textEl?.style.getPropertyValue("--doc-authored-background-color")).toBe(
+      TEST_DARK_HIGHLIGHT_COLOR,
+    );
   });
 
   test("preserves tracked-change author colors on DOCX highlights", () => {

--- a/packages/core/src/layout-painter/renderParagraph-inline-image.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-inline-image.test.ts
@@ -508,6 +508,7 @@ describe("renderLine text styling", () => {
 
     expect(textEl?.style.backgroundColor).toBe(TEST_HIGHLIGHT_COLOR);
     expect(textEl?.style.color).toBe("#000000");
+    expect(textEl?.style.getPropertyValue("--doc-run-color")).toBe("#000000");
     expect(textEl?.style.getPropertyValue("--doc-authored-background-color")).toBe(
       TEST_HIGHLIGHT_COLOR,
     );
@@ -996,6 +997,52 @@ describe("renderLine tab tracking", () => {
 });
 
 describe("renderParagraphFragment indentation handling", () => {
+  test("exposes automatic shading contrast for dark-mode adaptation", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p1",
+      runs: [{ kind: "text", text: "Shaded" }],
+      attrs: { shading: "#F8F2EB" },
+    };
+    const measure: ParagraphMeasure = {
+      kind: "paragraph",
+      lines: [
+        {
+          fromRun: 0,
+          fromChar: 0,
+          toRun: 0,
+          toChar: 6,
+          width: 42,
+          ascent: 10,
+          descent: 2,
+          lineHeight: 12,
+        },
+      ],
+      totalHeight: 12,
+    };
+    const fragment: ParagraphFragment = {
+      kind: "paragraph",
+      blockId: "p1",
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 12,
+      fromLine: 0,
+      toLine: 1,
+    };
+
+    const fragmentEl = renderParagraphFragment(
+      fragment,
+      block,
+      measure,
+      { pageNumber: 1, totalPages: 1, section: "body" },
+      { document: fakeDocument },
+    );
+
+    expect(fragmentEl.style.color).toBe("#000000");
+    expect(fragmentEl.style.getPropertyValue("--doc-run-color")).toBe("#000000");
+  });
+
   test("renders list marker revisions with tracked-change classes", () => {
     resetAuthorColors();
     const block: ParagraphBlock = {

--- a/packages/core/src/layout-painter/renderParagraph-line-box.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-line-box.test.ts
@@ -3,10 +3,28 @@ import { describe, expect, test } from "bun:test";
 import type { MeasuredLine, ParagraphBlock } from "../layout-engine/types";
 import { renderLine } from "./renderParagraph";
 
+function createFakeStyle(): Record<string, string> {
+  const store: Record<string, string> = {};
+  return new Proxy(store, {
+    get(target, prop: string) {
+      if (prop === "setProperty") {
+        return (key: string, value: string) => {
+          target[key] = value;
+        };
+      }
+      return target[prop];
+    },
+    set(target, prop: string, value: string) {
+      target[prop] = value;
+      return true;
+    },
+  }) as unknown as Record<string, string>;
+}
+
 class FakeElement {
   className = "";
   dataset: Record<string, string> = {};
-  style: Record<string, string> = {};
+  style: Record<string, string> = createFakeStyle();
   children: FakeElement[] = [];
   textContent = "";
   classList = {

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -72,7 +72,11 @@ import {
   type ScriptClass,
 } from "../utils/scriptSegments";
 import { borderStrokeToCss, resolveParagraphBorderHorizontalOutsets } from "./borderStroke";
-import { getAutomaticTextColorForBackground, setAuthoredBackgroundColor } from "./documentColors";
+import {
+  getAutomaticTextColorForBackground,
+  setAuthoredBackgroundColor,
+  setAuthoredTextColor,
+} from "./documentColors";
 import {
   applyImageBorder,
   applyImageVisualAttrs,
@@ -349,11 +353,10 @@ function applyRunStyles(element: HTMLElement, run: TextRun | TabRun): void {
   let hasExplicitTextColor = false;
   const textColor = getRenderableTextColor(run);
   if (textColor) {
-    element.style.color = textColor;
     // Also expose the authored color so dark mode can invert its lightness
     // (hue/chroma preserved) via relative-color CSS. The dark rule overrides
     // this inline color with !important; light mode keeps it verbatim.
-    element.style.setProperty("--doc-run-color", textColor);
+    setAuthoredTextColor(element.style, textColor);
     hasExplicitTextColor = true;
   }
 
@@ -451,7 +454,7 @@ function applyRunStyles(element: HTMLElement, run: TextRun | TabRun): void {
         ? undefined
         : getAutomaticTextColorForBackground(runBackground);
     if (automaticTextColor) {
-      element.style.color = automaticTextColor;
+      setAuthoredTextColor(element.style, automaticTextColor);
     }
   }
 
@@ -761,16 +764,14 @@ function renderTextRun(run: TextRun, doc: Document, options?: RenderTextRunOptio
     if (!run.hyperlink.noDefaultStyle) {
       // Default Word hyperlink color is blue (#0563c1)
       const hyperlinkColor = getHyperlinkTextColor(run, span.style.color);
-      anchor.style.color = hyperlinkColor;
+      setAuthoredTextColor(anchor.style, hyperlinkColor);
       anchor.style.textDecoration = "underline";
       // Override span color to match anchor (prevents color mismatch in selection)
-      span.style.color = hyperlinkColor;
+      setAuthoredTextColor(span.style, hyperlinkColor);
       // Expose the link colour on the anchor (which paints over the span) so
       // dark mode inverts its lightness via the same --doc-run-color rule.
       // `noDefaultStyle` (e.g. TOC) anchors set no colour and keep inheriting
       // the paragraph's inverted colour.
-      anchor.style.setProperty("--doc-run-color", hyperlinkColor);
-      span.style.setProperty("--doc-run-color", hyperlinkColor);
     }
     span.append(anchor);
   } else {
@@ -3066,7 +3067,7 @@ export function renderParagraphFragment(
     setAuthoredBackgroundColor(fragmentEl.style, block.attrs.shading);
     const automaticTextColor = getAutomaticTextColorForBackground(block.attrs.shading);
     if (automaticTextColor) {
-      fragmentEl.style.color = automaticTextColor;
+      setAuthoredTextColor(fragmentEl.style, automaticTextColor);
     }
   }
 

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -72,7 +72,7 @@ import {
   type ScriptClass,
 } from "../utils/scriptSegments";
 import { borderStrokeToCss, resolveParagraphBorderHorizontalOutsets } from "./borderStroke";
-import { getAutomaticTextColorForBackground } from "./documentColors";
+import { getAutomaticTextColorForBackground, setAuthoredBackgroundColor } from "./documentColors";
 import {
   applyImageBorder,
   applyImageVisualAttrs,
@@ -241,19 +241,6 @@ const SUGGESTION_TINT_CSS = "var(--suggestion-bg, color-mix(in oklch, #6d3bd6 12
 // painted via background-color earlier in applyRunStyles — stay visible
 // underneath the proposal wash instead of being replaced by it.
 const SUGGESTION_TINT_LAYER_CSS = `linear-gradient(${SUGGESTION_TINT_CSS}, ${SUGGESTION_TINT_CSS})`;
-const RUN_BACKGROUND_TEXT_COLOR_VAR = "--doc-run-background-text-color";
-
-const setRunBackgroundTextColor = (element: HTMLElement, color: string): void => {
-  element.classList.add("docx-run-background-text");
-  element.style.setProperty(RUN_BACKGROUND_TEXT_COLOR_VAR, color);
-};
-
-const hasRunBackgroundTextSurface = (run: TextRun | TabRun): boolean =>
-  Boolean(run.highlight ?? run.shading) &&
-  !run.isInsertion &&
-  !run.isDeletion &&
-  !(run.commentIds !== undefined && run.commentIds.length > 0);
-
 function normalizeTextColorValue(color: string): string {
   return color.trim().toLowerCase().replace(/^#/u, "");
 }
@@ -456,7 +443,7 @@ function applyRunStyles(element: HTMLElement, run: TextRun | TabRun): void {
   // they fall outside the OOXML named-highlight palette. eigenpal #722 (#712).
   const runBackground = run.highlight ?? run.shading;
   if (runBackground) {
-    element.style.backgroundColor = runBackground;
+    setAuthoredBackgroundColor(element.style, runBackground);
     const hasTrackedChangeColor = run.isInsertion || run.isDeletion;
     const hasCommentHighlight = run.commentIds !== undefined && run.commentIds.length > 0;
     const automaticTextColor =
@@ -465,15 +452,6 @@ function applyRunStyles(element: HTMLElement, run: TextRun | TabRun): void {
         : getAutomaticTextColorForBackground(runBackground);
     if (automaticTextColor) {
       element.style.color = automaticTextColor;
-    }
-    const backgroundTextColor = hasExplicitTextColor ? textColor : automaticTextColor;
-    if (backgroundTextColor && hasRunBackgroundTextSurface(run)) {
-      // Dark-mode canvas rules deliberately invert ordinary run colors, but an
-      // authored highlight/shading is its own local color surface. Preserve the
-      // foreground chosen for that surface so a bright yellow highlight does
-      // not turn direct/theme black (or automatic contrast black) into white.
-      // The CSS custom property is presentation-only; saved OOXML is untouched.
-      setRunBackgroundTextColor(element, backgroundTextColor);
     }
   }
 
@@ -793,12 +771,6 @@ function renderTextRun(run: TextRun, doc: Document, options?: RenderTextRunOptio
       // the paragraph's inverted colour.
       anchor.style.setProperty("--doc-run-color", hyperlinkColor);
       span.style.setProperty("--doc-run-color", hyperlinkColor);
-      if (hasRunBackgroundTextSurface(run)) {
-        // The anchor paints over the run span, so it must carry the same local
-        // surface foreground contract as the span after hyperlink styling wins.
-        setRunBackgroundTextColor(span, hyperlinkColor);
-        setRunBackgroundTextColor(anchor, hyperlinkColor);
-      }
     }
     span.append(anchor);
   } else {
@@ -3091,7 +3063,7 @@ export function renderParagraphFragment(
 
   // Apply shading (background color)
   if (block.attrs?.shading) {
-    fragmentEl.style.backgroundColor = block.attrs.shading;
+    setAuthoredBackgroundColor(fragmentEl.style, block.attrs.shading);
     const automaticTextColor = getAutomaticTextColorForBackground(block.attrs.shading);
     if (automaticTextColor) {
       fragmentEl.style.color = automaticTextColor;

--- a/packages/core/src/layout-painter/renderTable.ts
+++ b/packages/core/src/layout-painter/renderTable.ts
@@ -55,7 +55,7 @@ import { emuToPixels } from "../utils/units";
 import { applySanitizedImageSrc } from "../utils/sanitizeImageSrc";
 import { resolveAnchoredImagePosition, type PageGeometry } from "./anchoredImagePosition";
 import { borderStrokeToCss, resolveCssBorderStroke } from "./borderStroke";
-import { getAutomaticTextColorForBackground } from "./documentColors";
+import { getAutomaticTextColorForBackground, setAuthoredBackgroundColor } from "./documentColors";
 import { applyImageVisualAttrs, hasImageCrop, hasImageVisualAttrs } from "./renderImage";
 import { renderParagraphFragment } from "./renderParagraph";
 import { renderTextBoxFragment } from "./renderTextBox";
@@ -701,7 +701,7 @@ function renderTableCell({
 
   // Background color
   if (cell.background) {
-    cellEl.style.backgroundColor = cell.background;
+    setAuthoredBackgroundColor(cellEl.style, cell.background);
     const automaticTextColor = getAutomaticTextColorForBackground(cell.background);
     if (automaticTextColor) {
       cellEl.style.color = automaticTextColor;

--- a/packages/core/src/layout-painter/renderTable.ts
+++ b/packages/core/src/layout-painter/renderTable.ts
@@ -55,7 +55,11 @@ import { emuToPixels } from "../utils/units";
 import { applySanitizedImageSrc } from "../utils/sanitizeImageSrc";
 import { resolveAnchoredImagePosition, type PageGeometry } from "./anchoredImagePosition";
 import { borderStrokeToCss, resolveCssBorderStroke } from "./borderStroke";
-import { getAutomaticTextColorForBackground, setAuthoredBackgroundColor } from "./documentColors";
+import {
+  getAutomaticTextColorForBackground,
+  setAuthoredBackgroundColor,
+  setAuthoredTextColor,
+} from "./documentColors";
 import { applyImageVisualAttrs, hasImageCrop, hasImageVisualAttrs } from "./renderImage";
 import { renderParagraphFragment } from "./renderParagraph";
 import { renderTextBoxFragment } from "./renderTextBox";
@@ -704,7 +708,7 @@ function renderTableCell({
     setAuthoredBackgroundColor(cellEl.style, cell.background);
     const automaticTextColor = getAutomaticTextColorForBackground(cell.background);
     if (automaticTextColor) {
-      cellEl.style.color = automaticTextColor;
+      setAuthoredTextColor(cellEl.style, automaticTextColor);
     }
   }
 

--- a/packages/core/src/layout-painter/renderTableFragment.test.ts
+++ b/packages/core/src/layout-painter/renderTableFragment.test.ts
@@ -277,6 +277,7 @@ describe("renderTableFragment authored backgrounds", () => {
 
     expect(cell?.style["backgroundColor"]).toBe("#F8F2EB");
     expect(cell?.style["--doc-authored-background-color"]).toBe("#F8F2EB");
+    expect(cell?.style["--doc-run-color"]).toBe("#000000");
   });
 });
 

--- a/packages/core/src/layout-painter/renderTableFragment.test.ts
+++ b/packages/core/src/layout-painter/renderTableFragment.test.ts
@@ -12,10 +12,31 @@ import type { PageGeometry } from "./anchoredImagePosition";
 import { renderTableFragment, TABLE_CLASS_NAMES } from "./renderTable";
 import type { RenderContext } from "./renderUtils";
 
+function createFakeStyle(): Record<string, string> {
+  const store: Record<string, string> = {};
+  return new Proxy(store, {
+    get(target, prop: string) {
+      if (prop === "setProperty") {
+        return (key: string, value: string) => {
+          target[key] = value;
+        };
+      }
+      if (prop === "getPropertyValue") {
+        return (key: string) => target[key] ?? "";
+      }
+      return target[prop];
+    },
+    set(target, prop: string, value: string) {
+      target[prop] = value;
+      return true;
+    },
+  }) as unknown as Record<string, string>;
+}
+
 class FakeElement {
   className = "";
   dataset: Record<string, string> = {};
-  style: Record<string, string> = {};
+  style: Record<string, string> = createFakeStyle();
   children: FakeElement[] = [];
   private ownText = "";
   readonly tagName: string;
@@ -200,6 +221,64 @@ function buildHeaderContinuation(): {
   };
   return { fragment, block, measure };
 }
+
+describe("renderTableFragment authored backgrounds", () => {
+  test("exposes a cell fill for dark-mode adaptation", () => {
+    const block: TableBlock = {
+      kind: "table",
+      id: "tbl",
+      rows: [
+        {
+          id: "row",
+          cells: [
+            {
+              id: "cell",
+              background: "#F8F2EB",
+              blocks: [{ kind: "paragraph", id: "paragraph", runs: [] }],
+            },
+          ],
+        },
+      ],
+      columnWidths: [100],
+    };
+    const measure: TableMeasure = {
+      kind: "table",
+      rows: [
+        {
+          cells: [
+            {
+              blocks: [{ kind: "paragraph", lines: [], totalHeight: 20 }],
+              width: 100,
+              height: 20,
+            },
+          ],
+          height: 20,
+        },
+      ],
+      columnWidths: [100],
+      totalWidth: 100,
+      totalHeight: 20,
+    };
+    const fragment: TableFragment = {
+      kind: "table",
+      blockId: "tbl",
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 20,
+      fromRow: 0,
+      toRow: 1,
+    };
+
+    const table = renderTableFragment(fragment, block, measure, renderContext, {
+      document: fakeDocument,
+    }) as unknown as FakeElement;
+    const cell = findByClass(table, TABLE_CLASS_NAMES.cell).at(0);
+
+    expect(cell?.style["backgroundColor"]).toBe("#F8F2EB");
+    expect(cell?.style["--doc-authored-background-color"]).toBe("#F8F2EB");
+  });
+});
 
 describe("renderTableFragment clipped header continuations", () => {
   test("keeps repeated headers pinned while clipping the body row", () => {

--- a/packages/core/src/layout-painter/renderTextBox.ts
+++ b/packages/core/src/layout-painter/renderTextBox.ts
@@ -18,6 +18,7 @@ import type {
   TextBoxBlock,
   TextBoxMeasure,
 } from "../layout-engine/types";
+import { setAuthoredBackgroundColor } from "./documentColors";
 import { layoutTextBoxContent } from "../layout-engine/measure/textBoxParagraphLayout";
 import { renderParagraphFragment } from "./renderParagraph";
 import type { RenderContext } from "./renderUtils";
@@ -67,7 +68,7 @@ export function renderTextBoxFragment(
 
   // Fill color
   if (block.fillColor) {
-    containerEl.style.backgroundColor = block.fillColor;
+    setAuthoredBackgroundColor(containerEl.style, block.fillColor);
   }
 
   // Border/outline

--- a/packages/react/src/styles/editor.css
+++ b/packages/react/src/styles/editor.css
@@ -343,16 +343,14 @@
   color: oklch(from var(--doc-run-color) clamp(0, 1.22 - 0.95 * l, 1) calc(c * 0.6) h) !important;
 }
 
-/* An authored run background is a local color surface: the painter chooses
- * its foreground from direct/theme text color or automatic contrast. This
- * rule must follow both broad dark-canvas rules above so their !important
- * inversion cannot repaint black-on-yellow as white-on-yellow. */
-.dark
-  .layout-page
-  [style*="--doc-run-background-text-color"].docx-run-background-text:not(.docx-insertion):not(
-    .docx-deletion
-  ) {
-  color: var(--doc-run-background-text-color) !important;
+/* Word adapts authored document surfaces with the same lightness inversion as
+ * authored text. Keep hue while mapping light cell/paragraph shading and text
+ * highlights onto the dark canvas; the text continues through the ordinary
+ * inversion above (for example, direct black becomes white on darkened yellow). */
+.dark .layout-page [style*="--doc-authored-background-color"] {
+  background-color: oklch(
+    from var(--doc-authored-background-color) clamp(0, 1.22 - 0.95 * l, 1) calc(c * 0.6) h
+  ) !important;
 }
 
 /* Tracked-change spans color from --tc-color (author colour), not

--- a/packages/react/src/styles/highlightContrast.test.ts
+++ b/packages/react/src/styles/highlightContrast.test.ts
@@ -5,18 +5,21 @@ const BACKGROUND_TEXT_SELECTOR =
   '[style*="--doc-run-background-text-color"].docx-run-background-text';
 const EXPLICIT_COLOR_SELECTOR =
   '.dark .layout-page [style*="--doc-run-color"]:not(.docx-insertion):not(.docx-deletion)';
+const AUTHORED_BACKGROUND_SELECTOR =
+  '.dark .layout-page [style*="--doc-authored-background-color"]';
 
 describe("dark-mode authored run backgrounds", () => {
-  test("the local background foreground wins after ordinary run-color inversion", () => {
+  test("inverts authored backgrounds and leaves their text on the document color path", () => {
     const css = readFileSync(new URL("editor.css", import.meta.url), "utf-8");
     const explicitColorRule = css.indexOf(EXPLICIT_COLOR_SELECTOR);
-    const backgroundTextRule = css.indexOf(BACKGROUND_TEXT_SELECTOR);
+    const authoredBackgroundRule = css.indexOf(AUTHORED_BACKGROUND_SELECTOR);
 
     expect(explicitColorRule).toBeGreaterThanOrEqual(0);
-    expect(backgroundTextRule).toBeGreaterThan(explicitColorRule);
-    const ruleStart = css.lastIndexOf(".dark", backgroundTextRule);
-    expect(css.slice(ruleStart, css.indexOf("}", backgroundTextRule) + 1)).toContain(
-      "color: var(--doc-run-background-text-color) !important",
+    expect(authoredBackgroundRule).toBeGreaterThan(explicitColorRule);
+    const ruleStart = css.lastIndexOf(".dark", authoredBackgroundRule);
+    expect(css.slice(ruleStart, css.indexOf("}", authoredBackgroundRule) + 1)).toContain(
+      "from var(--doc-authored-background-color) clamp(0, 1.22 - 0.95 * l, 1)",
     );
+    expect(css).not.toContain(BACKGROUND_TEXT_SELECTOR);
   });
 });


### PR DESCRIPTION
Adapt authored document backgrounds through the existing dark-mode lightness transform so highlighted and shaded content retains readable contrast.

Constrain oversized auto-width header and footer table grids during measurement so page furniture remains inside the content frame without mutating authored OOXML. Add synthetic invariant coverage and patch changesets for the affected packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dark-mode rendering for authored backgrounds, including highlights, paragraph shading and table cell fills, while preserving the original colours for adaptation.
  - Improved measurement of oversized, automatically sized header and footer tables so they fit within the document content width without altering authored column widths.
  - Fixed handling of fixed-width, floating and pinned-column tables during layout measurement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->