### PR TITLE
chore: align local hooks with remote CI

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -232,9 +232,6 @@
       },
     },
   },
-  "trustedDependencies": [
-    "lefthook",
-  ],
   "overrides": {
     "archiver": "8.0.0",
     "brace-expansion": "5.0.9",

--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,7 @@
         "fast-xml-parser": "^5.10.1",
         "happy-dom": "^20.14.0",
         "jszip": "3.10.1",
+        "lefthook": "^2.1.12",
         "lightningcss": "1.32.0",
         "oxfmt": "0.59.0",
         "oxlint": "1.74.0",
@@ -231,6 +232,9 @@
       },
     },
   },
+  "trustedDependencies": [
+    "lefthook",
+  ],
   "overrides": {
     "archiver": "8.0.0",
     "brace-expansion": "5.0.9",
@@ -1552,6 +1556,28 @@
     "launch-editor": ["launch-editor@2.14.1", "", { "dependencies": { "picocolors": "^1.1.1", "shell-quote": "^1.8.4" } }, "sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA=="],
 
     "lazystream": ["lazystream@1.0.1", "", { "dependencies": { "readable-stream": "^2.0.5" } }, "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw=="],
+
+    "lefthook": ["lefthook@2.1.12", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.1.12", "lefthook-darwin-x64": "2.1.12", "lefthook-freebsd-arm64": "2.1.12", "lefthook-freebsd-x64": "2.1.12", "lefthook-linux-arm64": "2.1.12", "lefthook-linux-x64": "2.1.12", "lefthook-openbsd-arm64": "2.1.12", "lefthook-openbsd-x64": "2.1.12", "lefthook-windows-arm64": "2.1.12", "lefthook-windows-x64": "2.1.12" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-2uOexfsrrRhCiTUWdGyDySxVHHhOFJ8MQejs27dM3hugrQB48/z1ZVlaNoxpZ1SnzQ1GaDIbO5rAvicwyiknYQ=="],
+
+    "lefthook-darwin-arm64": ["lefthook-darwin-arm64@2.1.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-GSUjqaCuxAYlPOovbjXEWE3HAIa/xOQkTTmZ937zieQldjPLTaC7+s5FHoxKywn+D9riBlofkDqG7Z4f5zzmPA=="],
+
+    "lefthook-darwin-x64": ["lefthook-darwin-x64@2.1.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-qAUHSSw/7Afi5wxkoLkxORxSicCeTBXyVLnRgD6YZra6udviozpK3Aok9Z6FIWeKc5FBijRMSNDxGPTREhsjcQ=="],
+
+    "lefthook-freebsd-arm64": ["lefthook-freebsd-arm64@2.1.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-FHZRfKliFNbyz54zsoGdVe9muq67cNjBTZ6jrPPUjI7xUuyCwSpzA+1OpiwJT00L9pP5ZGONBqnGZKnrpC+7Uw=="],
+
+    "lefthook-freebsd-x64": ["lefthook-freebsd-x64@2.1.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-HYQZPGy2DDEx7dbuotusJpujY5q9igOLgx36qeeQcNQuvvdGHPj2ZGSIsGKhoJ0dw5Qa4knKJoPAHEZQWdV/og=="],
+
+    "lefthook-linux-arm64": ["lefthook-linux-arm64@2.1.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-ipjOri2PB/sk4noPrHQuM5fcpNBjmlKo4qMtXyLnxeOxGYHWZzf0Xi0OtrXHQ//tOprcv40ADvhUuSdcGqigLw=="],
+
+    "lefthook-linux-x64": ["lefthook-linux-x64@2.1.12", "", { "os": "linux", "cpu": "x64" }, "sha512-DmU6xfvqVoFdW+STyc70YI4Ry8vkHGKHx+IJ1Js/Gacq5dv+fiwNzwle3bi28EkL6P8xY67B/CfQfRj4SRU4tg=="],
+
+    "lefthook-openbsd-arm64": ["lefthook-openbsd-arm64@2.1.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-vb0J7bElLvoaCWQmna3HntsvoNqMsGAhfjjC99ss1OdCteufZKM3RxCVoMBEbD50Itv2c1Ua2AFVToltVFTy1Q=="],
+
+    "lefthook-openbsd-x64": ["lefthook-openbsd-x64@2.1.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-QOmhDWqPPK4+99scanfEmbJjUR+JYC93qhr/0bp5Dj3LaR3kVFNWc6zOQUsOTPy/LC6PG759Lej/mr/BtjUL2Q=="],
+
+    "lefthook-windows-arm64": ["lefthook-windows-arm64@2.1.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-eErEyr9AHkRFj6TxpCQeKGd0s6IrtL/VEIZ/ssg8dNfG+ycR4jAW/IAlrJSw6/ZQXb3WtWLaQ6QA5c+TLh7vmg=="],
+
+    "lefthook-windows-x64": ["lefthook-windows-x64@2.1.12", "", { "os": "win32", "cpu": "x64" }, "sha512-0h+WmDVdDriTjloD/UbjPq/ZtqaaJlPAdGcVwMCEdAxfbF0FTgDbKX3igui9g2U/qG2y6QpVhtz1jeiRe7ctaw=="],
 
     "lib0": ["lib0@0.2.117", "", { "dependencies": { "isomorphic.js": "^0.2.4" }, "bin": { "0serve": "bin/0serve.js", "0gentesthtml": "bin/gentesthtml.js", "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js" } }, "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw=="],
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,27 @@
+# Opt-in pre-commit hooks.
+# To activate: bun run hooks:install
+# To deactivate: bun run hooks:uninstall
+#
+# These hooks are NOT auto-installed. Each developer
+# chooses whether to use them.
+
+no_auto_install: true
+
+pre-commit:
+  parallel: false
+  commands:
+    lint:
+      glob: "**/*.{ts,tsx,js,jsx}"
+      run: bun --bun oxlint -c oxlint.config.ts --threads=2 --deny-warnings --no-error-on-unmatched-pattern --fix {staged_files}
+      stage_fixed: true
+    format:
+      glob: "**/*.{ts,tsx,js,jsx,json,css}"
+      run: bun --bun oxfmt -c .oxfmtrc.json --no-error-on-unmatched-pattern {staged_files}
+      stage_fixed: true
+    i18n:
+      glob: "packages/core/src/i18n/messages/*.{json,ts}"
+      run: bun run i18n:sync
+      stage_fixed: true
+
+# Heavy checks run in CI. Use the repository scripts when you want to run
+# lint, typecheck, tests, builds, or full formatting locally before pushing.

--- a/package.json
+++ b/package.json
@@ -151,8 +151,5 @@
     "undici": "8.9.0",
     "valibot": "1.4.2"
   },
