### PR TITLE
fix: project leading page break boundaries

### DIFF
--- a/.changeset/calm-pages-flow.md
+++ b/.changeset/calm-pages-flow.md
@@ -2,4 +2,4 @@
 "@stll/folio-core": patch
 ---
 
-Preserve leading page breaks in styled paragraphs and table rows, and coalesce structural section carriers correctly.
+Preserve leading page breaks in styled paragraphs and table rows, classify row boundaries from their projected revision view, and coalesce repeated structural section carriers in linear time.

--- a/.changeset/calm-pages-flow.md
+++ b/.changeset/calm-pages-flow.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Preserve leading page breaks in styled paragraphs and table rows, and coalesce structural section carriers correctly.

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -697,6 +697,7 @@ export type ParagraphBorders = {
 // @public
 export type ParagraphFragment = FragmentBase & {
     kind: "paragraph";
+    paginationRole?: "empty-carrier";
     fromLine: number;
     toLine: number;
     height: number;
@@ -982,6 +983,7 @@ export type TableRow = {
     justification?: "left" | "center" | "right";
     isHeader?: boolean;
     cantSplit?: boolean;
+    breakBefore?: "page";
     hidden?: boolean;
 };
 

--- a/api-reports/core/layout-engine.api.md
+++ b/api-reports/core/layout-engine.api.md
@@ -101,7 +101,7 @@ export function createInitialSectionState(margins: PageMargins, pageSize: {
 
 // @public
 export function createPaginator(options: PaginatorOptions): {
-    pages: Page[];
+    readonly pages: Page[];
     states: PageState[];
     readonly columnWidth: number;
     readonly columns: {

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.test.ts
@@ -2399,6 +2399,52 @@ describe("toFlowBlocks hyperlink identity", () => {
 
 describe("toFlowBlocks table cell formatting", () => {
   test.each([
+    { name: "ordinary", rowAttrs: null },
+    { name: "cantSplit", rowAttrs: { _originalFormatting: { cantSplit: true } } },
+  ])("projects a leading page-break run as a $name row boundary", ({ rowAttrs }) => {
+    const doc = schema.node("doc", null, [
+      schema.node("table", null, [
+        schema.node("tableRow", rowAttrs, [
+          schema.node("tableCell", null, [
+            schema.node("paragraph", null, [schema.node("pageBreakRun"), schema.text("after")]),
+          ]),
+        ]),
+      ]),
+    ]);
+
+    const table = toFlowBlocks(doc).at(0);
+    if (table?.kind !== "table") {
+      throw new Error("Expected table block");
+    }
+
+    expect(table.rows.at(0)?.breakBefore).toBe("page");
+  });
+
+  test("ignores a zero-width bookmark before a leading row boundary", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("table", null, [
+        schema.node("tableRow", null, [
+          schema.node("tableCell", null, [
+            schema.node("paragraph", null, [
+              schema.node("bookmarkBoundary", { type: "start", id: 7, name: "boundary" }),
+              schema.node("pageBreakRun"),
+              schema.text("after"),
+              schema.node("bookmarkBoundary", { type: "end", id: 7 }),
+            ]),
+          ]),
+        ]),
+      ]),
+    ]);
+
+    const table = toFlowBlocks(doc).at(0);
+    if (table?.kind !== "table") {
+      throw new Error("Expected table block");
+    }
+
+    expect(table.rows.at(0)?.breakBefore).toBe("page");
+  });
+
+  test.each([
     { name: "ordinary", rowAttrs: null, cellAttrs: null, nested: false },
     {
       name: "cantSplit",

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -2675,17 +2675,6 @@ function convertTableCell(
     right?: number;
   },
 ): TableCell {
-  const pageBreakPosition = options.firstPageBreakRunPosition(node);
-  if (pageBreakPosition !== undefined) {
-    // An OOXML page break is forced at its exact run position, while a table
-    // row paginates across all of its cells. Cell-local flow cannot model that
-    // row-wide boundary without table-fragment ownership, so reject the shape
-    // instead of projecting a zero-height marker that would not paginate.
-    panic(
-      `An explicit page-break run at ${String(pageBreakPosition)} cannot be projected inside a table cell`,
-    );
-  }
-
   const blocks: FlowBlock[] = [];
   let offset = startPos + 1; // +1 for opening tag
 
@@ -2793,10 +2782,20 @@ function convertTableRow(
 ): TableRow {
   const cells: TableCell[] = [];
   let offset = startPos + 1; // +1 for opening tag
+  let breakBefore: TableRow["breakBefore"];
 
   // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
   node.forEach((child) => {
     if (child.type.name === "tableCell" || child.type.name === "tableHeader") {
+      const pageBreakPosition = options.firstPageBreakRunPosition(child);
+      if (pageBreakPosition !== undefined) {
+        if (!hasSingleLeadingTableCellPageBreak(child)) {
+          panic(
+            `An explicit page-break run at ${String(pageBreakPosition)} cannot be projected inside a table cell`,
+          );
+        }
+        breakBefore = "page";
+      }
       cells.push(convertTableCell(child, offset, options, tableCellMargins));
     }
     offset += child.nodeSize;
@@ -2825,6 +2824,9 @@ function convertTableRow(
   if (attrs._originalFormatting?.cantSplit) {
     row.cantSplit = true;
   }
+  if (breakBefore !== undefined) {
+    row.breakBefore = breakBefore;
+  }
   if (attrs.hidden) {
     row.hidden = attrs.hidden;
   }
@@ -2835,6 +2837,33 @@ function convertTableRow(
   }
   return row;
 }
+
+const hasSingleLeadingParagraphPageBreak = (paragraph: PMNode): boolean => {
+  let pageBreaks = 0;
+  let contentBeforeBreak = false;
+  paragraph.descendants((child) => {
+    if (child.type.name === "renderedPageBreak" || child.type.name === "bookmarkBoundary") {
+      return false;
+    }
+    if (child.type.name === "pageBreakRun") {
+      pageBreaks += 1;
+      return false;
+    }
+    if (child.childCount > 0) {
+      return true;
+    }
+    if (pageBreaks === 0) {
+      contentBeforeBreak = true;
+    }
+    return false;
+  });
+  return !contentBeforeBreak && pageBreaks === 1;
+};
+
+const hasSingleLeadingTableCellPageBreak = (cell: PMNode): boolean => {
+  const paragraph = cell.childCount === 1 ? cell.firstChild : undefined;
+  return paragraph?.type.name === "paragraph" && hasSingleLeadingParagraphPageBreak(paragraph);
+};
 
 /**
  * Convert a table node to a TableBlock.
@@ -3403,7 +3432,10 @@ export function toFlowBlocks(doc: PMNode, options: ToFlowBlocksOptions = {}): Fl
   ): void => {
     if (opts.firstPageBreakRunPosition(node) !== undefined) {
       const disposition = pageBreakRunParagraphProjectionDisposition(node);
-      if (disposition.status === "unsupported") {
+      if (
+        disposition.status === "unsupported" &&
+        (disposition.reason === "textBoxAnchor" || !hasSingleLeadingParagraphPageBreak(node))
+      ) {
         panic(disposition.message);
       }
     }

--- a/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
+++ b/packages/core/src/layout-bridge/convert/toFlowBlocks.ts
@@ -2382,6 +2382,41 @@ type SplitParagraphAtPageBreaksOptions = {
   splitPageBreakAndParagraphMark: boolean;
 };
 
+const runIsZeroWidthBoundaryMarker = (run: Run): boolean => {
+  switch (run.kind) {
+    case "text":
+      return run.text.length === 0;
+    case "field":
+      return (run.fallback ?? "").length === 0;
+    case "renderedPageBreak":
+      return true;
+    case "image":
+    case "lineBreak":
+    case "math":
+    case "tab":
+      return false;
+    default: {
+      const unsupported: never = run;
+      return unsupported;
+    }
+  }
+};
+
+/** Decide leading-break eligibility from the exact projected runs consumed by layout. */
+const hasSingleLeadingProjectedPageBreak = (
+  runs: readonly Run[],
+  pageBreaks: readonly PageBreakRunProjection[],
+): boolean => {
+  if (pageBreaks.length !== 1) {
+    return false;
+  }
+  const partitioned = partitionRunsAtPageBreaks(runs, pageBreaks);
+  if (partitioned.type === "overlap") {
+    return false;
+  }
+  return partitioned.partitions[0]?.before.every(runIsZeroWidthBoundaryMarker) === true;
+};
+
 function splitParagraphAtPageBreaks({
   pageBreaks,
   paragraph,
@@ -2664,6 +2699,11 @@ function extractCellBorders(
 /**
  * Convert a table cell node.
  */
+type ConvertedTableCell = {
+  cell: TableCell;
+  breakBefore?: "page";
+};
+
 function convertTableCell(
   node: PMNode,
   startPos: number,
@@ -2674,14 +2714,30 @@ function convertTableCell(
     left?: number;
     right?: number;
   },
-): TableCell {
+): ConvertedTableCell {
   const blocks: FlowBlock[] = [];
   let offset = startPos + 1; // +1 for opening tag
+  const authoredPageBreakPosition = options.firstPageBreakRunPosition(node);
+  const singleParagraph =
+    node.childCount === 1 && node.firstChild?.type.name === "paragraph"
+      ? node.firstChild
+      : undefined;
+  if (authoredPageBreakPosition !== undefined && singleParagraph === undefined) {
+    panic(
+      `An explicit page-break run at ${String(authoredPageBreakPosition)} cannot be projected inside a table cell`,
+    );
+  }
+  const pageBreaks: PageBreakRunProjection[] = [];
 
   // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
   node.forEach((child) => {
     if (child.type.name === "paragraph") {
-      const block = convertParagraph(child, offset, options);
+      const block = convertParagraph(
+        child,
+        offset,
+        options,
+        child === singleParagraph ? pageBreaks : undefined,
+      );
       blocks.push(block);
     } else if (child.type.name === "table") {
       blocks.push(convertTable(child, offset, options));
@@ -2763,7 +2819,19 @@ function convertTableCell(
   if (attrs.noWrap) {
     cell.noWrap = true;
   }
-  return cell;
+  if (authoredPageBreakPosition === undefined || pageBreaks.length === 0) {
+    return { cell };
+  }
+  const paragraph = blocks.at(0);
+  if (
+    paragraph?.kind !== "paragraph" ||
+    !hasSingleLeadingProjectedPageBreak(paragraph.runs, pageBreaks)
+  ) {
+    panic(
+      `An explicit page-break run at ${String(authoredPageBreakPosition)} cannot be projected inside a table cell`,
+    );
+  }
+  return { cell, breakBefore: "page" };
 }
 
 /**
@@ -2787,16 +2855,11 @@ function convertTableRow(
   // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
   node.forEach((child) => {
     if (child.type.name === "tableCell" || child.type.name === "tableHeader") {
-      const pageBreakPosition = options.firstPageBreakRunPosition(child);
-      if (pageBreakPosition !== undefined) {
-        if (!hasSingleLeadingTableCellPageBreak(child)) {
-          panic(
-            `An explicit page-break run at ${String(pageBreakPosition)} cannot be projected inside a table cell`,
-          );
-        }
-        breakBefore = "page";
+      const converted = convertTableCell(child, offset, options, tableCellMargins);
+      if (converted.breakBefore !== undefined) {
+        breakBefore = converted.breakBefore;
       }
-      cells.push(convertTableCell(child, offset, options, tableCellMargins));
+      cells.push(converted.cell);
     }
     offset += child.nodeSize;
   });
@@ -2837,33 +2900,6 @@ function convertTableRow(
   }
   return row;
 }
-
-const hasSingleLeadingParagraphPageBreak = (paragraph: PMNode): boolean => {
-  let pageBreaks = 0;
-  let contentBeforeBreak = false;
-  paragraph.descendants((child) => {
-    if (child.type.name === "renderedPageBreak" || child.type.name === "bookmarkBoundary") {
-      return false;
-    }
-    if (child.type.name === "pageBreakRun") {
-      pageBreaks += 1;
-      return false;
-    }
-    if (child.childCount > 0) {
-      return true;
-    }
-    if (pageBreaks === 0) {
-      contentBeforeBreak = true;
-    }
-    return false;
-  });
-  return !contentBeforeBreak && pageBreaks === 1;
-};
-
-const hasSingleLeadingTableCellPageBreak = (cell: PMNode): boolean => {
-  const paragraph = cell.childCount === 1 ? cell.firstChild : undefined;
-  return paragraph?.type.name === "paragraph" && hasSingleLeadingParagraphPageBreak(paragraph);
-};
 
 /**
  * Convert a table node to a TableBlock.
@@ -3430,18 +3466,19 @@ export function toFlowBlocks(doc: PMNode, options: ToFlowBlocksOptions = {}): Fl
     pos: number,
     stripLeadingLineBreak = false,
   ): void => {
-    if (opts.firstPageBreakRunPosition(node) !== undefined) {
+    const pageBreaks: PageBreakRunProjection[] = [];
+    const paragraph = convertParagraph(node, pos, opts, pageBreaks);
+    if (pageBreaks.length > 0) {
       const disposition = pageBreakRunParagraphProjectionDisposition(node);
       if (
         disposition.status === "unsupported" &&
-        (disposition.reason === "textBoxAnchor" || !hasSingleLeadingParagraphPageBreak(node))
+        (disposition.reason === "textBoxAnchor" ||
+          !hasSingleLeadingProjectedPageBreak(paragraph.runs, pageBreaks))
       ) {
         panic(disposition.message);
       }
     }
 
-    const pageBreaks: PageBreakRunProjection[] = [];
-    const paragraph = convertParagraph(node, pos, opts, pageBreaks);
     if (stripLeadingLineBreak && paragraph.runs.at(0)?.kind === "lineBreak") {
       paragraph.runs.shift();
     }

--- a/packages/core/src/layout-engine/continuousSectionGeometry.test.ts
+++ b/packages/core/src/layout-engine/continuousSectionGeometry.test.ts
@@ -278,6 +278,69 @@ describe("continuous section break geometry", () => {
     });
   });
 
+  test("a section boundary reuses a hard-break page containing only its empty carrier", () => {
+    const cover = paragraph("cover", 100);
+    const carrier = emptyParagraph({
+      id: "carrier",
+      attrs: { suppressEmptyParagraphHeight: true },
+      lineHeight: 0,
+    });
+    const body = paragraph("body", 100);
+    const result = layoutDocument(
+      [
+        cover.block,
+        { kind: "pageBreak", id: "cover-break" },
+        carrier.block,
+        { kind: "sectionBreak", id: "body-section" },
+        body.block,
+      ],
+      [
+        cover.measure,
+        { kind: "pageBreak" },
+        carrier.measure,
+        { kind: "sectionBreak" },
+        body.measure,
+      ],
+      {
+        pageSize: { w: 800, h: 1000 },
+        margins: { top: 50, right: 50, bottom: 50, left: 50 },
+      },
+    );
+
+    expect(result.pages).toHaveLength(2);
+    expect(result.pages[1]?.fragments.map(({ blockId }) => blockId)).toEqual(["carrier", "body"]);
+  });
+
+  test("an ordinary empty paragraph preserves a blank page before a section boundary", () => {
+    const cover = paragraph("cover", 100);
+    const visibleEmpty = emptyParagraph({ id: "visible-empty", lineHeight: 0 });
+    const body = paragraph("body", 100);
+    const result = layoutDocument(
+      [
+        cover.block,
+        { kind: "pageBreak", id: "cover-break" },
+        visibleEmpty.block,
+        { kind: "sectionBreak", id: "body-section" },
+        body.block,
+      ],
+      [
+        cover.measure,
+        { kind: "pageBreak" },
+        visibleEmpty.measure,
+        { kind: "sectionBreak" },
+        body.measure,
+      ],
+      {
+        pageSize: { w: 800, h: 1000 },
+        margins: { top: 50, right: 50, bottom: 50, left: 50 },
+      },
+    );
+
+    expect(result.pages).toHaveLength(3);
+    expect(result.pages[1]?.fragments.map(({ blockId }) => blockId)).toEqual(["visible-empty"]);
+    expect(result.pages[2]?.fragments.map(({ blockId }) => blockId)).toEqual(["body"]);
+  });
+
   test("pageBreakBefore advances ordinals on a page opened by a section boundary", () => {
     const cover = paragraph("cover", 100);
     const body = paragraph("body", 100);

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -651,6 +651,9 @@ function layoutParagraph({
     // Create minimal fragment
     const fragment: ParagraphFragment = {
       kind: "paragraph",
+      ...(block.attrs?.suppressEmptyParagraphHeight === true
+        ? { paginationRole: "empty-carrier" as const }
+        : {}),
       blockId: block.id,
       x: paginator.getColumnX(state.columnIndex),
       y: state.cursorY + spaceBefore,
@@ -823,6 +826,9 @@ function layoutParagraph({
 
     const fragment: ParagraphFragment = {
       kind: "paragraph",
+      ...(block.attrs?.suppressEmptyParagraphHeight === true
+        ? { paginationRole: "empty-carrier" as const }
+        : {}),
       blockId: block.id,
       x: paginator.getColumnX(state.columnIndex),
       y: 0, // Will be set by addFragment
@@ -1118,6 +1124,11 @@ function layoutTable(
     const rowStartsFreshPage =
       rowState.cursorY === rowState.topMargin && rowState.page.fragments.length === 0;
 
+    if (block.rows[currentRowIndex]?.breakBefore === "page" && !rowStartsFreshPage) {
+      paginator.forcePageBreak();
+      continue;
+    }
+
     // A leading w:lastRenderedPageBreak is Word's cached boundary for this
     // row. Keep the hint advisory while the row fits, but when Folio would
     // otherwise split it in the remaining page space, snap the row to the
@@ -1278,6 +1289,9 @@ function layoutTable(
     });
 
     for (let j = currentRowIndex; j < rows.length; j++) {
+      if (j > currentRowIndex && block.rows[j]?.breakBefore === "page") {
+        break;
+      }
       if (
         j > currentRowIndex &&
         computeTableX({ columnIndex: state.columnIndex, rowIndex: j }) !== fragmentX

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -554,12 +554,12 @@ function layoutDocumentPass(
       block,
       pageNumberBefore: pageBeforeBlockLayout,
       pageNumberAfter: paginator.getCurrentState().page.number,
-      previousPage: paginator.pages[pageBeforeBlockLayout - 1],
+      previousPage: paginator.states[pageBeforeBlockLayout - 1]?.page,
     });
   }
 
   // Ensure at least one page exists
-  if (paginator.pages.length === 0) {
+  if (paginator.states.length === 0) {
     paginator.getCurrentState();
   }
 
@@ -1842,7 +1842,7 @@ function handleSectionBreak(
       // break before any content has no sheet to share, so it defers (the first
       // content then opens a page with the new geometry) rather than stranding
       // a blank leading page.
-      const currentPage = paginator.pages.at(-1);
+      const currentPage = paginator.states.at(-1)?.page;
       const nextSize = nextSectionConfig.pageSize;
       const pageSizeChanges =
         currentPage != null &&

--- a/packages/core/src/layout-engine/paginator.test.ts
+++ b/packages/core/src/layout-engine/paginator.test.ts
@@ -276,6 +276,66 @@ describe("paginator forcePageBreak", () => {
     expect(state.contentBottom).toBe(nextSize.h - nextMargins.bottom);
   });
 
+  test("retargets carrier geometry to the incoming first column", () => {
+    const paginator = createPaginator({ pageSize: SIZE, margins: MARGINS });
+    const carrier = {
+      ...paragraphFragment("carrier"),
+      height: 0,
+      paginationRole: "empty-carrier" as const,
+    };
+    paginator.addFragment(carrier, 0);
+
+    const nextSize = { w: 600, h: 700 };
+    const nextMargins = { top: 30, right: 40, bottom: 50, left: 60 };
+    paginator.updatePageLayout(nextSize, nextMargins);
+    paginator.startSection({ sectionIndex: 1 });
+    expect(paginator.retargetCurrentBlankPage()).toBe(true);
+    paginator.updateColumns({ count: 2, gap: 20, widths: [180, 300] });
+
+    expect(paginator.pages.at(0)?.fragments.at(0)).toMatchObject({
+      x: nextMargins.left,
+      y: nextMargins.top,
+      width: 180,
+    });
+  });
+
+  test("materializes each accumulated carrier once after repeated blank-page retargeting", () => {
+    const paginator = createPaginator({ pageSize: SIZE, margins: MARGINS });
+    const carrierCount = 256;
+    const writes = { x: 0, y: 0, width: 0 };
+
+    for (let index = 0; index < carrierCount; index += 1) {
+      const carrier = new Proxy(
+        {
+          ...paragraphFragment(`carrier-${String(index)}`),
+          height: 0,
+          paginationRole: "empty-carrier" as const,
+        },
+        {
+          set: (target, property, value, receiver) => {
+            if (property === "x" || property === "y" || property === "width") {
+              writes[property] += 1;
+            }
+            return Reflect.set(target, property, value, receiver);
+          },
+        },
+      );
+      paginator.addFragment(carrier, 0);
+      const inset = index % 17;
+      paginator.updatePageLayout(SIZE, {
+        top: MARGINS.top + inset,
+        right: MARGINS.right,
+        bottom: MARGINS.bottom,
+        left: MARGINS.left + inset,
+      });
+      paginator.startSection({ sectionIndex: index + 1 });
+      expect(paginator.retargetCurrentBlankPage()).toBe(true);
+    }
+
+    expect(paginator.pages.at(0)?.fragments).toHaveLength(carrierCount);
+    expect(writes).toEqual({ x: carrierCount * 2, y: carrierCount * 2, width: carrierCount });
+  });
+
   test("retargetCurrentBlankPage leaves nonblank pages unchanged", () => {
     const paginator = createPaginator({ pageSize: SIZE, margins: MARGINS });
     const state = paginator.getCurrentState();

--- a/packages/core/src/layout-engine/paginator.ts
+++ b/packages/core/src/layout-engine/paginator.ts
@@ -107,6 +107,11 @@ type StartSectionOptions = {
   placement?: SectionStartPlacement;
 };
 
+const pageHasNoVisiblePaginationContent = (page: Page): boolean =>
+  page.fragments.every(
+    (fragment) => fragment.kind === "paragraph" && fragment.paginationRole === "empty-carrier",
+  );
+
 /** Calculate active column widths, preferring authored unequal widths. */
 export function calculateColumnWidths(
   pageWidth: number,
@@ -566,7 +571,7 @@ export function createPaginator(options: PaginatorOptions) {
     if (
       breakOptions.coalesceBlankPage &&
       current &&
-      current.page.fragments.length === 0 &&
+      pageHasNoVisiblePaginationContent(current.page) &&
       current.cursorY === current.topMargin
     ) {
       if (current.page.sectionIndex !== currentSectionIndex) {
@@ -620,7 +625,11 @@ export function createPaginator(options: PaginatorOptions) {
 
   function retargetCurrentBlankPage(): boolean {
     const current = states.at(-1);
-    if (!current || current.page.fragments.length > 0 || current.cursorY !== current.topMargin) {
+    if (
+      !current ||
+      !pageHasNoVisiblePaginationContent(current.page) ||
+      current.cursorY !== current.topMargin
+    ) {
       return false;
     }
 
@@ -649,6 +658,9 @@ export function createPaginator(options: PaginatorOptions) {
 
     current.topMargin = topMargin;
     current.cursorY = topMargin;
+    for (const fragment of current.page.fragments) {
+      fragment.y = topMargin;
+    }
     current.columnIndex = 0;
     current.rawContentBottom = rawContentBottom;
     current.footnoteHeight = footnoteHeightFloor;

--- a/packages/core/src/layout-engine/paginator.ts
+++ b/packages/core/src/layout-engine/paginator.ts
@@ -107,10 +107,15 @@ type StartSectionOptions = {
   placement?: SectionStartPlacement;
 };
 
-const pageHasNoVisiblePaginationContent = (page: Page): boolean =>
-  page.fragments.every(
-    (fragment) => fragment.kind === "paragraph" && fragment.paginationRole === "empty-carrier",
-  );
+type PagePaginationState = {
+  /** Updated at insertion so blank-page checks never rescan accumulated carriers. */
+  visibleFragmentCount: number;
+  /** Retargeted carriers take their final coordinates once, when the page is observed or closed. */
+  carrierGeometryNeedsMaterialization: boolean;
+};
+
+const isEmptyCarrier = (fragment: Fragment): boolean =>
+  fragment.kind === "paragraph" && fragment.paginationRole === "empty-carrier";
 
 /** Calculate active column widths, preferring authored unequal widths. */
 export function calculateColumnWidths(
@@ -206,6 +211,7 @@ export function createPaginator(options: PaginatorOptions) {
 
   const pages: Page[] = [];
   const states: PageState[] = [];
+  const paginationStateByPage = new WeakMap<Page, PagePaginationState>();
 
   function getContentBottom(): number {
     return pageSize.h - margins.bottom;
@@ -293,10 +299,41 @@ export function createPaginator(options: PaginatorOptions) {
     });
   }
 
+  function getPagePaginationState(page: Page): PagePaginationState {
+    const state = paginationStateByPage.get(page);
+    if (!state) {
+      panic("Paginator: page visibility state is missing");
+    }
+    return state;
+  }
+
+  function materializeCarrierGeometry(state: PageState | undefined): void {
+    if (!state) {
+      return;
+    }
+    const paginationState = getPagePaginationState(state.page);
+    if (!paginationState.carrierGeometryNeedsMaterialization) {
+      return;
+    }
+
+    const x = getColumnX(0);
+    const width = columnWidths[0] ?? getContentWidth();
+    for (const fragment of state.page.fragments) {
+      if (!isEmptyCarrier(fragment)) {
+        continue;
+      }
+      fragment.x = x;
+      fragment.y = state.topMargin;
+      fragment.width = width;
+    }
+    paginationState.carrierGeometryNeedsMaterialization = false;
+  }
+
   /**
    * Create a new page and add it to the list.
    */
   function createNewPage(): PageState {
+    materializeCarrierGeometry(states.at(-1));
     if (pendingPageSize || pendingMargins) {
       applyPendingLayout();
     }
@@ -350,6 +387,10 @@ export function createPaginator(options: PaginatorOptions) {
       footnoteDemandHeight: 0,
       trailingSpacing: 0,
     };
+    paginationStateByPage.set(page, {
+      visibleFragmentCount: 0,
+      carrierGeometryNeedsMaterialization: false,
+    });
 
     pages.push(page);
     states.push(state);
@@ -504,6 +545,11 @@ export function createPaginator(options: PaginatorOptions) {
   function commitFragment(state: PageState, fragment: Fragment): void {
     consumeSharedSectionPage(state);
 
+    const paginationState = getPagePaginationState(state.page);
+    if (!isEmptyCarrier(fragment)) {
+      materializeCarrierGeometry(state);
+      paginationState.visibleFragmentCount += 1;
+    }
     const fragments = state.page.fragments;
     fragments.push(fragment);
   }
@@ -571,7 +617,7 @@ export function createPaginator(options: PaginatorOptions) {
     if (
       breakOptions.coalesceBlankPage &&
       current &&
-      pageHasNoVisiblePaginationContent(current.page) &&
+      getPagePaginationState(current.page).visibleFragmentCount === 0 &&
       current.cursorY === current.topMargin
     ) {
       if (current.page.sectionIndex !== currentSectionIndex) {
@@ -608,9 +654,14 @@ export function createPaginator(options: PaginatorOptions) {
     const pageMargins = getPageMargins(state.page.number, logicalNumber);
     const xDelta = pageMargins.left - previousMargins.left;
     const yDelta = pageMargins.top - previousMargins.top;
-    for (const fragment of state.page.fragments) {
-      fragment.x += xDelta;
-      fragment.y += yDelta;
+    const paginationState = getPagePaginationState(state.page);
+    if (paginationState.visibleFragmentCount === 0) {
+      paginationState.carrierGeometryNeedsMaterialization = state.page.fragments.length > 0;
+    } else {
+      for (const fragment of state.page.fragments) {
+        fragment.x += xDelta;
+        fragment.y += yDelta;
+      }
     }
     state.page.margins = pageMargins;
     state.topMargin = pageMargins.top;
@@ -627,7 +678,7 @@ export function createPaginator(options: PaginatorOptions) {
     const current = states.at(-1);
     if (
       !current ||
-      !pageHasNoVisiblePaginationContent(current.page) ||
+      getPagePaginationState(current.page).visibleFragmentCount > 0 ||
       current.cursorY !== current.topMargin
     ) {
       return false;
@@ -658,9 +709,8 @@ export function createPaginator(options: PaginatorOptions) {
 
     current.topMargin = topMargin;
     current.cursorY = topMargin;
-    for (const fragment of current.page.fragments) {
-      fragment.y = topMargin;
-    }
+    getPagePaginationState(current.page).carrierGeometryNeedsMaterialization =
+      current.page.fragments.length > 0;
     current.columnIndex = 0;
     current.rawContentBottom = rawContentBottom;
     current.footnoteHeight = footnoteHeightFloor;
@@ -787,7 +837,10 @@ export function createPaginator(options: PaginatorOptions) {
 
   return {
     /** All pages created so far. */
-    pages,
+    get pages() {
+      materializeCarrierGeometry(states.at(-1));
+      return pages;
+    },
     /** All page states. */
     states,
     /** Column width in pixels (use getColumnWidth() for current value after updates). */

--- a/packages/core/src/layout-engine/tableRowBreak.test.ts
+++ b/packages/core/src/layout-engine/tableRowBreak.test.ts
@@ -1324,6 +1324,27 @@ describe("floating table placement", () => {
 });
 
 describe("oversized table row splits across pages (#570)", () => {
+  test("starts a row with an authored leading page break on a fresh page", () => {
+    const { block, measure } = tallTable(1);
+    const secondRow = structuredClone(block.rows[0]!);
+    secondRow.id = "r1";
+    secondRow.breakBefore = "page";
+    block.rows.push(secondRow);
+    measure.rows.push(structuredClone(measure.rows[0]!));
+    measure.totalHeight += LINE;
+
+    const layout = layoutDocument([block], [measure], OPTIONS);
+    const fragments = layout.pages
+      .flatMap((page) => page.fragments)
+      .filter((fragment): fragment is TableFragment => fragment.kind === "table");
+
+    expect(layout.pages).toHaveLength(2);
+    expect(fragments.map(({ fromRow, toRow }) => [fromRow, toRow])).toEqual([
+      [0, 1],
+      [1, 2],
+    ]);
+  });
+
   test("consumes empty-paragraph leading spacing when a split row resumes", () => {
     const block: TableBlock = {
       kind: "table",

--- a/packages/core/src/layout-engine/types.ts
+++ b/packages/core/src/layout-engine/types.ts
@@ -682,6 +682,8 @@ export type TableRow = {
   isHeader?: boolean;
   /** `w:cantSplit`: keep this row in one flow region. */
   cantSplit?: boolean;
+  /** A leading authored page break in a cell advances the whole row. */
+  breakBefore?: "page";
   hidden?: boolean;
 };
 
@@ -1135,6 +1137,8 @@ export type FragmentBase = {
  */
 export type ParagraphFragment = FragmentBase & {
   kind: "paragraph";
+  /** Structural PM carrier that must not make an otherwise blank page visible. */
+  paginationRole?: "empty-carrier";
   /** First line index (inclusive) from the measure. */
   fromLine: number;
   /** Last line index (exclusive) from the measure. */

--- a/packages/core/src/prosemirror/conversion/pageBreakRunContainerOwnership.test.ts
+++ b/packages/core/src/prosemirror/conversion/pageBreakRunContainerOwnership.test.ts
@@ -10,6 +10,7 @@ import type {
   Table,
 } from "../../types/document";
 import { createEmptyDocument } from "../../utils/createDocument";
+import { fromProseDoc } from "./fromProseDoc";
 import {
   footnoteToProseDoc,
   headerFooterToProseDoc,
@@ -164,6 +165,7 @@ const documentWithContent = (content: BlockContent[]): Document => {
 type ContainerContext = {
   name: string;
   owner: "table-cell" | "text-box";
+  supportsLeadingBreak: boolean;
   build: (paragraph: Paragraph) => Document;
 };
 
@@ -171,16 +173,19 @@ const CONTAINER_CONTEXTS = [
   {
     name: "ordinary table cell",
     owner: "table-cell",
+    supportsLeadingBreak: true,
     build: (paragraph) => documentWithContent([tableWithParagraph(paragraph)]),
   },
   {
     name: "repeating-header table cell",
     owner: "table-cell",
+    supportsLeadingBreak: true,
     build: (paragraph) => documentWithContent([tableWithParagraph(paragraph, true)]),
   },
   {
     name: "nested table cell",
     owner: "table-cell",
+    supportsLeadingBreak: false,
     build: (paragraph) =>
       documentWithContent([
         {
@@ -202,16 +207,19 @@ const CONTAINER_CONTEXTS = [
   {
     name: "text box",
     owner: "text-box",
+    supportsLeadingBreak: false,
     build: (paragraph) => documentWithContent([textBoxHost([paragraph])]),
   },
   {
     name: "table nested in a text box",
     owner: "text-box",
+    supportsLeadingBreak: false,
     build: (paragraph) => documentWithContent([textBoxHost([tableWithParagraph(paragraph)])]),
   },
   {
     name: "text box nested in a table cell",
     owner: "table-cell",
+    supportsLeadingBreak: false,
     build: (paragraph) => documentWithContent([tableWithParagraph(textBoxHost([paragraph]))]),
   },
 ] as const satisfies readonly ContainerContext[];
@@ -226,11 +234,22 @@ const CONTAINER_MESSAGES = {
 describe("page-break run source-container ownership", () => {
   for (const context of CONTAINER_CONTEXTS) {
     test.each(INLINE_WRAPPERS)(
-      `rejects a page break in a ${context.name} through $name`,
+      `classifies a leading page break in a ${context.name} through $name`,
       ({ wrap }) => {
         const paragraph: Paragraph = { type: "paragraph", content: [wrap(pageBreakRun())] };
         const source = context.build(paragraph);
         const before = structuredClone(source.package.document.content);
+
+        if (context.supportsLeadingBreak) {
+          const prose = toProseDoc(source);
+          let pageBreaks = 0;
+          prose.descendants((node) => {
+            if (node.type.name === "pageBreakRun") pageBreaks += 1;
+          });
+          expect(pageBreaks).toBe(1);
+          expect(source.package.document.content).toEqual(before);
+          return;
+        }
 
         expectUnsupportedConversion(() => toProseDoc(source), {
           message: CONTAINER_MESSAGES[context.owner],
@@ -245,10 +264,12 @@ describe("page-break run source-container ownership", () => {
   test.each([
     {
       name: "only",
+      supported: true,
       content: [{ type: "break", breakType: "page" }],
     },
     {
       name: "leading",
+      supported: true,
       content: [
         { type: "break", breakType: "page" },
         { type: "text", text: "after" },
@@ -256,6 +277,7 @@ describe("page-break run source-container ownership", () => {
     },
     {
       name: "trailing",
+      supported: false,
       content: [
         { type: "text", text: "before" },
         { type: "break", breakType: "page" },
@@ -263,6 +285,7 @@ describe("page-break run source-container ownership", () => {
     },
     {
       name: "interleaved with rendered layout markers",
+      supported: false,
       content: [
         { type: "renderedPageBreak" },
         { type: "text", text: "before" },
@@ -271,23 +294,29 @@ describe("page-break run source-container ownership", () => {
         { type: "text", text: "after" },
       ],
     },
-  ] as const satisfies readonly { name: string; content: readonly RunContent[] }[])(
-    "rejects a $name authored page break regardless of its run position",
-    ({ content }) => {
-      const source = documentWithContent([
-        tableWithParagraph({
-          type: "paragraph",
-          content: [{ type: "run", content: [...content] }],
-        }),
-      ]);
+  ] as const satisfies readonly {
+    name: string;
+    supported: boolean;
+    content: readonly RunContent[];
+  }[])("classifies a $name authored page break by its run position", ({ content, supported }) => {
+    const source = documentWithContent([
+      tableWithParagraph({
+        type: "paragraph",
+        content: [{ type: "run", content: [...content] }],
+      }),
+    ]);
 
-      expectUnsupportedConversion(() => toProseDoc(source), {
-        message: CONTAINER_MESSAGES["table-cell"],
-        owner: "table-cell",
-        contentType: "break",
-      });
-    },
-  );
+    if (supported) {
+      expect(() => toProseDoc(source)).not.toThrow();
+      return;
+    }
+
+    expectUnsupportedConversion(() => toProseDoc(source), {
+      message: CONTAINER_MESSAGES["table-cell"],
+      owner: "table-cell",
+      contentType: "break",
+    });
+  });
 
   test.each([
     { content: [{ type: "renderedPageBreak" }] },
@@ -331,12 +360,31 @@ describe("page-break run source-container ownership", () => {
       name: "footnote or endnote conversion",
       convert: (paragraph: Paragraph) => footnoteToProseDoc([tableWithParagraph(paragraph)]),
     },
-  ])("builds source ownership for $name", ({ convert }) => {
-    expectUnsupportedConversion(() => convert(pageBreakParagraph()), {
-      message: CONTAINER_MESSAGES["table-cell"],
-      owner: "table-cell",
-      contentType: "break",
-    });
+  ])("supports a leading row boundary through $name", ({ convert }) => {
+    expect(() => convert(pageBreakParagraph())).not.toThrow();
+  });
+
+  test("round-trips a leading row boundary after a zero-width bookmark", () => {
+    const source = documentWithContent([
+      tableWithParagraph({
+        type: "paragraph",
+        content: [
+          { type: "bookmarkStart", id: 7, name: "boundary" },
+          {
+            type: "run",
+            content: [
+              { type: "break", breakType: "page" },
+              { type: "text", text: "after" },
+            ],
+          },
+          { type: "bookmarkEnd", id: 7 },
+        ],
+      }),
+    ]);
+
+    const restored = fromProseDoc(toProseDoc(source), source);
+
+    expect(restored.package.document.content).toEqual(source.package.document.content);
   });
 
   test.each([
@@ -445,12 +493,30 @@ const STORY_SURFACES = [
 describe("page-break run source-paragraph ownership", () => {
   for (const surface of STORY_SURFACES) {
     test.each(PARAGRAPH_DISPOSITIONS)(
-      `rejects a $name on the ${surface.name}`,
-      ({ formatting, owner, message }) => {
+      `supports a leading page break in a $name on the ${surface.name}`,
+      ({ formatting }) => {
         const paragraph: Paragraph = {
           type: "paragraph",
           formatting,
           content: [INLINE_WRAPPERS.at(-1)!.wrap(pageBreakRun())],
+        };
+        const before = structuredClone(paragraph);
+
+        expect(() => surface.convert(paragraph)).not.toThrow();
+        expect(paragraph).toEqual(before);
+      },
+    );
+
+    test.each(PARAGRAPH_DISPOSITIONS)(
+      `rejects an interior page break in a $name on the ${surface.name}`,
+      ({ formatting, owner, message }) => {
+        const paragraph: Paragraph = {
+          type: "paragraph",
+          formatting,
+          content: [
+            { type: "run", content: [{ type: "text", text: "before" }] },
+            INLINE_WRAPPERS.at(-1)!.wrap(pageBreakRun()),
+          ],
         };
         const before = structuredClone(paragraph);
 
@@ -495,7 +561,7 @@ describe("page-break run source-paragraph ownership", () => {
     },
   );
 
-  test("uses resolved paragraph attrs for style-owned projection constraints", () => {
+  test("supports a leading page break with a style-owned outline level", () => {
     const source = documentWithContent([
       {
         type: "paragraph",
@@ -507,14 +573,10 @@ describe("page-break run source-paragraph ownership", () => {
       styles: [{ styleId: "Outlined", type: "paragraph", pPr: { outlineLevel: 0 } }],
     };
 
-    expectUnsupportedConversion(() => toProseDoc(source), {
-      message: "An outline paragraph containing an explicit page-break run cannot be projected",
-      owner: "paragraph-outline",
-      contentType: "break",
-    });
+    expect(() => toProseDoc(source)).not.toThrow();
   });
 
-  test("rejects a page break in a paragraph-style-owned frame", () => {
+  test("supports a leading page break in a paragraph-style-owned frame", () => {
     const source = documentWithContent([
       {
         type: "paragraph",
@@ -526,14 +588,10 @@ describe("page-break run source-paragraph ownership", () => {
       styles: [{ styleId: "Framed", type: "paragraph", pPr: { frame: { width: 720 } } }],
     };
 
-    expectUnsupportedConversion(() => toProseDoc(source), {
-      message: "A framed paragraph containing an explicit page-break run cannot be projected",
-      owner: "paragraph-frame",
-      contentType: "break",
-    });
+    expect(() => toProseDoc(source)).not.toThrow();
   });
 
-  test("keeps outer table-cell ownership ahead of a table-style-owned frame", () => {
+  test("supports a leading table-row boundary with a table-style-owned frame", () => {
     const table = tableWithParagraph(pageBreakParagraph());
     table.formatting = { styleId: "FramedTable" };
     const source = documentWithContent([table]);
@@ -541,11 +599,7 @@ describe("page-break run source-paragraph ownership", () => {
       styles: [{ styleId: "FramedTable", type: "table", pPr: { frame: { width: 720 } } }],
     };
 
-    expectUnsupportedConversion(() => toProseDoc(source), {
-      message: CONTAINER_MESSAGES["table-cell"],
-      owner: "table-cell",
-      contentType: "break",
-    });
+    expect(() => toProseDoc(source)).not.toThrow();
   });
 
   test.each(["drop", "margin"] as const)(

--- a/packages/core/src/prosemirror/conversion/pageBreakRunContainerOwnership.test.ts
+++ b/packages/core/src/prosemirror/conversion/pageBreakRunContainerOwnership.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { toFlowBlocks } from "../../layout-bridge/convert/toFlowBlocks";
 import type {
   BlockContent,
   Document,
@@ -385,6 +386,113 @@ describe("page-break run source-container ownership", () => {
     const restored = fromProseDoc(toProseDoc(source), source);
 
     expect(restored.package.document.content).toEqual(source.package.document.content);
+  });
+
+  test.each([
+    {
+      name: "empty field",
+      content: {
+        type: "simpleField",
+        instruction: "REF empty",
+        fieldType: "REF",
+        content: [],
+      },
+    },
+    {
+      name: "empty inline content control",
+      content: {
+        type: "inlineSdt",
+        properties: { sdtType: "richText" },
+        content: [],
+      },
+    },
+  ] as const satisfies readonly { name: string; content: ParagraphContent }[])(
+    "projects a leading row boundary after an $name through the full conversion pipeline",
+    ({ content }) => {
+      const source = documentWithContent([
+        tableWithParagraph({
+          type: "paragraph",
+          content: [
+            content,
+            pageBreakRun(),
+            { type: "run", content: [{ type: "text", text: "after" }] },
+          ],
+        }),
+      ]);
+
+      const table = toFlowBlocks(toProseDoc(source)).at(0);
+
+      expect(table?.kind).toBe("table");
+      if (table?.kind !== "table") {
+        return;
+      }
+      expect(table.rows.at(0)?.breakBefore).toBe("page");
+    },
+  );
+
+  test("does not project a deleted leading page break as a row boundary", () => {
+    const source = documentWithContent([
+      tableWithParagraph({
+        type: "paragraph",
+        content: [{ type: "deletion", info: REVISION, content: [pageBreakRun()] }],
+      }),
+    ]);
+
+    const table = toFlowBlocks(toProseDoc(source)).at(0);
+
+    expect(table?.kind).toBe("table");
+    if (table?.kind !== "table") {
+      return;
+    }
+    expect(table.rows.at(0)?.breakBefore).toBeUndefined();
+  });
+
+  test.each([
+    {
+      name: "an insertion nested in a deletion",
+      content: {
+        type: "deletion",
+        info: REVISION,
+        content: [
+          {
+            type: "insertion",
+            info: { ...REVISION, id: REVISION.id + 1 },
+            content: [pageBreakRun()],
+          },
+        ],
+      } satisfies ParagraphContent,
+      expected: "page" as const,
+    },
+    {
+      name: "a deletion nested in an insertion",
+      content: {
+        type: "insertion",
+        info: REVISION,
+        content: [
+          {
+            type: "deletion",
+            info: { ...REVISION, id: REVISION.id + 1 },
+            content: [pageBreakRun()],
+          },
+        ],
+      } satisfies ParagraphContent,
+      expected: undefined,
+    },
+  ])("uses the innermost tracked state for $name", ({ content, expected }) => {
+    const source = documentWithContent([
+      tableWithParagraph({
+        type: "paragraph",
+        content: [content],
+      }),
+    ]);
+
+    const table = toFlowBlocks(toProseDoc(source)).at(0);
+
+    expect(table?.kind).toBe("table");
+    if (table?.kind !== "table") {
+      return;
+    }
+    expect(table.rows.at(0)?.breakBefore).toBe(expected);
   });
 
   test.each([

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -2784,7 +2784,7 @@ function assertSourceContainerHasNoPageBreakRun(
   });
 }
 
-/** A leading page-break run in a cell advances the whole row in Word. This
+/** A leading page-break run in a cell advances the whole row during pagination. This
  * narrow shape has a lossless PM representation and a row-wide layout
  * projection; interior breaks still require table-fragment ownership. */
 function hasSingleLeadingTableCellPageBreak(content: BlockContent[]): boolean {

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -1681,6 +1681,16 @@ function convertTable(
 ): PMNode {
   for (const row of table.rows) {
     for (const cell of row.cells) {
+      if (
+        cell.formatting?.vMerge === "continue" &&
+        context.pageBreakRunSourceDescendants.containsPageBreakRun(cell.content)
+      ) {
+        throw new UnsupportedDocxToProseMirrorConversionError({
+          message: `${PAGE_BREAK_CONTAINER_DESCRIPTIONS["table-cell"]} cannot be represented in the editor model`,
+          owner: "table-cell",
+          contentType: "break",
+        });
+      }
       assertSourceContainerHasNoPageBreakRun(
         cell.content,
         "table-cell",
@@ -2764,12 +2774,94 @@ function assertSourceContainerHasNoPageBreakRun(
   if (!sourceDescendants.containsPageBreakRun(content)) {
     return;
   }
+  if (owner === "table-cell" && hasSingleLeadingTableCellPageBreak(content)) {
+    return;
+  }
   throw new UnsupportedDocxToProseMirrorConversionError({
     message: `${PAGE_BREAK_CONTAINER_DESCRIPTIONS[owner]} cannot be represented in the editor model`,
     owner,
     contentType: "break",
   });
 }
+
+/** A leading page-break run in a cell advances the whole row in Word. This
+ * narrow shape has a lossless PM representation and a row-wide layout
+ * projection; interior breaks still require table-fragment ownership. */
+function hasSingleLeadingTableCellPageBreak(content: BlockContent[]): boolean {
+  const paragraph =
+    content.length === 1 && content[0]?.type === "paragraph" ? content[0] : undefined;
+  return paragraph !== undefined && hasSingleLeadingParagraphPageBreak(paragraph);
+}
+
+type LeadingPageBreakScan = {
+  contentBeforeBreak: boolean;
+  pageBreaks: number;
+};
+
+const scanLeadingPageBreakRun = (run: Run, scan: LeadingPageBreakScan): void => {
+  for (const content of run.content) {
+    if (content.type === "renderedPageBreak") {
+      continue;
+    }
+    if (content.type === "break" && content.breakType === "page") {
+      scan.pageBreaks += 1;
+      continue;
+    }
+    if (scan.pageBreaks === 0) {
+      scan.contentBeforeBreak = true;
+    }
+  }
+};
+
+const scanLeadingPageBreakContent = (
+  content: Paragraph["content"][number],
+  scan: LeadingPageBreakScan,
+): void => {
+  switch (content.type) {
+    case "run":
+      scanLeadingPageBreakRun(content, scan);
+      return;
+    case "hyperlink":
+      for (const child of content.children) scanLeadingPageBreakContent(child, scan);
+      return;
+    case "insertion":
+    case "deletion":
+    case "moveFrom":
+    case "moveTo":
+    case "inlineSdt":
+      for (const child of content.content) scanLeadingPageBreakContent(child, scan);
+      return;
+    case "simpleField":
+      for (const child of content.content) scanLeadingPageBreakContent(child, scan);
+      return;
+    case "complexField":
+      for (const child of content.fieldResult) scanLeadingPageBreakRun(child, scan);
+      return;
+    case "bookmarkStart":
+    case "bookmarkEnd":
+    case "commentRangeStart":
+    case "commentRangeEnd":
+    case "moveFromRangeStart":
+    case "moveFromRangeEnd":
+    case "moveToRangeStart":
+    case "moveToRangeEnd":
+      return;
+    case "commentReference":
+    case "mathEquation":
+      if (scan.pageBreaks === 0) scan.contentBeforeBreak = true;
+      return;
+    default: {
+      const unsupported: never = content;
+      return unsupported;
+    }
+  }
+};
+
+const hasSingleLeadingParagraphPageBreak = (paragraph: Paragraph): boolean => {
+  const scan: LeadingPageBreakScan = { contentBeforeBreak: false, pageBreaks: 0 };
+  for (const content of paragraph.content) scanLeadingPageBreakContent(content, scan);
+  return !scan.contentBeforeBreak && scan.pageBreaks === 1;
+};
 
 type ParagraphPageBreakProjectionOptions = {
   paragraph: Paragraph;
@@ -2797,6 +2889,9 @@ function assertParagraphPageBreakCanBeProjected({
     hasTextBoxAnchor: sourceFeatures.hasTextBoxShape && !sourceFeatures.pageBreakSharesTextBoxShape,
   });
   if (disposition.status === "supported") {
+    return;
+  }
+  if (disposition.reason !== "textBoxAnchor" && hasSingleLeadingParagraphPageBreak(paragraph)) {
     return;
   }
   throw new UnsupportedDocxToProseMirrorConversionError({


### PR DESCRIPTION
## Summary

- preserve logically leading authored page breaks in framed, outlined, and bordered paragraphs
- project leading table-cell breaks as row-wide page boundaries while rejecting ambiguous nested or interior placements
- distinguish structural empty carriers from visible empty paragraphs when coalescing section boundaries

## Validation

- `bun --filter @stll/folio-core test`
- `bun --filter @stll/folio-core typecheck`
- `bun run lint`
- `bun run format:check`
- `bun audit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Leading page breaks in table cells now correctly move the entire row to a new page.
  * Leading page breaks in styled and bordered paragraphs are preserved during document conversion.
  * Blank pages containing structural content are now handled correctly, preventing unintended extra pages.
  * Section boundaries after hard page breaks now retain the expected pagination and layout.
  * Content following zero-width bookmarks is preserved when leading page breaks are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->