### PR TITLE
fix: reduce visual parity comparison noise

### DIFF
--- a/parity/__tests__/compare.test.ts
+++ b/parity/__tests__/compare.test.ts
@@ -172,6 +172,80 @@ describe("compareGeoms", () => {
     expect(merged).toHaveLength(2);
   });
 
+  test("merges header-story margin line numbers with adjacent body text", () => {
+    const merged = mergeVisualRows([
+      makeLine({
+        text: "16",
+        region: "header",
+        xPt: 81.7,
+        yPt: 423.4,
+        widthPt: 12,
+        heightPt: 8.25,
+      }),
+      makeLine({
+        text: "Application for Compensation",
+        region: "body",
+        xPt: 108,
+        yPt: 422.7,
+        widthPt: 150,
+        heightPt: 10.9,
+        direction: "ltr",
+      }),
+    ]);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toMatchObject({
+      normText: "16 Application for Compensation",
+      region: "body",
+    });
+  });
+
+  test("normalizes margin line-number rows symmetrically across extractors", () => {
+    const reference = makeDoc("word", [
+      makePage({
+        lines: [
+          makeLine({ text: "16", xPt: 81.7, yPt: 423.4, widthPt: 12, heightPt: 8.25 }),
+          makeLine({
+            text: "Application for Compensation",
+            xPt: 108,
+            yPt: 422.7,
+            widthPt: 150,
+            heightPt: 10.9,
+            direction: "ltr",
+          }),
+        ],
+      }),
+    ]);
+    const folio = makeDoc("folio", [
+      makePage({
+        lines: [
+          makeLine({
+            text: "16",
+            region: "header",
+            xPt: 81.7,
+            yPt: 423.4,
+            widthPt: 12,
+            heightPt: 8.25,
+          }),
+          makeLine({
+            text: "Application for Compensation",
+            region: "body",
+            xPt: 108,
+            yPt: 422.7,
+            widthPt: 150,
+            heightPt: 10.9,
+            direction: "ltr",
+          }),
+        ],
+      }),
+    ]);
+
+    const result = compareGeoms(reference, folio);
+
+    expect(result.score).toBe(1);
+    expect(result.divergences).toEqual([]);
+  });
+
   test("normalizes adjacent table cells symmetrically across extractors", () => {
     const word = makeDoc("word", [
       makePage({

--- a/parity/__tests__/compare.test.ts
+++ b/parity/__tests__/compare.test.ts
@@ -204,7 +204,7 @@ describe("compareGeoms", () => {
     const reference = makeDoc("word", [
       makePage({
         lines: [
-          makeLine({ text: "16", xPt: 81.7, yPt: 423.4, widthPt: 12, heightPt: 8.25 }),
+          makeLine({ text: "١٦", xPt: 81.7, yPt: 423.4, widthPt: 12, heightPt: 8.25 }),
           makeLine({
             text: "Application for Compensation",
             xPt: 108,
@@ -220,7 +220,7 @@ describe("compareGeoms", () => {
       makePage({
         lines: [
           makeLine({
-            text: "16",
+            text: "١٦",
             region: "header",
             xPt: 81.7,
             yPt: 423.4,

--- a/parity/__tests__/features.test.ts
+++ b/parity/__tests__/features.test.ts
@@ -273,6 +273,29 @@ describe("attributeDivergences", () => {
     expect(attributed.attributed[0]?.features).toEqual(["table"]);
   });
 
+  test("attributes refreshed TOC page numbers to the field paragraph, not the heading", () => {
+    const tocFeatures = ["tab-stops", "tab", "field", "hyperlink"];
+    const doc: DocFeatures = {
+      paragraphs: [
+        paragraph("Course Description & Objectives1", tocFeatures),
+        paragraph("Course Description & Objectives", []),
+      ],
+      docFeatures: [],
+    };
+    const result = baseResult([
+      {
+        kind: "text-mismatch",
+        page: 1,
+        referenceText: "Course Description & Objectives … 2",
+        folioText: "Course Description & Objectives … 1",
+      },
+    ]);
+
+    const attributed = attributeDivergences(result, doc);
+
+    expect(attributed.attributed[0]?.features).toEqual(tocFeatures);
+  });
+
   test("canonicalizes Word Arabic glyph aliases only for paragraph attribution", () => {
     const doc: DocFeatures = {
       paragraphs: [
@@ -673,6 +696,7 @@ describe("assessFontEnvironment", () => {
   test("recognizes equivalent PDF and CSS family names", () => {
     expect(fontFamiliesMatch("ArialMT", "Arial")).toBe(true);
     expect(fontFamiliesMatch("ABCDEF+Calibri-BoldItalic", "Calibri")).toBe(true);
+    expect(fontFamiliesMatch("TimesNewRomanPS-BoldItal", "Times New Roman")).toBe(true);
     expect(fontFamiliesMatch("Interstate-Bold", "Inter")).toBe(false);
   });
 

--- a/parity/__tests__/features.test.ts
+++ b/parity/__tests__/features.test.ts
@@ -697,6 +697,7 @@ describe("assessFontEnvironment", () => {
     expect(fontFamiliesMatch("ArialMT", "Arial")).toBe(true);
     expect(fontFamiliesMatch("ABCDEF+Calibri-BoldItalic", "Calibri")).toBe(true);
     expect(fontFamiliesMatch("TimesNewRomanPS-BoldItal", "Times New Roman")).toBe(true);
+    expect(fontFamiliesMatch("ArialMT-PSIt", "ArialMT")).toBe(true);
     expect(fontFamiliesMatch("Interstate-Bold", "Inter")).toBe(false);
   });
 

--- a/parity/__tests__/pdfReference.test.ts
+++ b/parity/__tests__/pdfReference.test.ts
@@ -45,6 +45,17 @@ describe("PDF reference page cache", () => {
               region: "body",
               direction: "rtl",
             },
+            {
+              text: "¨ Apply",
+              normText: "stale",
+              xPt: 0,
+              yPt: 30,
+              widthPt: 10,
+              heightPt: 10,
+              fontName: "Wingdings-Regular",
+              region: "body",
+              direction: "rtl",
+            },
           ],
         },
       ],
@@ -57,8 +68,13 @@ describe("PDF reference page cache", () => {
       "rtl",
       "ltr",
       "unknown",
+      "ltr",
     ]);
     expect(refreshed.pages[0]?.lines[0]?.normText).toBe("عنوان عربي");
+    expect(refreshed.pages[0]?.lines[3]).toMatchObject({
+      text: "\uf0a8 Apply",
+      normText: "☐ Apply",
+    });
   });
 
   test("does not treat a bounded render as a complete unbounded cache", () => {

--- a/parity/__tests__/stextParse.test.ts
+++ b/parity/__tests__/stextParse.test.ts
@@ -160,6 +160,34 @@ describe("parseStextXml", () => {
     expect(pages[0]?.lines[1]?.text).toBe("§ 12");
   });
 
+  test("normalizes the Wingdings F0A8 checkbox alias", () => {
+    const xml = documentEl(
+      pageEl(
+        1,
+        "612",
+        "792",
+        [
+          lineEl({
+            bbox: "0 0 100 10",
+            chars: "¨ Apply",
+            font: { name: "Wingdings-Regular", size: "12" },
+          }),
+          lineEl({
+            bbox: "0 20 100 30",
+            chars: "¨ Apply",
+            font: { name: "ArialMT", size: "12" },
+          }),
+        ].join(""),
+      ),
+    );
+
+    const lines = parseStextXml(xml)[0]?.lines;
+
+    expect(lines?.[0]?.text).toBe("\uf0a8 Apply");
+    expect(lines?.[0]?.normText).toBe("☐ Apply");
+    expect(lines?.[1]?.text).toBe("¨ Apply");
+  });
+
   test("reconstructs text from <char> elements when the line has no text attribute", () => {
     const xml = documentEl(
       pageEl(1, "612", "792", lineEl({ bbox: "0 0 60 10", chars: "NoTextAttr" })),

--- a/parity/__tests__/textNorm.test.ts
+++ b/parity/__tests__/textNorm.test.ts
@@ -36,6 +36,10 @@ describe("normalizeLineText", () => {
     expect(normalizeLineText("\uf0b7 First item")).toBe("• First item");
   });
 
+  test("normalizes legacy Wingdings checkboxes", () => {
+    expect(normalizeLineText("\uf0a8 Apply")).toBe("☐ Apply");
+  });
+
   test("folds Persian code points a PDF font map returns for Arabic letters", () => {
     expect(
       normalizeLineText(

--- a/parity/compare.ts
+++ b/parity/compare.ts
@@ -240,7 +240,7 @@ const shouldMergeRowBoxes = (current: LineBox, next: LineBox): boolean => {
  * shape; ordinary header/body content must remain separate. */
 const isHeaderLineNumberBodyPair = (a: LineBox, b: LineBox): boolean => {
   const isHeaderLineNumber = (line: LineBox): boolean =>
-    line.region === "header" && /^\d+$/u.test(normalizeLineText(line.text));
+    line.region === "header" && /^\p{Decimal_Number}+$/u.test(normalizeLineText(line.text));
   return (
     (isHeaderLineNumber(a) && b.region === "body") || (isHeaderLineNumber(b) && a.region === "body")
   );

--- a/parity/compare.ts
+++ b/parity/compare.ts
@@ -214,7 +214,10 @@ const mergeConnectedComponent = (component: LineBox[]): LineBox[] => {
 };
 
 const shouldMergeRowBoxes = (current: LineBox, next: LineBox): boolean => {
-  if (current.region !== next.region || resolveDirection([current, next]) === null) {
+  if (
+    (current.region !== next.region && !isHeaderLineNumberBodyPair(current, next)) ||
+    resolveDirection([current, next]) === null
+  ) {
     return false;
   }
   if (
@@ -228,6 +231,19 @@ const shouldMergeRowBoxes = (current: LineBox, next: LineBox): boolean => {
     return true;
   }
   return isStandaloneListMarker(current.text) && gap <= MARKER_ROW_MERGE_GAP_PT;
+};
+
+/** Word documents sometimes implement margin line numbers as a page-height
+ * text box in the header story. Folio consequently labels the number `header`
+ * and its adjacent text `body`, while PDF extraction has no story identity
+ * and merges the same two ink boxes. Permit only that narrow cross-story
+ * shape; ordinary header/body content must remain separate. */
+const isHeaderLineNumberBodyPair = (a: LineBox, b: LineBox): boolean => {
+  const isHeaderLineNumber = (line: LineBox): boolean =>
+    line.region === "header" && /^\d+$/u.test(normalizeLineText(line.text));
+  return (
+    (isHeaderLineNumber(a) && b.region === "body") || (isHeaderLineNumber(b) && a.region === "body")
+  );
 };
 
 const isStandaloneListMarker = (text: string): boolean => {
@@ -291,7 +307,7 @@ const mergeBoxes = (a: LineBox, b: LineBox): LineBox | null => {
     widthPt: Math.max(a.xPt + a.widthPt, b.xPt + b.widthPt) - xPt,
     heightPt: Math.max(a.yPt + a.heightPt, b.yPt + b.heightPt) - yPt,
     ...(baselinePt !== undefined ? { baselinePt } : {}),
-    region: a.region,
+    region: isHeaderLineNumberBodyPair(a, b) ? "body" : a.region,
     direction,
     ...(fontName !== undefined ? { fontName } : {}),
     ...(fontSizePt !== undefined ? { fontSizePt } : {}),

--- a/parity/features.ts
+++ b/parity/features.ts
@@ -353,8 +353,10 @@ const PDF_FONT_STYLE_SUFFIXES = new Set([
   "roman",
   "bold",
   "italic",
+  "ital",
   "oblique",
   "bolditalic",
+  "boldital",
   "boldoblique",
   "light",
   "medium",
@@ -365,7 +367,9 @@ const PDF_FONT_STYLE_SUFFIXES = new Set([
   "bolditalicmt",
   "psboldmt",
   "psitalicmt",
+  "psital",
   "psbolditalicmt",
+  "psboldital",
 ]);
 
 const normalizeFontName = (name: string): string =>
@@ -609,6 +613,8 @@ const MIN_MATCH_LEN = 4;
 const SIMILARITY_THRESHOLD = 0.9;
 const MIN_LENGTH_RATIO = 0.8;
 const MIN_SIMILARITY_MARGIN = 0.05;
+const TOC_LEADER_PAGE_PATTERN = /^(?<title>.+?)\s+(?:…|\.{3})\s+\p{Decimal_Number}+$/u;
+const TRAILING_PAGE_NUMBER_PATTERN = /\p{Decimal_Number}+$/u;
 
 /** Canonicalization used only to identify a divergence's source paragraph.
  * It must not hide text differences from the comparator. */
@@ -645,6 +651,26 @@ const shareFeatureSet = (candidates: ParagraphCandidate[]): boolean => {
   );
 };
 
+/** A Word export can refresh a TOC's PAGEREF result while Folio still paints
+ * the cached source value. Attribute that real mismatch to the field-bearing
+ * TOC paragraph, not to a later heading with the same title. XML paragraph
+ * scanning sees the tab and page field as adjacent text (`Title2`), whereas
+ * rendered geometry exposes a dot leader (`Title … 2`). */
+const findTocFieldParagraph = (
+  normalizedSearchText: string,
+  candidates: ParagraphCandidate[],
+): ParagraphFeatures | undefined => {
+  const title = TOC_LEADER_PAGE_PATTERN.exec(normalizedSearchText)?.groups?.["title"];
+  if (!title) return undefined;
+
+  const matches = candidates.filter(({ paragraph, normText }) => {
+    if (!paragraph.features.includes("field")) return false;
+    return normText.replace(TRAILING_PAGE_NUMBER_PATTERN, "").trimEnd() === title;
+  });
+  if (matches.length === 1) return matches[0]?.paragraph;
+  return shareFeatureSet(matches) ? matches[0]?.paragraph : undefined;
+};
+
 /** Prefer unambiguous substring matches. Fuzzy attribution is limited to
  * similarly sized, high-confidence candidates with a clear winner. */
 const findMatchingParagraph = (
@@ -652,6 +678,8 @@ const findMatchingParagraph = (
   candidates: ParagraphCandidate[],
 ): ParagraphFeatures | undefined => {
   const normalizedSearchText = normalizeAttributionText(searchText);
+  const tocFieldParagraph = findTocFieldParagraph(normalizedSearchText, candidates);
+  if (tocFieldParagraph) return tocFieldParagraph;
 
   const substringMatches = candidates.filter(({ normText }) => {
     const shorterLen = Math.min(normText.length, normalizedSearchText.length);

--- a/parity/features.ts
+++ b/parity/features.ts
@@ -367,6 +367,7 @@ const PDF_FONT_STYLE_SUFFIXES = new Set([
   "bolditalicmt",
   "psboldmt",
   "psitalicmt",
+  "psit",
   "psital",
   "psbolditalicmt",
   "psboldital",

--- a/parity/pdfReference.ts
+++ b/parity/pdfReference.ts
@@ -10,7 +10,7 @@ import { readdir } from "node:fs/promises";
 import path from "node:path";
 
 import { CACHE_DIR } from "./config";
-import { parseStextXml } from "./stextParse";
+import { normalizeFontEncodedText, parseStextXml } from "./stextParse";
 import { normalizeLineText } from "./textNorm";
 import { firstStrongTextDirection } from "./textDirection";
 import type { DocGeom, PageGeom } from "./types";
@@ -48,12 +48,14 @@ export const refreshCachedReferenceGeom = (geom: DocGeom, absDocxPath: string): 
     file: absDocxPath,
     pages: geom.pages.map((page) =>
       Object.assign({}, page, {
-        lines: page.lines.map((line) =>
-          Object.assign({}, line, {
-            normText: normalizeLineText(line.text),
-            direction: firstStrongTextDirection(line.text),
-          }),
-        ),
+        lines: page.lines.map((line) => {
+          const text = normalizeFontEncodedText(line.text, line.fontName);
+          return Object.assign({}, line, {
+            text,
+            normText: normalizeLineText(text),
+            direction: firstStrongTextDirection(text),
+          });
+        }),
       }),
     ),
   });

--- a/parity/stextParse.ts
+++ b/parity/stextParse.ts
@@ -68,7 +68,7 @@ const parseBbox = (bboxAttr: string): Bbox | null => {
 
 type LineFont = { name?: string; sizePt?: number };
 
-const normalizeFontEncodedText = (text: string, fontName: string | undefined): string => {
+export const normalizeFontEncodedText = (text: string, fontName: string | undefined): string => {
   // mutool exposes the character code behind Word's Wingdings square marker
   // as a section sign even though the rendered glyph is a black square.
   if (
@@ -77,6 +77,12 @@ const normalizeFontEncodedText = (text: string, fontName: string | undefined): s
     normalizeLineText(text) === "§"
   ) {
     return text.replace("§", "■");
+  }
+  // Word stores an empty Wingdings checkbox as w:sym F0A8. Chromium keeps
+  // that private-use code point, while mutool exposes the font's character
+  // code as U+00A8 even though both renderers paint the same square.
+  if (fontName !== undefined && /^(?:[A-Z]{6}\+)?Wingdings(?:-|$)/iu.test(fontName)) {
+    return text.replaceAll("¨", "\uf0a8");
   }
   return text;
 };

--- a/parity/textNorm.ts
+++ b/parity/textNorm.ts
@@ -58,6 +58,7 @@ export const normalizeLineText = (text: string): string => {
     .replace(/[⺀-⿕]/gu, (character) => character.normalize("NFKC"))
     .replace(/[­​-‍﻿]/gu, "")
     .replace(/\uf0b7/gu, "•")
+    .replace(/\uf0a8/gu, "☐")
     .replace(/\uf0e3/gu, "ã")
     // A PDF's ToUnicode map answers shaped Arabic glyphs with the Persian code
     // points (Farsi Yeh, Heh Doachashmee) even for documents that authored the


### PR DESCRIPTION
## Summary

- normalize equivalent line-number and Wingdings geometry across Word and Folio extraction
- refresh cached reference text facts after normalization changes
- recognize valid PostScript font style suffixes and attribute refreshed TOC fields correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved document comparison for margin line numbers adjacent to body text.
  - Improved attribution of table-of-contents page-number differences.
  - Recognised additional italic font naming variants when comparing documents.
  - Improved handling of Wingdings checkbox symbols, including direction detection and text normalisation.
- **Tests**
  - Added coverage for line merging, TOC divergence attribution, font matching and checkbox rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->