### PR TITLE
fix: position text boxes in active columns

### DIFF
--- a/.changeset/bright-columns-align.md
+++ b/.changeset/bright-columns-align.md
@@ -1,0 +1,5 @@
+---
+"@stll/folio-core": patch
+---
+
+Position and wrap column-relative text boxes within their active flow column.

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -1645,6 +1645,8 @@ function layoutTextBox(
           pageWidth: state.page.size.w,
           marginLeft: state.page.margins.left,
           marginRight: state.page.margins.right,
+          activeColumnLeft: paginator.getColumnX(state.columnIndex),
+          activeColumnWidth: paginator.columnWidth,
           boxWidth: measure.width,
         })
       : paginator.getColumnX(state.columnIndex);
@@ -1678,6 +1680,8 @@ function layoutTextBox(
           pageWidth: state.page.size.w,
           marginLeft: state.page.margins.left,
           marginRight: state.page.margins.right,
+          activeColumnLeft: paginator.getColumnX(state.columnIndex),
+          activeColumnWidth: paginator.columnWidth,
           boxWidth: measure.width,
         })
       : paginator.getColumnX(state.columnIndex);

--- a/packages/core/src/layout-engine/index.ts
+++ b/packages/core/src/layout-engine/index.ts
@@ -1639,17 +1639,14 @@ function layoutTextBox(
     // Honor the box's horizontal anchor (align center/right, page-relative
     // offset) instead of always pinning to the column's left edge. The band is
     // full-width regardless, so this only moves where the box paints.
-    const horizontal = block.position?.horizontal;
-    const x = horizontal
-      ? bandFragmentX(horizontal, {
-          pageWidth: state.page.size.w,
-          marginLeft: state.page.margins.left,
-          marginRight: state.page.margins.right,
-          activeColumnLeft: paginator.getColumnX(state.columnIndex),
-          activeColumnWidth: paginator.columnWidth,
-          boxWidth: measure.width,
-        })
-      : paginator.getColumnX(state.columnIndex);
+    const x = bandFragmentX(block.position?.horizontal, {
+      pageWidth: state.page.size.w,
+      marginLeft: state.page.margins.left,
+      marginRight: state.page.margins.right,
+      activeColumnLeft: paginator.getColumnX(state.columnIndex),
+      activeColumnWidth: paginator.columnWidth,
+      boxWidth: measure.width,
+    });
     const fragment: TextBoxFragment = {
       kind: "textBox",
       blockId: block.id,
@@ -1674,17 +1671,14 @@ function layoutTextBox(
   // shape-only paragraph stack vertically and push the body onto another page.
   if (block.position !== undefined) {
     const state = paginator.getCurrentState();
-    const horizontal = block.position.horizontal;
-    const x = horizontal
-      ? bandFragmentX(horizontal, {
-          pageWidth: state.page.size.w,
-          marginLeft: state.page.margins.left,
-          marginRight: state.page.margins.right,
-          activeColumnLeft: paginator.getColumnX(state.columnIndex),
-          activeColumnWidth: paginator.columnWidth,
-          boxWidth: measure.width,
-        })
-      : paginator.getColumnX(state.columnIndex);
+    const x = bandFragmentX(block.position.horizontal, {
+      pageWidth: state.page.size.w,
+      marginLeft: state.page.margins.left,
+      marginRight: state.page.margins.right,
+      activeColumnLeft: paginator.getColumnX(state.columnIndex),
+      activeColumnWidth: paginator.columnWidth,
+      boxWidth: measure.width,
+    });
     const vertical = block.position.vertical;
     const anchorBlockId = readTextBoxAnchorBlockId(block);
     const anchorParagraph =

--- a/packages/core/src/layout-engine/measure/measureBlocks.test.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.test.ts
@@ -951,47 +951,67 @@ describe("measureBlocks", () => {
   });
 
   test.each([
-    { name: "column-relative", horizontal: { relativeTo: "column" as const, posOffset: 0 } },
-    { name: "horizontally implicit", horizontal: undefined },
-  ])("wraps from a $name text box in the active column frame", ({ horizontal }) => {
-    withFakeTextMeasure(() => {
-      const textBox: TextBoxBlock = {
-        kind: "textBox",
-        id: "second-column-box",
-        width: 100,
-        height: 100,
-        content: [],
-        wrapType: "square",
-        wrapText: "bothSides",
-        position: {
-          ...(horizontal ? { horizontal } : {}),
-          vertical: { relativeTo: "paragraph", posOffset: 0 },
-        },
-      };
-      const blocks: FlowBlock[] = [
-        { kind: "columnBreak", id: "second-column" },
-        textBox,
-        para("body", "body"),
-      ];
+    {
+      name: "column-relative left-aligned",
+      horizontal: { relativeTo: "column" as const, posOffset: 0 },
+      expectedLeftOffset: 112,
+      expectedRightOffset: undefined,
+    },
+    {
+      name: "column-relative right-aligned",
+      horizontal: { relativeTo: "column" as const, align: "right" as const },
+      expectedLeftOffset: undefined,
+      expectedRightOffset: 112,
+    },
+    {
+      name: "horizontally implicit",
+      horizontal: undefined,
+      expectedLeftOffset: 112,
+      expectedRightOffset: undefined,
+    },
+  ])(
+    "wraps from a $name text box in the active column frame",
+    ({ horizontal, expectedLeftOffset, expectedRightOffset }) => {
+      withFakeTextMeasure(() => {
+        const textBox: TextBoxBlock = {
+          kind: "textBox",
+          id: "second-column-box",
+          width: 100,
+          height: 100,
+          content: [],
+          wrapType: "square",
+          wrapText: "bothSides",
+          position: {
+            ...(horizontal ? { horizontal } : {}),
+            vertical: { relativeTo: "paragraph", posOffset: 0 },
+          },
+        };
+        const blocks: FlowBlock[] = [
+          { kind: "columnBreak", id: "second-column" },
+          textBox,
+          para("body", "body"),
+        ];
 
-      const measures = measureBlocks(blocks, 350, 0, {
-        pageWidth: 1_000,
-        pageHeight: 1_000,
-        marginLeft: 100,
-        marginRight: 100,
-        marginBottom: 40,
-        contentLeft: [100, 550, 550],
-        columnIndex: [0, 1, 1],
-        columnCount: 2,
-      });
-      const bodyMeasure = measures.at(2);
-      if (bodyMeasure?.kind !== "paragraph") {
-        throw new Error("Expected paragraph measure");
-      }
+        const measures = measureBlocks(blocks, [200, 300, 300], 0, {
+          pageWidth: 1_000,
+          pageHeight: 1_000,
+          marginLeft: 100,
+          marginRight: 100,
+          marginBottom: 40,
+          contentLeft: [100, 350, 350],
+          columnIndex: [0, 1, 1],
+          columnCount: 2,
+        });
+        const bodyMeasure = measures.at(2);
+        if (bodyMeasure?.kind !== "paragraph") {
+          throw new Error("Expected paragraph measure");
+        }
 
-      expect(bodyMeasure.lines.at(0)?.leftOffset).toBe(112);
-    }, fakeMeasure);
-  });
+        expect(bodyMeasure.lines.at(0)?.leftOffset).toBe(expectedLeftOffset);
+        expect(bodyMeasure.lines.at(0)?.rightOffset).toBe(expectedRightOffset);
+      }, fakeMeasure);
+    },
+  );
 
   test("drops an active band at a section break whose omitted type defaults to nextPage", () => {
     withFakeTextMeasure(() => {

--- a/packages/core/src/layout-engine/measure/measureBlocks.test.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.test.ts
@@ -950,6 +950,49 @@ describe("measureBlocks", () => {
     }, fakeMeasure);
   });
 
+  test.each([
+    { name: "column-relative", horizontal: { relativeTo: "column" as const, posOffset: 0 } },
+    { name: "horizontally implicit", horizontal: undefined },
+  ])("wraps from a $name text box in the active column frame", ({ horizontal }) => {
+    withFakeTextMeasure(() => {
+      const textBox: TextBoxBlock = {
+        kind: "textBox",
+        id: "second-column-box",
+        width: 100,
+        height: 100,
+        content: [],
+        wrapType: "square",
+        wrapText: "bothSides",
+        position: {
+          ...(horizontal ? { horizontal } : {}),
+          vertical: { relativeTo: "paragraph", posOffset: 0 },
+        },
+      };
+      const blocks: FlowBlock[] = [
+        { kind: "columnBreak", id: "second-column" },
+        textBox,
+        para("body", "body"),
+      ];
+
+      const measures = measureBlocks(blocks, 350, 0, {
+        pageWidth: 1_000,
+        pageHeight: 1_000,
+        marginLeft: 100,
+        marginRight: 100,
+        marginBottom: 40,
+        contentLeft: [100, 550, 550],
+        columnIndex: [0, 1, 1],
+        columnCount: 2,
+      });
+      const bodyMeasure = measures.at(2);
+      if (bodyMeasure?.kind !== "paragraph") {
+        throw new Error("Expected paragraph measure");
+      }
+
+      expect(bodyMeasure.lines.at(0)?.leftOffset).toBe(112);
+    }, fakeMeasure);
+  });
+
   test("drops an active band at a section break whose omitted type defaults to nextPage", () => {
     withFakeTextMeasure(() => {
       const band: TextBoxBlock = {

--- a/packages/core/src/layout-engine/measure/measureBlocks.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.ts
@@ -777,6 +777,7 @@ function extractFloatingZones(
     const blockMarginRight = perBlockNumberValue(marginRightInput, blockIndex, defaultMarginRight);
     const blockPageWidth = perBlockNumberValue(pageWidthInput, blockIndex, defaultPageWidth);
     const blockContentWidth = perBlockNumberValue(contentWidth, blockIndex, defaultContentWidth);
+    const blockContentLeft = perBlockNumberValue(contentLeftInput, blockIndex, defaultContentLeft);
     const vertical = tb.position.vertical;
     const pageFrameRelative = isPageFrameRelativeAnchor(vertical?.relativeTo);
     const topY = pageFrameRelative
@@ -817,10 +818,12 @@ function extractFloatingZones(
           pageWidth: blockPageWidth,
           marginLeft: blockMarginLeft,
           marginRight: blockMarginRight,
+          activeColumnLeft: blockContentLeft,
+          activeColumnWidth: blockContentWidth,
           boxWidth: measure.width,
         })
-      : blockMarginLeft;
-    const contentX = pageX - blockMarginLeft;
+      : blockContentLeft;
+    const contentX = pageX - blockContentLeft;
     const wrapSide = textBoxWrapSide({
       box: tb,
       contentX,

--- a/packages/core/src/layout-engine/measure/measureBlocks.ts
+++ b/packages/core/src/layout-engine/measure/measureBlocks.ts
@@ -812,17 +812,14 @@ function extractFloatingZones(
       continue;
     }
 
-    const horizontal = tb.position.horizontal;
-    const pageX = horizontal
-      ? bandFragmentX(horizontal, {
-          pageWidth: blockPageWidth,
-          marginLeft: blockMarginLeft,
-          marginRight: blockMarginRight,
-          activeColumnLeft: blockContentLeft,
-          activeColumnWidth: blockContentWidth,
-          boxWidth: measure.width,
-        })
-      : blockContentLeft;
+    const pageX = bandFragmentX(tb.position.horizontal, {
+      pageWidth: blockPageWidth,
+      marginLeft: blockMarginLeft,
+      marginRight: blockMarginRight,
+      activeColumnLeft: blockContentLeft,
+      activeColumnWidth: blockContentWidth,
+      boxWidth: measure.width,
+    });
     const contentX = pageX - blockContentLeft;
     const wrapSide = textBoxWrapSide({
       box: tb,

--- a/packages/core/src/layout-engine/textBoxFlow.test.ts
+++ b/packages/core/src/layout-engine/textBoxFlow.test.ts
@@ -82,8 +82,14 @@ describe("bandFragmentX (eigenpal #694)", () => {
   };
   const EMU_PER_INCH = 914_400; // 1in = 96px at 96 DPI = marginLeft.
 
-  test("no horizontal anchor → content left edge", () => {
-    expect(bandFragmentX(undefined, geometry)).toBe(96);
+  test("no horizontal anchor → active column left edge", () => {
+    expect(
+      bandFragmentX(undefined, {
+        ...geometry,
+        activeColumnLeft: 420,
+        activeColumnWidth: 300,
+      }),
+    ).toBe(420);
   });
 
   test("margin-relative align=center centers within the content box", () => {
@@ -141,7 +147,6 @@ describe("bandFragmentX (eigenpal #694)", () => {
       activeColumnWidth: 300,
     };
     const nonColumnFrames = [
-      undefined,
       "page",
       "margin",
       "character",

--- a/packages/core/src/layout-engine/textBoxFlow.test.ts
+++ b/packages/core/src/layout-engine/textBoxFlow.test.ts
@@ -76,6 +76,8 @@ describe("bandFragmentX (eigenpal #694)", () => {
     pageWidth: 816,
     marginLeft: 96,
     marginRight: 96,
+    activeColumnLeft: 96,
+    activeColumnWidth: 624,
     boxWidth: 600,
   };
   const EMU_PER_INCH = 914_400; // 1in = 96px at 96 DPI = marginLeft.
@@ -116,6 +118,20 @@ describe("bandFragmentX (eigenpal #694)", () => {
     ).toBe(96);
     // margin frame: 96 + 96
     expect(bandFragmentX({ relativeTo: "margin", posOffset: EMU_PER_INCH }, geometry)).toBe(192);
+  });
+
+  test("resolves column-relative placement from the active column frame", () => {
+    const secondColumn = {
+      ...geometry,
+      activeColumnLeft: 420,
+      activeColumnWidth: 300,
+      boxWidth: 120,
+    };
+
+    expect(bandFragmentX({ relativeTo: "column", posOffset: EMU_PER_INCH }, secondColumn)).toBe(
+      516,
+    );
+    expect(bandFragmentX({ relativeTo: "column", align: "right" }, secondColumn)).toBe(600);
   });
 
   test("resolves left/right margin-strip frames", () => {

--- a/packages/core/src/layout-engine/textBoxFlow.test.ts
+++ b/packages/core/src/layout-engine/textBoxFlow.test.ts
@@ -134,6 +134,29 @@ describe("bandFragmentX (eigenpal #694)", () => {
     expect(bandFragmentX({ relativeTo: "column", align: "right" }, secondColumn)).toBe(600);
   });
 
+  test("changing the active column cannot move anchors in any other frame", () => {
+    const shiftedColumn = {
+      ...geometry,
+      activeColumnLeft: 420,
+      activeColumnWidth: 300,
+    };
+    const nonColumnFrames = [
+      undefined,
+      "page",
+      "margin",
+      "character",
+      "leftMargin",
+      "rightMargin",
+      "insideMargin",
+      "outsideMargin",
+    ] as const;
+
+    for (const relativeTo of nonColumnFrames) {
+      const horizontal = { relativeTo, align: "center" as const };
+      expect(bandFragmentX(horizontal, shiftedColumn)).toBe(bandFragmentX(horizontal, geometry));
+    }
+  });
+
   test("resolves left/right margin-strip frames", () => {
     // leftMargin/insideMargin → left strip [0, 96]; rightMargin/outsideMargin →
     // right strip [720, 816]. The box's left edge sits at the strip's left.

--- a/packages/core/src/layout-engine/textBoxFlow.ts
+++ b/packages/core/src/layout-engine/textBoxFlow.ts
@@ -130,6 +130,8 @@ export type BandHorizontalGeometry = {
   pageWidth: number;
   marginLeft: number;
   marginRight: number;
+  activeColumnLeft: number;
+  activeColumnWidth: number;
   boxWidth: number;
 };
 
@@ -139,14 +141,15 @@ type HorizontalAlign = NonNullable<ImageRunPosition["horizontal"]>["align"];
 /**
  * Page-absolute `[left, right]` (px) of the frame a horizontal anchor positions
  * within. `inside`/`outsideMargin` map to the left/right margin strips (page
- * parity is not modelled); `column`/`character` fall back to the content box
- * (folio has no per-column/character X here). eigenpal #694.
+ * parity is not modelled); `column` uses the active flow-column frame, while
+ * `character` falls back to the content box because character X is unavailable.
+ * eigenpal #694.
  */
 function bandHorizontalFrame(
   relativeTo: HorizontalRelativeTo,
   geometry: BandHorizontalGeometry,
 ): { left: number; right: number } {
-  const { pageWidth, marginLeft, marginRight } = geometry;
+  const { pageWidth, marginLeft, marginRight, activeColumnLeft, activeColumnWidth } = geometry;
   switch (relativeTo) {
     case "page":
       return { left: 0, right: pageWidth };
@@ -156,8 +159,9 @@ function bandHorizontalFrame(
     case "rightMargin":
     case "outsideMargin":
       return { left: pageWidth - marginRight, right: pageWidth };
-    case "margin":
     case "column":
+      return { left: activeColumnLeft, right: activeColumnLeft + activeColumnWidth };
+    case "margin":
     case "character":
     case undefined:
       return { left: marginLeft, right: pageWidth - marginRight };

--- a/packages/core/src/layout-engine/textBoxFlow.ts
+++ b/packages/core/src/layout-engine/textBoxFlow.ts
@@ -141,9 +141,9 @@ type HorizontalAlign = NonNullable<ImageRunPosition["horizontal"]>["align"];
 /**
  * Page-absolute `[left, right]` (px) of the frame a horizontal anchor positions
  * within. `inside`/`outsideMargin` map to the left/right margin strips (page
- * parity is not modelled); `column` uses the active flow-column frame, while
- * `character` falls back to the content box because character X is unavailable.
- * eigenpal #694.
+ * parity is not modelled); `column` and an omitted horizontal anchor use the
+ * active flow-column frame, while `character` falls back to the content box
+ * because character X is unavailable. eigenpal #694.
  */
 function bandHorizontalFrame(
   relativeTo: HorizontalRelativeTo,
@@ -160,10 +160,10 @@ function bandHorizontalFrame(
     case "outsideMargin":
       return { left: pageWidth - marginRight, right: pageWidth };
     case "column":
+    case undefined:
       return { left: activeColumnLeft, right: activeColumnLeft + activeColumnWidth };
     case "margin":
     case "character":
-    case undefined:
       return { left: marginLeft, right: pageWidth - marginRight };
     default:
       relativeTo satisfies never;

--- a/packages/core/src/layout-engine/textbox-band.test.ts
+++ b/packages/core/src/layout-engine/textbox-band.test.ts
@@ -201,6 +201,27 @@ describe("topAndBottom band text box layout", () => {
     expect(paragraph?.y).toBe(MARGINS.top);
   });
 
+  test("positions column-relative text boxes in their active column", () => {
+    const first = withHorizontal(verticalBanner({ relativeTo: "paragraph" }), {
+      relativeTo: "column",
+      posOffset: 0,
+    });
+    first.id = "first-column-box";
+    first.width = 120;
+    const second = { ...first, id: "second-column-box" };
+    const columnMeasure = { ...boxMeasure, width: 120 };
+    const layout = layoutDocument(
+      [first, { kind: "columnBreak", id: "next-column" }, second],
+      [columnMeasure, { kind: "columnBreak" }, columnMeasure],
+      { ...OPTIONS, columns: { count: 2, gap: 24 } },
+    );
+    const boxes = layout.pages[0]?.fragments.filter(
+      (fragment): fragment is TextBoxFragment => fragment.kind === "textBox",
+    );
+
+    expect(boxes?.map(({ x }) => x)).toEqual([96, 420]);
+  });
+
   test("paragraph-owned text box positions from its host paragraph", () => {
     const host = para("host");
     const anchored = verticalBanner({ relativeTo: "paragraph", posOffset: EMU_PER_INCH });

--- a/packages/core/src/layout-engine/textbox-band.test.ts
+++ b/packages/core/src/layout-engine/textbox-band.test.ts
@@ -201,10 +201,10 @@ describe("topAndBottom band text box layout", () => {
     expect(paragraph?.y).toBe(MARGINS.top);
   });
 
-  test("positions column-relative text boxes in their active column", () => {
+  test("uses each unequal column's origin and width for column-relative text boxes", () => {
     const first = withHorizontal(verticalBanner({ relativeTo: "paragraph" }), {
       relativeTo: "column",
-      posOffset: 0,
+      align: "right",
     });
     first.id = "first-column-box";
     first.width = 120;
@@ -213,13 +213,16 @@ describe("topAndBottom band text box layout", () => {
     const layout = layoutDocument(
       [first, { kind: "columnBreak", id: "next-column" }, second],
       [columnMeasure, { kind: "columnBreak" }, columnMeasure],
-      { ...OPTIONS, columns: { count: 2, gap: 24 } },
+      {
+        ...OPTIONS,
+        columns: { count: 2, gap: 24, equalWidth: false, widths: [200, 400], gaps: [24] },
+      },
     );
     const boxes = layout.pages[0]?.fragments.filter(
       (fragment): fragment is TextBoxFragment => fragment.kind === "textBox",
     );
 
-    expect(boxes?.map(({ x }) => x)).toEqual([96, 420]);
+    expect(boxes?.map(({ x }) => x)).toEqual([176, 600]);
   });
 
   test("paragraph-owned text box positions from its host paragraph", () => {


### PR DESCRIPTION
## Summary

- resolve `relativeFrom=column` text-box anchors against the active flow column
- keep paint placement and wrap measurement in the same page coordinate space
- cover first- and second-column placement plus second-column wrapping

## Validation

- `bun --filter @stll/folio-core test`
- `bun --filter @stll/folio-core typecheck`
- `bun run lint`
- `bun run format:check`
- `bun audit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed column-relative text boxes so they are positioned and wrapped according to the active column’s boundaries.
  * Improved placement across columns with different widths, including left-aligned, right-aligned and implicit horizontal positioning.

* **Tests**
  * Added coverage for text-box positioning and text wrapping across multiple, unequal-width columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->