-  "packageManager": "bun@1.4.1",
-  "trustedDependencies": [
-    "lefthook"
-  ]
+  "packageManager": "bun@1.4.1"
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   "type": "module",
   "scripts": {
     "clean": "git clean -xdf packages/*/dist .cache .turbo node_modules",
+    "hooks:install": "lefthook install",
+    "hooks:uninstall": "lefthook uninstall",
     "audit": "bun audit --audit-level=moderate --ignore=GHSA-5p4m-2wfm-xmqj",
     "check:parity-contract": "node scripts/check-parity-contract.mjs",
     "check:export-parity": "node scripts/check-export-parity.mjs",
@@ -124,6 +126,7 @@
     "fast-xml-parser": "^5.10.1",
     "happy-dom": "^20.14.0",
     "jszip": "3.10.1",
+    "lefthook": "^2.1.12",
     "lightningcss": "1.32.0",
     "oxfmt": "0.59.0",
     "oxlint": "1.74.0",
@@ -148,5 +151,8 @@
     "undici": "8.9.0",
     "valibot": "1.4.2"
   },
-  "packageManager": "bun@1.4.1"
+  "packageManager": "bun@1.4.1",
+  "trustedDependencies": [
+    "lefthook"
+  ]
 }


### PR DESCRIPTION
## Summary

- add Stella-aligned opt-in Lefthook installation scripts and dependency
- run staged lint fixes, formatting, and i18n synchronization before commits
- keep pre-push free of heavy checks so remote CI remains authoritative
- avoid lifecycle-script trust because it changes Bun's isolated dependency layout and breaks Nuxt type inference