### PR TITLE
fix: surface parity editor failures

### DIFF
--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -31,6 +31,12 @@ import type {
 import { FOLIO_LOCALES, getFolioMessages } from "@stll/folio-react/messages";
 
 import { CollaborationApp } from "./CollaborationApp";
+import {
+  IDLE_PLAYGROUND_STATUS,
+  PLAYGROUND_STATUS_CLASS_NAME,
+  PLAYGROUND_STATUS_TYPE,
+  type PlaygroundStatus,
+} from "./playgroundStatus";
 
 const ZOOM_INITIAL = 1;
 const DEFAULT_LOCALE = "en";
@@ -590,7 +596,7 @@ export function App() {
   const [currentDocument, setCurrentDocument] = useState<FolioDocument | null>(null);
   const [documentBuffer, setDocumentBuffer] = useState<ArrayBuffer | null>(null);
   const [fileName, setFileName] = useState("Untitled.docx");
-  const [status, setStatus] = useState("");
+  const [status, setStatus] = useState<PlaygroundStatus>(IDLE_PLAYGROUND_STATUS);
   const [editorMode, setEditorMode] = useState<EditorMode>("editing");
   const [locale, setLocale] = useState<string>(DEFAULT_LOCALE);
   const query = new URLSearchParams(window.location.search);
@@ -606,19 +612,22 @@ export function App() {
   const loadDocument = useCallback(
     async ({ fileName: nextFileName, loadingStatus, missingStatus, url }: LoadDocumentOptions) => {
       try {
-        setStatus(loadingStatus);
+        setStatus({ type: PLAYGROUND_STATUS_TYPE.LOADING, message: loadingStatus });
         const response = await fetch(url);
         if (!response.ok) {
-          setStatus(missingStatus);
+          setStatus({ type: PLAYGROUND_STATUS_TYPE.ERROR, message: missingStatus });
           return;
         }
         const buffer = await response.arrayBuffer();
         setCurrentDocument(null);
         setDocumentBuffer(buffer);
         setFileName(nextFileName);
-        setStatus("");
+        setStatus(IDLE_PLAYGROUND_STATUS);
       } catch {
-        setStatus(`Error loading ${nextFileName}`);
+        setStatus({
+          type: PLAYGROUND_STATUS_TYPE.ERROR,
+          message: `Error loading ${nextFileName}`,
+        });
       }
     },
     [],
@@ -662,7 +671,7 @@ export function App() {
     setCurrentDocument(createStellaStyleDocument());
     setDocumentBuffer(null);
     setFileName("Untitled.docx");
-    setStatus("");
+    setStatus(IDLE_PLAYGROUND_STATUS);
   }, []);
 
   const handleFileSelect = useCallback(async (event: ChangeEvent<HTMLInputElement>) => {
@@ -672,14 +681,14 @@ export function App() {
       return;
     }
     try {
-      setStatus("Loading...");
+      setStatus({ type: PLAYGROUND_STATUS_TYPE.LOADING, message: "Loading..." });
       const buffer = await file.arrayBuffer();
       setCurrentDocument(null);
       setDocumentBuffer(buffer);
       setFileName(file.name);
-      setStatus(`Loaded ${file.name}`);
+      setStatus({ type: PLAYGROUND_STATUS_TYPE.SUCCESS, message: `Loaded ${file.name}` });
     } catch {
-      setStatus("Error loading file");
+      setStatus({ type: PLAYGROUND_STATUS_TYPE.ERROR, message: "Error loading file" });
     } finally {
       input.value = "";
     }
@@ -688,7 +697,7 @@ export function App() {
   const handleOpenDocument = useCallback(() => {
     const input = fileInputRef.current;
     if (!input) {
-      setStatus("File picker unavailable");
+      setStatus({ type: PLAYGROUND_STATUS_TYPE.ERROR, message: "File picker unavailable" });
       return;
     }
     input.value = "";
@@ -709,7 +718,7 @@ export function App() {
       return;
     }
     try {
-      setStatus("Saving...");
+      setStatus({ type: PLAYGROUND_STATUS_TYPE.LOADING, message: "Saving..." });
       const buffer = await editorRef.current.save();
       if (buffer) {
         const blob = new Blob([buffer], {
@@ -723,16 +732,16 @@ export function App() {
         a.click();
         a.remove();
         URL.revokeObjectURL(url);
-        setStatus("Saved!");
-        setTimeout(() => setStatus(""), 2000);
+        setStatus({ type: PLAYGROUND_STATUS_TYPE.SUCCESS, message: "Saved!" });
+        setTimeout(() => setStatus(IDLE_PLAYGROUND_STATUS), 2000);
       }
     } catch {
-      setStatus("Save failed");
+      setStatus({ type: PLAYGROUND_STATUS_TYPE.ERROR, message: "Save failed" });
     }
   }, [fileName]);
 
   const handleError = useCallback((error: Error) => {
-    setStatus(`Error: ${error.message}`);
+    setStatus({ type: PLAYGROUND_STATUS_TYPE.ERROR, message: error.message });
   }, []);
 
   const handleInsertImage = useCallback(() => {
@@ -897,7 +906,11 @@ export function App() {
             ))}
           </select>
 
-          {status && <span className="pg-status">{status}</span>}
+          {status.type !== PLAYGROUND_STATUS_TYPE.IDLE && (
+            <span className={PLAYGROUND_STATUS_CLASS_NAME} data-status={status.type}>
+              {status.message}
+            </span>
+          )}
           <span className="pg-filename">{fileName}</span>
         </div>
       </div>

--- a/packages/playground/src/playgroundStatus.ts
+++ b/packages/playground/src/playgroundStatus.ts
@@ -1,0 +1,24 @@
+export const PLAYGROUND_STATUS_TYPE = {
+  IDLE: "idle",
+  LOADING: "loading",
+  SUCCESS: "success",
+  ERROR: "error",
+} as const;
+
+export type PlaygroundStatus =
+  | { type: typeof PLAYGROUND_STATUS_TYPE.IDLE }
+  | {
+      type:
+        | typeof PLAYGROUND_STATUS_TYPE.LOADING
+        | typeof PLAYGROUND_STATUS_TYPE.SUCCESS
+        | typeof PLAYGROUND_STATUS_TYPE.ERROR;
+      message: string;
+    };
+
+export const IDLE_PLAYGROUND_STATUS = {
+  type: PLAYGROUND_STATUS_TYPE.IDLE,
+} as const satisfies PlaygroundStatus;
+
+export const PLAYGROUND_STATUS_CLASS_NAME = "pg-status";
+
+export const PLAYGROUND_ERROR_STATUS_SELECTOR = `.${PLAYGROUND_STATUS_CLASS_NAME}[data-status="${PLAYGROUND_STATUS_TYPE.ERROR}"]`;

--- a/parity/__tests__/folioExtract.test.ts
+++ b/parity/__tests__/folioExtract.test.ts
@@ -14,12 +14,12 @@ import {
   parseCssFontFamilies,
   parseFirstFontFamily,
   parseInsetClipPath,
-  parseUnsupportedProjectionConsoleError,
   retryDetachedPageCapture,
   screenshotViewportHeight,
   toPageGeom,
 } from "../folioExtract";
 import type { RawLine, RawPage } from "../folioExtract";
+import { parseUnsupportedProjectionConsoleError } from "../editorReadiness";
 
 const rect = (left: number, top: number, width: number, height: number) => ({
   left,
@@ -106,8 +106,13 @@ describe("editor error capture", () => {
     ).toBe("UnsupportedDocxToProseMirrorConversionError: A nested break cannot be projected");
   });
 
-  test("ignores unrelated console output", () => {
-    expect(parseUnsupportedProjectionConsoleError("warning", "deprecated API")).toBeUndefined();
+  test("ignores non-error and unrelated console output", () => {
+    expect(
+      parseUnsupportedProjectionConsoleError(
+        "warning",
+        "UnsupportedDocxToProseMirrorConversionError: diagnostic only",
+      ),
+    ).toBeUndefined();
     expect(
       parseUnsupportedProjectionConsoleError("error", "failed to load favicon"),
     ).toBeUndefined();

--- a/parity/__tests__/folioExtract.test.ts
+++ b/parity/__tests__/folioExtract.test.ts
@@ -14,6 +14,7 @@ import {
   parseCssFontFamilies,
   parseFirstFontFamily,
   parseInsetClipPath,
+  parseUnsupportedProjectionConsoleError,
   retryDetachedPageCapture,
   screenshotViewportHeight,
   toPageGeom,
@@ -92,6 +93,24 @@ describe("detached page capture retry", () => {
       }),
     ).rejects.toThrow("page closed");
     expect(attempts).toBe(1);
+  });
+});
+
+describe("editor error capture", () => {
+  test("extracts an unsupported projection without its React stack", () => {
+    expect(
+      parseUnsupportedProjectionConsoleError(
+        "error",
+        "React caught UnsupportedDocxToProseMirrorConversionError: A nested break cannot be projected\n    at Editor",
+      ),
+    ).toBe("UnsupportedDocxToProseMirrorConversionError: A nested break cannot be projected");
+  });
+
+  test("ignores unrelated console output", () => {
+    expect(parseUnsupportedProjectionConsoleError("warning", "deprecated API")).toBeUndefined();
+    expect(
+      parseUnsupportedProjectionConsoleError("error", "failed to load favicon"),
+    ).toBeUndefined();
   });
 });
 

--- a/parity/editorReadiness.ts
+++ b/parity/editorReadiness.ts
@@ -1,0 +1,35 @@
+const UNSUPPORTED_PROJECTION_ERROR_NAME = "UnsupportedDocxToProseMirrorConversionError";
+
+export const parseUnsupportedProjectionConsoleError = (
+  type: string,
+  text: string,
+): string | undefined => {
+  if (type !== "error") {
+    return undefined;
+  }
+  const markerIndex = text.indexOf(UNSUPPORTED_PROJECTION_ERROR_NAME);
+  if (markerIndex < 0) {
+    return undefined;
+  }
+  return text.slice(markerIndex).split("\n", 1).at(0)?.trim();
+};
+
+type EditorReadinessProbeOptions = {
+  playgroundErrorSelector: string;
+  readySelector: string;
+};
+
+export const readEditorReadinessState = ({
+  playgroundErrorSelector,
+  readySelector,
+}: EditorReadinessProbeOptions) => {
+  const loadError = document.querySelector(".folio-editor-error p")?.textContent?.trim();
+  if (loadError) {
+    return { type: "error" as const, message: loadError };
+  }
+  const playgroundError = document.querySelector(playgroundErrorSelector)?.textContent?.trim();
+  if (playgroundError) {
+    return { type: "error" as const, message: playgroundError };
+  }
+  return document.querySelector(readySelector) ? { type: "ready" as const } : null;
+};

--- a/parity/folioExtract.ts
+++ b/parity/folioExtract.ts
@@ -153,10 +153,25 @@ const STABILITY_POLL_INTERVAL_MS = 250;
 const STABILITY_MAX_MS = 15_000;
 const STABILITY_SETTLE_MS = 250;
 const PAGE_CAPTURE_MAX_ATTEMPTS = 3;
+const UNSUPPORTED_PROJECTION_ERROR_NAME = "UnsupportedDocxToProseMirrorConversionError";
 
 const CHROMIUM_MISSING_MARKER = "Executable doesn't exist";
 const CHROMIUM_MISSING_MESSAGE =
   "Playwright chromium missing; run: bunx playwright install chromium";
+
+export const parseUnsupportedProjectionConsoleError = (
+  type: string,
+  text: string,
+): string | undefined => {
+  if (type !== "error") {
+    return undefined;
+  }
+  const markerIndex = text.indexOf(UNSUPPORTED_PROJECTION_ERROR_NAME);
+  if (markerIndex < 0) {
+    return undefined;
+  }
+  return text.slice(markerIndex).split("\n", 1)[0]?.trim() || UNSUPPORTED_PROJECTION_ERROR_NAME;
+};
 
 const FONT_MIME_BY_EXTENSION = {
   ".otf": "font/otf",
@@ -631,22 +646,89 @@ const waitForLayoutStability = async (page: Page): Promise<void> => {
   }
 };
 
-const waitForEditorLayout = async (page: Page): Promise<void> => {
-  try {
-    await page.waitForSelector(EDITOR_SELECTOR, { timeout: EDITOR_RENDER_TIMEOUT_MS });
-  } catch {
-    throw new FolioExtractError(
-      `folio editor root (${EDITOR_SELECTOR}) never rendered within ${EDITOR_RENDER_TIMEOUT_MS}ms`,
-    );
-  }
+type EditorErrorMonitor = {
+  capture: (message: string) => void;
+  reset: () => void;
+  wait: () => Promise<string>;
+};
 
+const createEditorErrorMonitor = (): EditorErrorMonitor => {
+  let resolveError: ((message: string) => void) | undefined;
+  let error = new Promise<string>((resolve) => {
+    resolveError = resolve;
+  });
+  return {
+    capture: (message) => resolveError?.(message),
+    reset: () => {
+      error = new Promise<string>((resolve) => {
+        resolveError = resolve;
+      });
+    },
+    wait: () => error,
+  };
+};
+
+const EDITOR_READY_STATE = "ready";
+const EDITOR_ERROR_STATE_PREFIX = "error:";
+
+const waitForSelectorOrEditorError = async (
+  page: Page,
+  selector: string,
+  timeoutMessage: string,
+  errorMonitor: EditorErrorMonitor,
+): Promise<void> => {
   try {
-    await page.waitForSelector(PAGE_SELECTOR, { timeout: EDITOR_RENDER_TIMEOUT_MS });
-  } catch {
-    throw new FolioExtractError(
-      `folio never painted a ${PAGE_SELECTOR} element within ${EDITOR_RENDER_TIMEOUT_MS}ms`,
-    );
+    const browserState = page
+      .waitForFunction(
+        ({ errorPrefix, readySelector, readyState }) => {
+          const loadError = document.querySelector(".folio-editor-error p")?.textContent?.trim();
+          if (loadError) {
+            return `${errorPrefix}${loadError}`;
+          }
+          const playgroundStatus = document.querySelector(".pg-status")?.textContent?.trim();
+          if (playgroundStatus?.startsWith("Error:")) {
+            return `${errorPrefix}${playgroundStatus.slice("Error:".length).trim()}`;
+          }
+          return document.querySelector(readySelector) ? readyState : null;
+        },
+        {
+          errorPrefix: EDITOR_ERROR_STATE_PREFIX,
+          readySelector: selector,
+          readyState: EDITOR_READY_STATE,
+        },
+        { timeout: EDITOR_RENDER_TIMEOUT_MS },
+      )
+      .then((handle) => handle.jsonValue());
+    const state = await Promise.race([
+      browserState,
+      errorMonitor.wait().then((message) => `${EDITOR_ERROR_STATE_PREFIX}${message}`),
+    ]);
+    if (state?.startsWith(EDITOR_ERROR_STATE_PREFIX)) {
+      throw new FolioExtractError(
+        `folio editor failed: ${state.slice(EDITOR_ERROR_STATE_PREFIX.length)}`,
+      );
+    }
+  } catch (error) {
+    if (error instanceof FolioExtractError) {
+      throw error;
+    }
+    throw new FolioExtractError(timeoutMessage);
   }
+};
+
+const waitForEditorLayout = async (page: Page, errorMonitor: EditorErrorMonitor): Promise<void> => {
+  await waitForSelectorOrEditorError(
+    page,
+    EDITOR_SELECTOR,
+    `folio editor root (${EDITOR_SELECTOR}) never rendered within ${EDITOR_RENDER_TIMEOUT_MS}ms`,
+    errorMonitor,
+  );
+  await waitForSelectorOrEditorError(
+    page,
+    PAGE_SELECTOR,
+    `folio never painted a ${PAGE_SELECTOR} element within ${EDITOR_RENDER_TIMEOUT_MS}ms`,
+    errorMonitor,
+  );
 
   await page.evaluate(() => document.fonts.ready);
   await waitForLayoutStability(page);
@@ -1359,6 +1441,16 @@ export const createFolioExtractor = async (
     colorScheme: "light",
   });
   const page = await context.newPage();
+  const editorErrorMonitor = createEditorErrorMonitor();
+  page.on("pageerror", (error) => {
+    editorErrorMonitor.capture(`${error.name}: ${error.message}`);
+  });
+  page.on("console", (message) => {
+    const error = parseUnsupportedProjectionConsoleError(message.type(), message.text());
+    if (error !== undefined) {
+      editorErrorMonitor.capture(error);
+    }
+  });
   const routedFonts = await loadBrowserFonts(opts.localFonts);
   if (routedFonts.length > 0) {
     for (const { definition, body, contentType } of routedFonts) {
@@ -1376,6 +1468,7 @@ export const createFolioExtractor = async (
   }
 
   const navigateToDocument = async (stagedName: string): Promise<void> => {
+    editorErrorMonitor.reset();
     const documentUrl = `${PLAYGROUND_URL}/?file=${encodeURIComponent(stagedName)}`;
     try {
       await page.goto(documentUrl, {
@@ -1403,7 +1496,7 @@ export const createFolioExtractor = async (
     await fs.copyFile(absoluteDocxPath, stagedPath);
     try {
       await navigateToDocument(stagedName);
-      await waitForEditorLayout(page);
+      await waitForEditorLayout(page, editorErrorMonitor);
 
       const pageMeta = await listPageMeta(page);
       if (pageMeta.length === 0) {
@@ -1479,7 +1572,7 @@ export const createFolioExtractor = async (
     await fs.copyFile(absoluteDocxPath, stagedPath);
     try {
       await navigateToDocument(stagedName);
-      await waitForEditorLayout(page);
+      await waitForEditorLayout(page, editorErrorMonitor);
 
       const pageMeta = await listPageMeta(page);
       const target = pageMeta.find((meta) => meta.pageNumber === pageNumber);

--- a/parity/folioExtract.ts
+++ b/parity/folioExtract.ts
@@ -19,6 +19,8 @@ import path from "node:path";
 
 import { chromium, type Browser, type BrowserContext, type Page } from "@playwright/test";
 
+import { PLAYGROUND_ERROR_STATUS_SELECTOR } from "../packages/playground/src/playgroundStatus";
+
 import {
   CACHE_DIR,
   FIXTURES_DIR,
@@ -29,6 +31,10 @@ import {
   REPO_ROOT,
   TMP_FIXTURE_PREFIX,
 } from "./config";
+import {
+  parseUnsupportedProjectionConsoleError,
+  readEditorReadinessState,
+} from "./editorReadiness";
 import { normalizeLineText } from "./textNorm";
 import { firstStrongTextDirection } from "./textDirection";
 import type { DocGeom, LineBox, PageGeom, Region } from "./types";
@@ -153,25 +159,9 @@ const STABILITY_POLL_INTERVAL_MS = 250;
 const STABILITY_MAX_MS = 15_000;
 const STABILITY_SETTLE_MS = 250;
 const PAGE_CAPTURE_MAX_ATTEMPTS = 3;
-const UNSUPPORTED_PROJECTION_ERROR_NAME = "UnsupportedDocxToProseMirrorConversionError";
-
 const CHROMIUM_MISSING_MARKER = "Executable doesn't exist";
 const CHROMIUM_MISSING_MESSAGE =
   "Playwright chromium missing; run: bunx playwright install chromium";
-
-export const parseUnsupportedProjectionConsoleError = (
-  type: string,
-  text: string,
-): string | undefined => {
-  if (type !== "error") {
-    return undefined;
-  }
-  const markerIndex = text.indexOf(UNSUPPORTED_PROJECTION_ERROR_NAME);
-  if (markerIndex < 0) {
-    return undefined;
-  }
-  return text.slice(markerIndex).split("\n", 1)[0]?.trim() || UNSUPPORTED_PROJECTION_ERROR_NAME;
-};
 
 const FONT_MIME_BY_EXTENSION = {
   ".otf": "font/otf",
@@ -668,9 +658,6 @@ const createEditorErrorMonitor = (): EditorErrorMonitor => {
   };
 };
 
-const EDITOR_READY_STATE = "ready";
-const EDITOR_ERROR_STATE_PREFIX = "error:";
-
 const waitForSelectorOrEditorError = async (
   page: Page,
   selector: string,
@@ -680,33 +667,20 @@ const waitForSelectorOrEditorError = async (
   try {
     const browserState = page
       .waitForFunction(
-        ({ errorPrefix, readySelector, readyState }) => {
-          const loadError = document.querySelector(".folio-editor-error p")?.textContent?.trim();
-          if (loadError) {
-            return `${errorPrefix}${loadError}`;
-          }
-          const playgroundStatus = document.querySelector(".pg-status")?.textContent?.trim();
-          if (playgroundStatus?.startsWith("Error:")) {
-            return `${errorPrefix}${playgroundStatus.slice("Error:".length).trim()}`;
-          }
-          return document.querySelector(readySelector) ? readyState : null;
-        },
+        readEditorReadinessState,
         {
-          errorPrefix: EDITOR_ERROR_STATE_PREFIX,
+          playgroundErrorSelector: PLAYGROUND_ERROR_STATUS_SELECTOR,
           readySelector: selector,
-          readyState: EDITOR_READY_STATE,
         },
         { timeout: EDITOR_RENDER_TIMEOUT_MS },
       )
       .then((handle) => handle.jsonValue());
     const state = await Promise.race([
       browserState,
-      errorMonitor.wait().then((message) => `${EDITOR_ERROR_STATE_PREFIX}${message}`),
+      errorMonitor.wait().then((message) => ({ type: "error" as const, message })),
     ]);
-    if (state?.startsWith(EDITOR_ERROR_STATE_PREFIX)) {
-      throw new FolioExtractError(
-        `folio editor failed: ${state.slice(EDITOR_ERROR_STATE_PREFIX.length)}`,
-      );
+    if (state?.type === "error") {
+      throw new FolioExtractError(`folio editor failed: ${state.message}`);
     }
   } catch (error) {
     if (error instanceof FolioExtractError) {

--- a/tests/visual/interactions.spec.ts
+++ b/tests/visual/interactions.spec.ts
@@ -15,7 +15,9 @@
 import { expect, test } from "@playwright/test";
 import type { Locator, Page } from "@playwright/test";
 
+import { PLAYGROUND_ERROR_STATUS_SELECTOR } from "../../packages/playground/src/playgroundStatus";
 import type { DocxEditorRef } from "../../packages/react/src/components/DocxEditor.props";
+import { readEditorReadinessState } from "../../parity/editorReadiness";
 
 declare global {
   var __folioPlayground: { getEditorRef: () => DocxEditorRef | null } | undefined;
@@ -97,6 +99,22 @@ test("showcase document loads from the recording URL and playground control", as
   await page.getByRole("button", { name: "Showcase", exact: true }).click();
   await expect(page.locator(".pg-filename")).toHaveText("folio-showcase.docx");
   await expect(page.getByRole("status")).toHaveText("1 of 5");
+});
+
+test("fixture load failures expose a machine-readable error state", async ({ page }) => {
+  await page.goto("/?file=missing-parity-fixture.docx");
+
+  await expect(page.locator(PLAYGROUND_ERROR_STATUS_SELECTOR)).toHaveText(
+    "Fixture not found: missing-parity-fixture.docx",
+  );
+  const readiness = await page.evaluate(readEditorReadinessState, {
+    playgroundErrorSelector: PLAYGROUND_ERROR_STATUS_SELECTOR,
+    readySelector: ".layout-page",
+  });
+  expect(readiness).toEqual({
+    type: "error",
+    message: "Fixture not found: missing-parity-fixture.docx",
+  });
 });
 
 /** Place the caret inside the first painted table cell and open its menu. */


### PR DESCRIPTION
## Summary

- race editor readiness against document-scoped browser failures
- surface load-state and playground error messages before the paint timeout
- encode playground status as a discriminated state with a shared machine-readable error marker
- retain filtering for unrelated console noise while recognizing unsupported projection errors

## Validation

- `bun test parity/__tests__/folioExtract.test.ts`
- focused interaction test for missing-fixture error classification
- exact-head CI
- consumer-backed parity run: unsupported projection reported in under 10 seconds