### PR TITLE
fix: improve Word visual parity signals

### DIFF
--- a/.changeset/crisp-table-fonts.md
+++ b/.changeset/crisp-table-fonts.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Keep table-style fonts ahead of document-default fonts in table cells.

--- a/.changeset/quiet-anchored-textboxes.md
+++ b/.changeset/quiet-anchored-textboxes.md
@@ -1,0 +1,6 @@
+---
+"@stll/docx-core": patch
+"@stll/folio-core": patch
+---
+
+Preserve and render DrawingML text-box rotation and flips across editor and PDF output.

--- a/.changeset/steady-page-furniture.md
+++ b/.changeset/steady-page-furniture.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Honor page-margin header tabs without changing body tab stops.

--- a/api-reports/core/layout-bridge-engine-measuring.api.md
+++ b/api-reports/core/layout-bridge-engine-measuring.api.md
@@ -197,6 +197,7 @@ export type MeasureParagraphOptions = {
     floatingZones?: FloatingImageZone[];
     paragraphYOffset?: number;
     fieldValues?: ReadonlyMap<number, string>;
+    allowEndTabOverflow?: boolean;
 };
 
 // @public

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -1020,6 +1020,7 @@ export type TextBoxBlock = {
     outlineWidth?: number;
     outlineColor?: string;
     outlineStyle?: OutlineStyleAttr;
+    transform?: string;
     margins?: {
         top: number;
         bottom: number;

--- a/api-reports/core/prosemirror-schema.api.md
+++ b/api-reports/core/prosemirror-schema.api.md
@@ -568,6 +568,7 @@ export type TextBoxAttrs = {
     outlineWidth?: number;
     outlineColor?: string;
     outlineStyle?: OutlineStyleAttr;
+    transform?: string;
     marginTop?: number;
     marginBottom?: number;
     marginLeft?: number;

--- a/api-reports/docx-core/model.api.md
+++ b/api-reports/docx-core/model.api.md
@@ -1280,6 +1280,7 @@ export type TextBox = {
     wrap?: ImageWrap;
     fill?: ShapeFill;
     outline?: ShapeOutline;
+    transform?: ImageTransform;
     content: (Paragraph | Table)[];
     autoFit?: ShapeTextBody["autoFit"];
     textWrap?: ShapeTextBody["textWrap"];

--- a/packages/core/src/controller/layoutPipeline.ts
+++ b/packages/core/src/controller/layoutPipeline.ts
@@ -539,6 +539,7 @@ export function runLayoutPipeline<THfPMs>(
           undefined,
           undefined,
           buildHeaderFooterFieldValues(hfBlocks, pageCount, hfClock, fieldInputs),
+          { allowEndTabOverflow: true },
         );
       return {
         ...(flowOpts.styles ? { styles: flowOpts.styles } : {}),

--- a/packages/core/src/display-list/build/buildDisplayList.test.ts
+++ b/packages/core/src/display-list/build/buildDisplayList.test.ts
@@ -368,6 +368,31 @@ describe("buildDisplayList: paint order", () => {
       ).toBe(true);
     }, fakeMeasure);
   });
+
+  test("applies DrawingML rotation and flips about its authored text-box frame centre", () => {
+    withFakeTextMeasure(() => {
+      const textBox: TextBoxBlock = {
+        kind: "textBox",
+        id: "rotated-box",
+        width: 120,
+        height: 40,
+        transform: "rotate(270deg) scaleX(-1) scaleY(-1)",
+        content: [para("rotated-box-paragraph", "Likelihood")],
+      };
+
+      const primitive = pagePrimitives([textBox]).at(0);
+      expect(primitive?.kind).toBe("rotateGroup");
+      if (primitive?.kind !== "rotateGroup") {
+        return;
+      }
+      expect(primitive.degrees).toBe(270);
+      expect(primitive.originXPx).toBe(MARGINS.left + 60);
+      expect(primitive.originYPx).toBe(MARGINS.top + 20);
+      expect(primitive.scaleX).toBe(-1);
+      expect(primitive.scaleY).toBe(-1);
+      expect(primitive.children.some(({ kind }) => kind === "glyphRun")).toBe(true);
+    }, fakeMeasure);
+  });
 });
 
 describe("buildDisplayList: contract obligations", () => {

--- a/packages/core/src/display-list/build/textBoxPrimitives.ts
+++ b/packages/core/src/display-list/build/textBoxPrimitives.ts
@@ -8,10 +8,15 @@
 import { layoutTextBoxContent } from "../../layout-engine/measure/textBoxParagraphLayout";
 import { DEFAULT_TEXTBOX_MARGINS } from "../../layout-engine/types";
 import type { TextBoxBlock, TextBoxFragment, TextBoxMeasure } from "../../layout-engine/types";
+import {
+  hasHorizontalFlip,
+  hasVerticalFlip,
+  parseRotationDegrees,
+} from "../../utils/rotationBoundingBox";
 import type { DisplayPrimitive } from "../types";
 import { HIT_REGION_KINDS } from "../primitives";
 import type { BuildContext } from "./buildContext";
-import { blockRegion, type PageComposer } from "./regions";
+import { blockRegion, createPageComposer, type PageComposer } from "./regions";
 import { parseDisplayColor } from "./colors";
 import { paintParagraphFragment } from "./paragraphPrimitives";
 import { paintTableBlock } from "./tablePrimitives";
@@ -27,6 +32,36 @@ export type TextBoxPaintOptions = {
 };
 
 export const paintTextBoxFragment = ({
+  composer,
+  fragment,
+  block,
+  measure,
+  context,
+}: TextBoxPaintOptions): void => {
+  const rotation = parseRotationDegrees(block.transform);
+  const flipH = hasHorizontalFlip(block.transform);
+  const flipV = hasVerticalFlip(block.transform);
+  if (rotation === 0 && !flipH && !flipV) {
+    paintUnrotatedTextBoxFragment({ composer, fragment, block, measure, context });
+    return;
+  }
+
+  const inner = createPageComposer();
+  paintUnrotatedTextBoxFragment({ composer: inner, fragment, block, measure, context });
+  composer.push([
+    {
+      kind: "rotateGroup",
+      degrees: rotation,
+      originXPx: fragment.x + fragment.width / 2,
+      originYPx: fragment.y + fragment.height / 2,
+      ...(flipH ? { scaleX: -1 } : {}),
+      ...(flipV ? { scaleY: -1 } : {}),
+      children: inner.primitives(),
+    },
+  ]);
+};
+
+const paintUnrotatedTextBoxFragment = ({
   composer,
   fragment,
   block,

--- a/packages/core/src/display-list/dom/renderDisplayListToDom.test.ts
+++ b/packages/core/src/display-list/dom/renderDisplayListToDom.test.ts
@@ -496,18 +496,20 @@ describe("renderDisplayListToDom", () => {
     expect(child?.style.top).toBe("40px");
   });
 
-  test("keeps child coordinates through rotate and opacity groups", () => {
+  test("keeps child coordinates through transformed and opacity groups", () => {
     const rotate = renderPrimitives([
       {
         kind: "rotateGroup",
         degrees: 90,
         originXPx: 40,
         originYPx: 50,
+        scaleX: -1,
+        scaleY: -1,
         children: [PRIMITIVE_SAMPLES.rect],
       },
     ]).children.at(0);
 
-    expect(rotate?.style.transform).toBe("rotate(90deg)");
+    expect(rotate?.style.transform).toBe("rotate(90deg) scaleX(-1) scaleY(-1)");
     expect(rotate?.style.transformOrigin).toBe("40px 50px");
     expect(rotate?.children.at(0)?.style.left).toBe("10px");
 

--- a/packages/core/src/display-list/dom/renderDisplayListToDom.ts
+++ b/packages/core/src/display-list/dom/renderDisplayListToDom.ts
@@ -609,12 +609,19 @@ const paintClipGroup = ({ rect, children, regions }: DisplayClipGroup, context: 
 };
 
 const paintRotateGroup = (
-  { degrees, originXPx, originYPx, children }: DisplayRotateGroup,
+  { degrees, originXPx, originYPx, scaleX, scaleY, children }: DisplayRotateGroup,
   context: PaintContext,
 ) => {
   const element = createTransparentGroupDiv(context);
   element.style.transformOrigin = `${px(originXPx - context.originXPx)} ${px(originYPx - context.originYPx)}`;
-  element.style.transform = `rotate(${degrees}deg)`;
+  const transforms = [`rotate(${degrees}deg)`];
+  if (scaleX === -1) {
+    transforms.push("scaleX(-1)");
+  }
+  if (scaleY === -1) {
+    transforms.push("scaleY(-1)");
+  }
+  element.style.transform = transforms.join(" ");
   context.parent.append(element);
 
   const inner = { ...context, parent: element };

--- a/packages/core/src/display-list/types.ts
+++ b/packages/core/src/display-list/types.ts
@@ -319,16 +319,20 @@ export type DisplayClipGroup = {
 };
 
 /**
- * Rotates its children about `originXPx`/`originYPx`. Rotated images,
- * watermark text and vertical (`w:textDirection`) table text are all this.
- * Rotation is the only transform folio paints; scale is resolved into
- * geometry by the producer.
+ * Rotates and optionally reflects its children about `originXPx`/`originYPx`.
+ * Rotated images, text boxes, watermark text and vertical (`w:textDirection`)
+ * table text are all this. A scale of `-1` is a DrawingML flip; the scale is
+ * applied before the rotation, matching CSS and OOXML transform order.
  */
 export type DisplayRotateGroup = {
   readonly kind: "rotateGroup";
   readonly degrees: number;
   readonly originXPx: number;
   readonly originYPx: number;
+  /** Optional horizontal reflection about the transform origin. */
+  readonly scaleX?: -1;
+  /** Optional vertical reflection about the transform origin. */
+  readonly scaleY?: -1;
   readonly children: readonly DisplayPrimitive[];
 };
 

--- a/packages/core/src/headless-layout.ts
+++ b/packages/core/src/headless-layout.ts
@@ -310,6 +310,7 @@ const convertStories = ({
           undefined,
           undefined,
           buildHeaderFooterFieldValues(blocks, pageCount, now),
+          { allowEndTabOverflow: true },
         ),
       rId,
     });

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -3137,6 +3137,9 @@ function convertTextBoxNode(
   if (attrs.outlineStyle !== undefined) {
     textBox.outlineStyle = attrs.outlineStyle;
   }
+  if (attrs.transform !== undefined) {
+    textBox.transform = attrs.transform;
+  }
   // Carry anchored-textbox wrap attributes through so the page renderer can
   // build exclusion rects (eigenpal #474).
   if (attrs.displayMode !== undefined) {

--- a/packages/core/src/layout-engine/measure/measureBlocks.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.ts
@@ -57,6 +57,11 @@ const NO_WRAP_MEASURE_WIDTH = 1_000_000;
  */
 const MAX_TABLE_COLUMNS = 63;
 
+export type MeasureBlocksOptions = {
+  /** Header/footer tabs may be authored in the page margin, beyond body width. */
+  allowEndTabOverflow?: boolean;
+};
+
 /**
  * Check if an image run is a *text-wrapping* floating image — it
  * occupies an exclusion zone the body text should flow around.
@@ -963,6 +968,7 @@ export function measureBlock(
   floatingZones?: FloatingImageZone[],
   cumulativeY?: number,
   fieldValues?: ReadonlyMap<number, string>,
+  options?: MeasureBlocksOptions,
 ): Measure {
   switch (block.kind) {
     case "paragraph": {
@@ -978,7 +984,9 @@ export function measureBlock(
       // the stabilization pass; field-free paragraphs stay cacheable.
       const hasFieldRuns = pBlock.runs.some((run) => run.kind === "field");
       const cacheable =
-        (!floatingZones || floatingZones.length === 0) && (!fieldValues || !hasFieldRuns);
+        (!floatingZones || floatingZones.length === 0) &&
+        (!fieldValues || !hasFieldRuns) &&
+        options?.allowEndTabOverflow !== true;
       if (cacheable) {
         const cached = getCachedParagraphMeasure(pBlock, contentWidth);
         if (cached) {
@@ -994,6 +1002,9 @@ export function measureBlock(
       }
       if (fieldValues) {
         measureOpts.fieldValues = fieldValues;
+      }
+      if (options?.allowEndTabOverflow === true) {
+        measureOpts.allowEndTabOverflow = true;
       }
       const result = measureParagraph(pBlock, contentWidth, measureOpts);
 
@@ -1111,6 +1122,7 @@ export function measureBlocks(
   marginTop: number | number[] = 0,
   pageGeometry?: BandPageGeometry,
   fieldValues?: ReadonlyMap<number, string>,
+  options?: MeasureBlocksOptions,
 ): Measure[] {
   const defaultWidth = Array.isArray(contentWidth) ? (contentWidth[0] ?? 0) : contentWidth;
   // Pre-extract floating image exclusion zones with anchor block indices
@@ -1284,7 +1296,7 @@ export function measureBlocks(
         : undefined;
 
     try {
-      const measure = measureBlock(block, blockWidth, zones, cumulativeY, fieldValues);
+      const measure = measureBlock(block, blockWidth, zones, cumulativeY, fieldValues, options);
 
       // Paragraphs clear floating exclusions internally (findClearLineY inside
       // measureParagraph). An in-flow table cannot reflow its cells around a

--- a/packages/core/src/layout-engine/measure/measureParagraph-right-tab.test.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph-right-tab.test.ts
@@ -268,6 +268,30 @@ describe("measureParagraph — right/center tab stops (eigenpal #576)", () => {
     });
   });
 
+  test("preserves a header/footer end tab authored beyond the body width", () => {
+    withFakeTextMeasure(() => {
+      const measure = measureParagraph(
+        {
+          kind: "paragraph",
+          id: "header-end-tab-in-page-margin",
+          runs: [
+            { kind: "text", text: "Title", fontSize: 11 },
+            { kind: "tab" },
+            { kind: "text", text: "7", fontSize: 11 },
+          ],
+          attrs: {
+            tabs: [{ val: "end", pos: 7500 }],
+          },
+        },
+        400,
+        { allowEndTabOverflow: true },
+      );
+
+      expect(measure.lines).toHaveLength(1);
+      expect(measure.lines.at(0)?.width).toBe(500);
+    });
+  });
+
   test("preserves the logical endpoint of an RTL TOC end tab", () => {
     withFakeTextMeasure(
       () => {

--- a/packages/core/src/layout-engine/measure/measureParagraph.ts
+++ b/packages/core/src/layout-engine/measure/measureParagraph.ts
@@ -126,6 +126,8 @@ export type MeasureParagraphOptions = {
   /** Field run `pmStart` -> resolved display text, so a field measures at its
    *  painted width instead of the cached fallback. */
   fieldValues?: ReadonlyMap<number, string>;
+  /** Header/footer tabs may be authored in the page margin, beyond body width. */
+  allowEndTabOverflow?: boolean;
 };
 
 /**
@@ -1772,7 +1774,8 @@ export function measureParagraph(
       const activeContentRightEdge = maxWidth - currentLine.rightOffset;
       const preservesAuthoredEndStop =
         tabResult.alignment === "end" &&
-        authoredEndpoint <= activeContentRightEdge + WIDTH_TOLERANCE;
+        (options?.allowEndTabOverflow === true ||
+          authoredEndpoint <= activeContentRightEdge + WIDTH_TOLERANCE);
       const landsOnLeftIndent =
         tabResult.alignment === "start" &&
         indentLeft > 0 &&

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -876,6 +876,8 @@ export type TextBoxBlock = {
   outlineColor?: string;
   /** Outline dash style, or `"none"` for an explicit no-outline. */
   outlineStyle?: OutlineStyleAttr;
+  /** DrawingML rotation and/or flips, serialized as CSS transform functions. */
+  transform?: string;
   /** Internal padding */
   margins?: { top: number; bottom: number; left: number; right: number };
   /** Flow blocks inside the text box */

--- a/packages/core/src/layout-painter/renderParagraph-right-tab.test.ts
+++ b/packages/core/src/layout-painter/renderParagraph-right-tab.test.ts
@@ -373,6 +373,39 @@ describe("renderLine right-tab flex anchor", () => {
     expect(lineEl.dataset["flexLine"]).toBe("true");
   });
 
+  test("keeps a header end tab authored in the page margin", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "header-end-tab-in-page-margin",
+      runs: [{ kind: "text", text: "Title" }, { kind: "tab" }, { kind: "text", text: "7" }],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 2,
+      toChar: 1,
+      width: 500,
+      ascent: 12,
+      descent: 3,
+      lineHeight: 15,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument, {
+      availableWidth: 400,
+      isLastLine: true,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      tabStops: [{ val: "end", pos: 7500 }],
+      leftIndentPx: 0,
+      contentWidthPx: 400,
+      lineRightEdgePx: 400,
+      context: { pageNumber: 1, totalPages: 1, section: "header" },
+    }) as unknown as FakeElement;
+
+    expect(lineEl.dataset["flexLine"]).toBeUndefined();
+    expect(findTabEl(lineEl)?.style["width"]).toBe("458px");
+  });
+
   test("keeps an RTL TOC end tab logical instead of flex-anchoring it physically", () => {
     const block: ParagraphBlock = {
       kind: "paragraph",

--- a/packages/core/src/layout-painter/renderParagraph.ts
+++ b/packages/core/src/layout-painter/renderParagraph.ts
@@ -2542,7 +2542,9 @@ export function renderLine(
       const preservesAuthoredEndStop =
         activeContentRightEdge !== undefined &&
         tabResult.alignment === "end" &&
-        authoredEndpoint <= activeContentRightEdge + RIGHT_EDGE_EPSILON_PX;
+        (options?.context?.section === "header" ||
+          options?.context?.section === "footer" ||
+          authoredEndpoint <= activeContentRightEdge + RIGHT_EDGE_EPSILON_PX);
       const preservesAuthoredEndStopPastIndent =
         lineRightEdgeX !== undefined &&
         preservesAuthoredEndStop &&

--- a/packages/core/src/pdf/pageSpace.ts
+++ b/packages/core/src/pdf/pageSpace.ts
@@ -74,3 +74,39 @@ export const rotationMatrix = (
     originYPx - originXPx * sin - originYPx * cos,
   ];
 };
+
+/**
+ * A DrawingML flip and rotation about one display-list point. CSS applies the
+ * rightmost scale first, then the rotation; this matrix does the same.
+ */
+export const transformMatrix = ({
+  degrees,
+  originXPx,
+  originYPx,
+  scaleX,
+  scaleY,
+}: {
+  readonly degrees: number;
+  readonly originXPx: number;
+  readonly originYPx: number;
+  readonly scaleX?: -1;
+  readonly scaleY?: -1;
+}): PdfMatrix => {
+  const radians = (degrees * Math.PI) / 180;
+  const cos = Math.cos(radians);
+  const sin = Math.sin(radians);
+  const horizontalScale = scaleX ?? 1;
+  const verticalScale = scaleY ?? 1;
+  const a = cos * horizontalScale;
+  const b = sin * horizontalScale;
+  const c = -sin * verticalScale;
+  const d = cos * verticalScale;
+  return [
+    a,
+    b,
+    c,
+    d,
+    originXPx - originXPx * a - originYPx * c,
+    originYPx - originXPx * b - originYPx * d,
+  ];
+};

--- a/packages/core/src/pdf/paint.ts
+++ b/packages/core/src/pdf/paint.ts
@@ -32,7 +32,7 @@ import {
 } from "./contentStream";
 import { needsShaping } from "../shaping/placeRun";
 import type { EmbeddedPdfFont, PreparedFont, ShapedRunRequest } from "./fonts";
-import { basePageMatrix, rotationMatrix } from "./pageSpace";
+import { basePageMatrix, transformMatrix } from "./pageSpace";
 
 export class PaintError extends TaggedError("PaintError")<{ message: string }> {}
 
@@ -494,9 +494,7 @@ const paintPrimitive = (context: PaintContext, primitive: DisplayPrimitive) => {
     }
     case "rotateGroup": {
       context.stream.save();
-      context.stream.concat(
-        rotationMatrix(primitive.degrees, primitive.originXPx, primitive.originYPx),
-      );
+      context.stream.concat(transformMatrix(primitive));
       for (const child of primitive.children) {
         paintPrimitive(context, child);
       }

--- a/packages/core/src/pdf/writePdf.test.ts
+++ b/packages/core/src/pdf/writePdf.test.ts
@@ -445,6 +445,23 @@ describe("primitive coverage", () => {
     expect(content).toContain("0 1 -1 0 30 10 cm");
   });
 
+  test("reflects around the same origin before rotating", async () => {
+    const content = contentStreamOf(
+      (
+        await write(
+          listWith([
+            {
+              ...SAMPLE_BY_KIND.rotateGroup,
+              degrees: 0,
+              scaleX: -1,
+            },
+          ]),
+        )
+      ).bytes,
+    );
+    expect(content).toContain("-1 0 0 1 20 0 cm");
+  });
+
   test("clips a cropped image and scales it past the destination box", async () => {
     const list: DisplayList = {
       ...listWith([SAMPLE_BY_KIND.image]),

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -115,6 +115,10 @@ const TEXT_BOX_TEXT_WRAP_VALUES = ["square", "none"] as const satisfies readonly
   TextBoxAttrs["textWrap"]
 >[];
 
+/** The complete DrawingML transform subset carried by text boxes. */
+const TEXT_BOX_TRANSFORM_PATTERN =
+  /^(?=rotate|scaleX|scaleY)(?:rotate\(-?\d+(?:\.\d+)?deg\)(?: )?)?(?:scaleX\(-1\)(?: )?)?(?:scaleY\(-1\))?$/u;
+
 const FIELD_KINDS = ["simple", "complex"] as const satisfies readonly FieldAttrs["fieldKind"][];
 
 const MATH_DISPLAYS = ["inline", "block"] as const satisfies readonly NonNullable<
@@ -901,6 +905,7 @@ export const readTextBoxAttrs = (node: PMNode): ReadProseMirrorAttrsResult<TextB
     issues,
     OUTLINE_STYLE_ATTR_VALUES,
   );
+  optionalTextBoxTransform(attrs, "transform", "textBox.attrs.transform", issues);
   optionalNumber(attrs, "marginTop", "textBox.attrs.marginTop", issues);
   optionalNumber(attrs, "marginBottom", "textBox.attrs.marginBottom", issues);
   optionalNumber(attrs, "marginLeft", "textBox.attrs.marginLeft", issues);
@@ -1650,6 +1655,28 @@ const optionalString = (
   const value = attrs[key];
   if (value !== undefined && value !== null && typeof value !== "string") {
     issues.push({ path, message: "Expected a string." });
+  }
+};
+
+const optionalTextBoxTransform = (
+  attrs: Record<string, unknown>,
+  key: string,
+  path: string,
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  const value = attrs[key];
+  if (value === undefined || value === null) {
+    return;
+  }
+  if (typeof value !== "string") {
+    issues.push({ path, message: "Expected a string." });
+    return;
+  }
+  if (!TEXT_BOX_TRANSFORM_PATTERN.test(value)) {
+    issues.push({
+      path,
+      message: "Expected DrawingML rotation and/or horizontal or vertical flips.",
+    });
   }
 };
 

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.test.ts
@@ -2885,6 +2885,37 @@ describe("fromProseDoc", () => {
     expect(firstShapeType(block)).toBe("textBox");
   });
 
+  test("round-trips a DrawingML text-box transform", () => {
+    const document = documentWithTextBoxParagraph({ includeText: false });
+    const sourceParagraph = document.package.document.content.at(0);
+    const sourceRun =
+      sourceParagraph?.type === "paragraph" ? sourceParagraph.content.at(0) : undefined;
+    const sourceShape = sourceRun?.type === "run" ? sourceRun.content.at(0) : undefined;
+    if (sourceShape?.type !== "shape") {
+      throw new Error("Expected source text-box shape");
+    }
+    sourceShape.shape.position = {
+      horizontal: { relativeTo: "column", posOffset: 0 },
+      vertical: { relativeTo: "paragraph", posOffset: 0 },
+    };
+    sourceShape.shape.transform = { rotation: 270, flipH: true, flipV: true };
+
+    const pmDoc = toProseDoc(document);
+    const restored = fromProseDoc(pmDoc, document);
+    const restoredParagraph = restored.package.document.content.at(0);
+
+    expect(pmDoc.childCount).toBe(1);
+    expect(pmDoc.lastChild?.attrs["transform"]).toBe("rotate(270deg) scaleX(-1) scaleY(-1)");
+    if (restoredParagraph?.type !== "paragraph") {
+      throw new Error("Expected restored text-box paragraph");
+    }
+    expect(firstShapeContent(restoredParagraph)?.shape.transform).toEqual({
+      rotation: 270,
+      flipH: true,
+      flipV: true,
+    });
+  });
+
   test.each(["insertion", "deletion", "moveFrom", "moveTo"] as const)(
     "round-trips a text box inside the %s wrapper",
     (type) => {

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -5030,6 +5030,11 @@ function convertPMTextBox(node: PMNode, styleResolver: StyleEngine | null = null
     shape.id = attrs.textBoxId;
   }
 
+  const transform = parseTransformAttr(attrs.transform);
+  if (transform) {
+    shape.transform = transform;
+  }
+
   // Convert fill color back
   if (attrs.fillColor) {
     shape.fill = {

--- a/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
@@ -1225,6 +1225,71 @@ describe("toProseDoc", () => {
     expect(text?.marks.find((mark) => mark.type.name === "textColor")?.attrs.rgb).toBe("365F91");
   });
 
+  test("table style fonts replace doc defaults while retaining paragraph-style slots", () => {
+    const document: Document = {
+      package: {
+        styles: {
+          docDefaults: {
+            rPr: {
+              fontFamily: { ascii: "Calibri", hAnsi: "Calibri", cs: "Calibri" },
+            },
+          },
+          styles: [
+            {
+              styleId: "Normal",
+              type: "paragraph",
+              default: true,
+              rPr: { fontFamily: { cs: "Times New Roman" } },
+            },
+            {
+              styleId: "Header",
+              type: "paragraph",
+              basedOn: "Normal",
+              rPr: { fontFamily: { cs: "Times New Roman" } },
+            },
+            {
+              styleId: "TableGrid",
+              type: "table",
+              rPr: { fontFamily: { ascii: "Arial", hAnsi: "Arial", cs: "Times New Roman" } },
+            },
+          ],
+        },
+        document: {
+          content: [
+            {
+              type: "table",
+              formatting: { styleId: "TableGrid" },
+              rows: [
+                {
+                  cells: [
+                    {
+                      content: [
+                        {
+                          type: "paragraph",
+                          formatting: { styleId: "Header" },
+                          content: [
+                            { type: "run", content: [{ type: "text", text: "Styled cell" }] },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const text = toProseDoc(document).firstChild?.firstChild?.firstChild?.firstChild?.firstChild;
+    const fontFamily = text?.marks.find((mark) => mark.type.name === "fontFamily")?.attrs;
+
+    expect(fontFamily?.ascii).toBe("Arial");
+    expect(fontFamily?.hAnsi).toBe("Arial");
+    expect(fontFamily?.cs).toBe("Times New Roman");
+  });
+
   test("resolves themed table-cell fills while preserving their OOXML metadata", () => {
     const shading = {
       pattern: "clear",

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -480,7 +480,14 @@ function convertParagraph(
   let paragraphStyleFontFamily: TextFormatting["fontFamily"] | undefined;
   if (styleResolver) {
     const resolved = styleResolver.resolveParagraphStyle(paragraph.formatting?.styleId);
-    styleRunFormatting = resolved.runFormatting;
+    // The enclosing table style supplies the body-run defaults for cell
+    // paragraphs. Do not let a font inherited from docDefaults displace that
+    // table contribution; paragraph-style font slots are restored below from
+    // the style chain without docDefaults.
+    styleRunFormatting =
+      extraRunFormatting === undefined
+        ? resolved.runFormatting
+        : withoutFontFamily(resolved.runFormatting);
     const paragraphStyle = paragraph.formatting?.styleId
       ? (styleResolver.getStyle(paragraph.formatting.styleId) ??
         styleResolver.getDefaultParagraphStyle())
@@ -519,9 +526,9 @@ function convertParagraph(
     },
   );
   let baseRunFormatting = orderedToggleFormatting.formatting;
-  // A table style can carry legacy theme/fallback fonts from the template
-  // that created it. Preserve the paragraph style's authored font slots over
-  // the table contribution; direct run formatting still wins later.
+  // Preserve paragraph-style font slots over the table contribution, but not
+  // docDefaults: Word lets a table style replace a document-default font.
+  // Direct run formatting still wins later.
   if (paragraphStyleFontFamily) {
     baseRunFormatting = mergeTextFormatting(baseRunFormatting, {
       fontFamily: paragraphStyleFontFamily,
@@ -730,20 +737,33 @@ function convertParagraph(
   return proseParagraph;
 }
 
+const withoutFontFamily = (formatting: TextFormatting | undefined): TextFormatting | undefined => {
+  if (!formatting?.fontFamily) {
+    return formatting;
+  }
+  const { fontFamily: _fontFamily, ...withoutFont } = formatting;
+  return Object.keys(withoutFont).length > 0 ? withoutFont : undefined;
+};
+
 const resolveParagraphStyleFontFamily = (
   styleId: string | undefined,
   styleResolver: StyleEngine,
 ): TextFormatting["fontFamily"] | undefined => {
   let style = styleId ? styleResolver.getStyle(styleId) : styleResolver.getDefaultParagraphStyle();
   const visited = new Set<string>();
+  const styleChain: TextFormatting[] = [];
   while (style?.type === "paragraph" && !visited.has(style.styleId)) {
     visited.add(style.styleId);
     if (style.rPr?.fontFamily) {
-      return style.rPr.fontFamily;
+      styleChain.push({ fontFamily: style.rPr.fontFamily });
     }
     style = style.basedOn ? styleResolver.getStyle(style.basedOn) : undefined;
   }
-  return undefined;
+  let formatting: TextFormatting | undefined;
+  for (const styleFormatting of styleChain.toReversed()) {
+    formatting = mergeTextFormatting(formatting, styleFormatting);
+  }
+  return formatting?.fontFamily;
 };
 
 /**

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -4393,6 +4393,9 @@ function textBoxFromShape(shape: Shape, textBody: ShapeTextBody): TextBox {
   if (shape.outline) {
     textBox.outline = shape.outline;
   }
+  if (shape.transform) {
+    textBox.transform = shape.transform;
+  }
   if (textBody.margins) {
     textBox.margins = textBody.margins;
   }
@@ -4450,6 +4453,23 @@ function convertTextBox(
       outlineColor = `#${textBox.outline.color.rgb}`;
     }
     outlineStyle = textBox.outline.style || "solid";
+  }
+
+  let transform: string | undefined;
+  if (textBox.transform) {
+    const transforms: string[] = [];
+    if (textBox.transform.rotation) {
+      transforms.push(`rotate(${textBox.transform.rotation}deg)`);
+    }
+    if (textBox.transform.flipH) {
+      transforms.push("scaleX(-1)");
+    }
+    if (textBox.transform.flipV) {
+      transforms.push("scaleY(-1)");
+    }
+    if (transforms.length > 0) {
+      transform = transforms.join(" ");
+    }
   }
 
   // Convert margins from EMU to pixels
@@ -4561,6 +4581,7 @@ function convertTextBox(
       outlineWidth,
       outlineColor,
       outlineStyle,
+      transform,
       marginTop,
       marginBottom,
       marginLeft,

--- a/packages/core/src/prosemirror/extensions/nodes/TextBoxExtension.test.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/TextBoxExtension.test.ts
@@ -33,6 +33,22 @@ describe("TextBoxExtension toDOM border", () => {
     expect(styleOf({ verticalAlign: "bottom" })).toContain("justify-content: flex-end");
   });
 
+  test("applies a DrawingML transform about the text-box centre", () => {
+    const style = styleOf({ transform: "rotate(270deg) scaleX(-1) scaleY(-1)" });
+
+    expect(style).toContain("transform: rotate(270deg) scaleX(-1) scaleY(-1)");
+    expect(style).toContain("transform-origin: center center");
+  });
+
+  test("rejects transforms outside the carried DrawingML subset", () => {
+    expect(() => styleOf({ transform: "skewX(10deg)" })).toThrow(
+      "Expected DrawingML rotation and/or horizontal or vertical flips.",
+    );
+    expect(() => styleOf({ transform: "" })).toThrow(
+      "Expected DrawingML rotation and/or horizontal or vertical flips.",
+    );
+  });
+
   test.each(["distributed", "justified"])(
     "does not approximate %s line alignment with block flex spacing",
     (verticalAlign) => {

--- a/packages/core/src/prosemirror/extensions/nodes/TextBoxExtension.ts
+++ b/packages/core/src/prosemirror/extensions/nodes/TextBoxExtension.ts
@@ -35,6 +35,8 @@ export type TextBoxAttrs = {
   outlineColor?: string;
   /** Outline dash style, or `"none"` for an explicit no-outline. */
   outlineStyle?: OutlineStyleAttr;
+  /** DrawingML rotation and/or flips, serialized as CSS transform functions. */
+  transform?: string;
   /** Internal margin top in pixels */
   marginTop?: number;
   /** Internal margin bottom in pixels */
@@ -135,6 +137,7 @@ export const TextBoxExtension = createNodeExtension({
       outlineWidth: { default: null },
       outlineColor: { default: null },
       outlineStyle: { default: null },
+      transform: { default: null },
       marginTop: { default: 4 },
       marginBottom: { default: 4 },
       marginLeft: { default: 7 },
@@ -183,6 +186,7 @@ export const TextBoxExtension = createNodeExtension({
                   outlineStyle: d["outlineStyle"] as NonNullable<TextBoxAttrs["outlineStyle"]>,
                 }
               : {}),
+            ...(d["transform"] ? { transform: d["transform"] } : {}),
             ...(d["marginTop"] ? { marginTop: Number(d["marginTop"]) } : {}),
             ...(d["marginBottom"] ? { marginBottom: Number(d["marginBottom"]) } : {}),
             ...(d["marginLeft"] ? { marginLeft: Number(d["marginLeft"]) } : {}),
@@ -246,6 +250,9 @@ export const TextBoxExtension = createNodeExtension({
       }
       if (attrs.outlineStyle) {
         domAttrs["data-outline-style"] = attrs.outlineStyle;
+      }
+      if (attrs.transform) {
+        domAttrs["data-transform"] = attrs.transform;
       }
       if (typeof attrs.marginTop === "number") {
         domAttrs["data-margin-top"] = String(attrs.marginTop);
@@ -350,6 +357,10 @@ export const TextBoxExtension = createNodeExtension({
       styles.push("box-sizing: border-box");
       styles.push("overflow: hidden");
       styles.push("position: relative");
+      if (attrs.transform) {
+        styles.push(`transform: ${attrs.transform}`);
+        styles.push("transform-origin: center center");
+      }
 
       domAttrs["style"] = styles.join("; ");
 

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -625,6 +625,8 @@ export type TextBoxAttrs = {
   outlineColor?: string;
   /** Outline dash style, or `"none"` for an explicit no-outline. */
   outlineStyle?: OutlineStyleAttr;
+  /** DrawingML rotation and/or flips, serialized as CSS transform functions. */
+  transform?: string;
   /** Internal margin top in pixels */
   marginTop?: number;
   /** Internal margin bottom in pixels */

--- a/packages/core/src/utils/rotationBoundingBox.ts
+++ b/packages/core/src/utils/rotationBoundingBox.ts
@@ -31,6 +31,16 @@ export function parseRotationDegrees(transform: string | undefined): number {
   return ((raw % 360) + 360) % 360;
 }
 
+/** Whether a DrawingML/CSS transform reflects around the vertical centre line. */
+export function hasHorizontalFlip(transform: string | undefined): boolean {
+  return /scaleX\(\s*-1\s*\)/iu.test(transform ?? "");
+}
+
+/** Whether a DrawingML/CSS transform reflects around the horizontal centre line. */
+export function hasVerticalFlip(transform: string | undefined): boolean {
+  return /scaleY\(\s*-1\s*\)/iu.test(transform ?? "");
+}
+
 // Axis-aligned bounding box of a `w × h` rectangle rotated by `deg` degrees.
 // 90°/270° swap the dims exactly (no FP drift); 0°/180° keep them; arbitrary
 // angles use the standard |cos θ|·w + |sin θ|·h formula.

--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -859,6 +859,8 @@ export type TextBox = {
   fill?: ShapeFill;
   /** Outline */
   outline?: ShapeOutline;
+  /** DrawingML transform applied to the text-box frame and content. */
+  transform?: ImageTransform;
   /** Text and table content */
   content: (Paragraph | Table)[];
   /** Text fitting behavior */

--- a/parity/__tests__/folioExtract.test.ts
+++ b/parity/__tests__/folioExtract.test.ts
@@ -14,6 +14,7 @@ import {
   parseCssFontFamilies,
   parseFirstFontFamily,
   parseInsetClipPath,
+  retryDetachedPageCapture,
   screenshotViewportHeight,
   toPageGeom,
 } from "../folioExtract";
@@ -64,6 +65,33 @@ describe("screenshot viewport height", () => {
 
   test("ignores invalid page heights", () => {
     expect(screenshotViewportHeight([Number.NaN, Number.POSITIVE_INFINITY], 1000)).toBe(1000);
+  });
+});
+
+describe("detached page capture retry", () => {
+  test("retries virtualized page remounts and returns the fresh capture", async () => {
+    let attempts = 0;
+    const result = await retryDetachedPageCapture(async () => {
+      attempts += 1;
+      if (attempts < 3) {
+        throw new Error("screenshot: Element is not attached to the DOM");
+      }
+      return "captured";
+    });
+
+    expect(result).toBe("captured");
+    expect(attempts).toBe(3);
+  });
+
+  test("does not retry unrelated capture failures", async () => {
+    let attempts = 0;
+    await expect(
+      retryDetachedPageCapture(async () => {
+        attempts += 1;
+        throw new Error("page closed");
+      }),
+    ).rejects.toThrow("page closed");
+    expect(attempts).toBe(1);
   });
 });
 

--- a/parity/__tests__/rasterCompare.test.ts
+++ b/parity/__tests__/rasterCompare.test.ts
@@ -84,8 +84,51 @@ describe("page raster comparison", () => {
     expect(comparison.diffPixels).toBe(4);
   });
 
-  test("makes page dimensions part of the result", async () => {
-    const reference = await writeSolidPng("size-reference.png", 2, 2, [255, 255, 255, 255]);
+  test("normalizes a one-pixel page-edge rounding difference on either raster", async () => {
+    const cases = [
+      { name: "folio-width", reference: [4, 4], folio: [5, 4] },
+      { name: "reference-width", reference: [5, 4], folio: [4, 4] },
+      { name: "folio-height", reference: [4, 4], folio: [4, 5] },
+      { name: "reference-height", reference: [4, 5], folio: [4, 4] },
+      { name: "both-edges", reference: [4, 4], folio: [5, 5] },
+    ] as const;
+
+    await Promise.all(
+      cases.map(async ({ name, reference: [referenceWidth, referenceHeight], folio }) => {
+        const reference = await writeSolidPng(
+          `${name}-reference.png`,
+          referenceWidth,
+          referenceHeight,
+          [255, 255, 255, 255],
+        );
+        const folioPath = await writeSolidPng(
+          `${name}-folio.png`,
+          folio[0],
+          folio[1],
+          [255, 255, 255, 255],
+        );
+
+        const { comparison } = await comparePageRasters({
+          referencePagePngs: [reference],
+          folioPagePngs: [folioPath],
+          outputDir: path.join(tmpDir, `${name}-diffs`),
+        });
+
+        expect(comparison.status).toBe("compared");
+        if (comparison.status !== "compared") return;
+        expect(comparison.pages[0]).toMatchObject({
+          status: "match",
+          widthPx: 4,
+          heightPx: 4,
+          similarity: 1,
+        });
+        expect(comparison.score).toBe(1);
+      }),
+    );
+  });
+
+  test("makes larger page dimension differences part of the result", async () => {
+    const reference = await writeSolidPng("size-reference.png", 3, 2, [255, 255, 255, 255]);
     const folio = await writeSolidPng("size-folio.png", 1, 2, [255, 255, 255, 255]);
 
     const { comparison } = await comparePageRasters({
@@ -98,13 +141,13 @@ describe("page raster comparison", () => {
     if (comparison.status !== "compared") return;
     expect(comparison.pages[0]).toMatchObject({
       status: "dimension-mismatch",
-      referenceWidthPx: 2,
+      referenceWidthPx: 3,
       referenceHeightPx: 2,
       folioWidthPx: 1,
       folioHeightPx: 2,
-      similarity: 0.5,
     });
-    expect(comparison.score).toBe(0.5);
+    expect(comparison.pages[0]?.similarity).toBeCloseTo(1 / 3);
+    expect(comparison.score).toBeCloseTo(1 / 3);
   });
 
   test("treats a missing page as fully different", async () => {

--- a/parity/features.ts
+++ b/parity/features.ts
@@ -366,6 +366,7 @@ const PDF_FONT_STYLE_SUFFIXES = new Set([
   "italicmt",
   "bolditalicmt",
   "psboldmt",
+  "psboldital",
   "psitalicmt",
   "psit",
   "psital",
@@ -754,7 +755,7 @@ type Bucket = {
   examples: AttributedDivergence[];
 };
 
-const KEY_SEP = " ";
+const KEY_SEP = "\0";
 const bucketKey = (kind: DivergenceKind, feature: string): string => `${kind}${KEY_SEP}${feature}`;
 const splitBucketKey = (key: string): { kind: DivergenceKind; feature: string } => {
   const sepIndex = key.indexOf(KEY_SEP);

--- a/parity/folioExtract.ts
+++ b/parity/folioExtract.ts
@@ -152,6 +152,7 @@ const EDITOR_RENDER_TIMEOUT_MS = 90_000;
 const STABILITY_POLL_INTERVAL_MS = 250;
 const STABILITY_MAX_MS = 15_000;
 const STABILITY_SETTLE_MS = 250;
+const PAGE_CAPTURE_MAX_ATTEMPTS = 3;
 
 const CHROMIUM_MISSING_MARKER = "Executable doesn't exist";
 const CHROMIUM_MISSING_MESSAGE =
@@ -679,6 +680,25 @@ const installCleanScreenshotStyle = async (page: Page): Promise<void> => {
 export const screenshotViewportHeight = (pageHeights: number[], currentHeight: number): number => {
   const tallestPage = Math.max(0, ...pageHeights.filter(Number.isFinite));
   return Math.max(currentHeight, Math.ceil(tallestPage + SCREENSHOT_VIEWPORT_VERTICAL_CHROME_PX));
+};
+
+const DETACHED_ELEMENT_SCREENSHOT_MARKER = "Element is not attached to the DOM";
+
+/** Retry only the virtualized-page remount failure Playwright reports while
+ * scrolling or screenshotting a locator. The caller repeats geometry
+ * extraction too, keeping the screenshot paired with the same DOM instance. */
+export const retryDetachedPageCapture = async <T>(operation: () => Promise<T>): Promise<T> => {
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      const isDetached =
+        error instanceof Error && error.message.includes(DETACHED_ELEMENT_SCREENSHOT_MARKER);
+      if (!isDetached || attempt >= PAGE_CAPTURE_MAX_ATTEMPTS) {
+        throw error;
+      }
+    }
+  }
 };
 
 const fitViewportToPages = async (page: Page): Promise<void> => {
@@ -1405,16 +1425,18 @@ export const createFolioExtractor = async (
       const rawPages: RawPage[] = [];
       const screenshotPaths: string[] = [];
       for (const { domIndex, pageNumber } of pagesToExtract) {
-        const locator = page.locator(PAGE_SELECTOR).nth(domIndex);
-        await locator.scrollIntoViewIfNeeded();
-        await waitForLayoutStability(page);
-        await page.waitForTimeout(STABILITY_SETTLE_MS);
-
-        const rawPage = await extractSinglePage(page, domIndex);
-        rawPages.push(rawPage);
-
         const screenshotPath = path.join(screenshotDir, `p${pageNumber}.png`);
-        await locator.screenshot({ path: screenshotPath });
+        const rawPage = await retryDetachedPageCapture(async () => {
+          const locator = page.locator(PAGE_SELECTOR).nth(domIndex);
+          await locator.scrollIntoViewIfNeeded();
+          await waitForLayoutStability(page);
+          await page.waitForTimeout(STABILITY_SETTLE_MS);
+
+          const capturedPage = await extractSinglePage(page, domIndex);
+          await locator.screenshot({ path: screenshotPath });
+          return capturedPage;
+        });
+        rawPages.push(rawPage);
         screenshotPaths.push(screenshotPath);
       }
 

--- a/parity/rasterCompare.ts
+++ b/parity/rasterCompare.ts
@@ -22,6 +22,10 @@ const MAX_TOTAL_RASTER_PIXELS = 250_000_000;
 const MAX_DIFF_PNG_BYTES = 64 * 1024 * 1024;
 const MAX_TOTAL_DIFF_BYTES = 256 * 1024 * 1024;
 const PIXELMATCH_THRESHOLD = 0.1;
+/** Browser element screenshots and PDF rasterizers can round the same physical
+ * page edge to adjacent pixels. Crop that non-semantic fringe before comparing
+ * pixels; larger deltas remain explicit page-size mismatches. */
+const PAGE_EDGE_ROUNDING_TOLERANCE_PX = 1;
 
 /** Signals invalid or resource-exceeding raster comparison input. */
 export class RasterComparisonError extends TaggedError("RasterComparisonError")<{
@@ -160,8 +164,17 @@ const comparePresentPage = async ({
   diffPath,
   remainingOutputBytes,
 }: ComparePresentPageOptions): Promise<ComparedPage> => {
-  const width = Math.max(reference.width, folio.width);
-  const height = Math.max(reference.height, folio.height);
+  const hasDimensionMismatch = reference.width !== folio.width || reference.height !== folio.height;
+  const hasOnlyPageEdgeRounding =
+    hasDimensionMismatch &&
+    Math.abs(reference.width - folio.width) <= PAGE_EDGE_ROUNDING_TOLERANCE_PX &&
+    Math.abs(reference.height - folio.height) <= PAGE_EDGE_ROUNDING_TOLERANCE_PX;
+  const width = hasOnlyPageEdgeRounding
+    ? Math.min(reference.width, folio.width)
+    : Math.max(reference.width, folio.width);
+  const height = hasOnlyPageEdgeRounding
+    ? Math.min(reference.height, folio.height)
+    : Math.max(reference.height, folio.height);
   const referenceData = fitToCanvas(reference, width, height);
   const folioData = fitToCanvas(folio, width, height);
   const diff = new PNG({ width, height });
@@ -182,7 +195,7 @@ const comparePresentPage = async ({
   );
 
   const totalPixels = width * height;
-  if (reference.width !== folio.width || reference.height !== folio.height) {
+  if (hasDimensionMismatch && !hasOnlyPageEdgeRounding) {
     const overlapWidth = Math.min(reference.width, folio.width);
     const overlapHeight = Math.min(reference.height, folio.height);
     const overlapPixels = overlapWidth * overlapHeight;


### PR DESCRIPTION
## Summary

- preserve header/footer end tabs authored into page margins
- preserve table-style fonts over document defaults
- render and round-trip DrawingML text-box rotation and flips in DOM, display-list, and PDF paths
- normalize one-pixel rasterizer page-edge rounding and PostScript font suffixes in parity reports
- retry virtualized parity pages that remount during screenshot capture

## Validation
- 7,590 folio-core tests and 88 docx-core tests
- package typechecks, lint, format check
- API snapshots/budgets, adapter contracts, DOCX kernel check
- `bun audit` (no vulnerabilities)