### PR TITLE
refactor(core): make paragraph property state explicit

### DIFF
--- a/.changeset/model-text-formatting-descriptors.md
+++ b/.changeset/model-text-formatting-descriptors.md
@@ -1,0 +1,5 @@
+---
+"@stll/docx-core": minor
+---
+
+Export total runtime descriptors and value domains for modeled text formatting, colors, and shading so validation, comparison, and projection share one property taxonomy.

--- a/api-reports/docx-core/model.api.md
+++ b/api-reports/docx-core/model.api.md
@@ -14,6 +14,9 @@ export type AbstractNumbering = {
     name?: string;
 };
 
+// @public (undocumented)
+export const ASCII_THEME_FONTS: readonly ["majorAscii", "majorHAnsi", "majorEastAsia", "majorBidi", "minorAscii", "minorHAnsi", "minorEastAsia", "minorBidi"];
+
 // @public
 export type BlockContent = Paragraph | Table | BlockSdt;
 
@@ -67,6 +70,30 @@ export type CellMargins = {
     bottom?: TableMeasurement;
     left?: TableMeasurement;
     right?: TableMeasurement;
+};
+
+// @public (undocumented)
+export const COLOR_VALUE_PROPERTY_DESCRIPTORS: {
+    readonly rgb: {
+        readonly field: "rgb";
+        readonly validation: "hex";
+    };
+    readonly themeColor: {
+        readonly field: "themeColor";
+        readonly validation: "theme-color";
+    };
+    readonly themeTint: {
+        readonly field: "themeTint";
+        readonly validation: "hex";
+    };
+    readonly themeShade: {
+        readonly field: "themeShade";
+        readonly validation: "hex";
+    };
+    readonly auto: {
+        readonly field: "auto";
+        readonly validation: "boolean";
+    };
 };
 
 // @public
@@ -263,7 +290,10 @@ export type DrawingContent = {
 export type DrawingRawXmlMode = (typeof DRAWING_RAW_XML_MODES)[keyof typeof DRAWING_RAW_XML_MODES];
 
 // @public
-export type EmphasisMark = "none" | "dot" | "comma" | "circle" | "underDot";
+export const EMPHASIS_MARKS: readonly ["none", "dot", "comma", "circle", "underDot"];
+
+// @public (undocumented)
+export type EmphasisMark = (typeof EMPHASIS_MARKS)[number];
 
 // @public
 export type Endnote = {
@@ -312,6 +342,9 @@ export type FloatingTableProperties = {
     leftFromText?: number;
     rightFromText?: number;
 };
+
+// @public (undocumented)
+export const FONT_HINTS: readonly ["default", "eastAsia", "cs"];
 
 // @public
 export type FontInfo = {
@@ -383,6 +416,9 @@ export type HeaderReference = {
     type: HeaderFooterType;
     rId: string;
 };
+
+// @public (undocumented)
+export const HIGHLIGHT_COLORS: readonly ["black", "blue", "cyan", "darkBlue", "darkCyan", "darkGray", "darkGreen", "darkMagenta", "darkRed", "darkYellow", "green", "lightGray", "magenta", "none", "red", "white", "yellow"];
 
 // @public
 export type Hyperlink = {
@@ -938,10 +974,29 @@ export type SectionPropertyChange = {
 export type SectionStart = "continuous" | "nextPage" | "oddPage" | "evenPage" | "nextColumn";
 
 // @public
+export const SHADING_PATTERNS: readonly ["clear", "solid", "horzStripe", "vertStripe", "reverseDiagStripe", "diagStripe", "horzCross", "diagCross", "thinHorzStripe", "thinVertStripe", "thinReverseDiagStripe", "thinDiagStripe", "thinHorzCross", "thinDiagCross", "pct5", "pct10", "pct12", "pct15", "pct20", "pct25", "pct30", "pct35", "pct37", "pct40", "pct45", "pct50", "pct55", "pct60", "pct62", "pct65", "pct70", "pct75", "pct80", "pct85", "pct87", "pct90", "pct95", "nil"];
+
+// @public (undocumented)
+export const SHADING_PROPERTY_DESCRIPTORS: {
+    readonly color: {
+        readonly field: "color";
+        readonly validation: "color";
+    };
+    readonly fill: {
+        readonly field: "fill";
+        readonly validation: "color";
+    };
+    readonly pattern: {
+        readonly field: "pattern";
+        readonly validation: "pattern";
+    };
+};
+
+// @public (undocumented)
 export type ShadingProperties = {
     color?: ColorValue;
     fill?: ColorValue;
-    pattern?: "clear" | "solid" | "horzStripe" | "vertStripe" | "reverseDiagStripe" | "diagStripe" | "horzCross" | "diagCross" | "thinHorzStripe" | "thinVertStripe" | "thinReverseDiagStripe" | "thinDiagStripe" | "thinHorzCross" | "thinDiagCross" | "pct5" | "pct10" | "pct12" | "pct15" | "pct20" | "pct25" | "pct30" | "pct35" | "pct37" | "pct40" | "pct45" | "pct50" | "pct55" | "pct60" | "pct62" | "pct65" | "pct70" | "pct75" | "pct80" | "pct85" | "pct87" | "pct90" | "pct95" | "nil";
+    pattern?: (typeof SHADING_PATTERNS)[number];
 };
 
 // @public
@@ -1272,6 +1327,298 @@ export type TabStop = {
 export type TabStopAlignment = "left" | "center" | "right" | "decimal" | "bar" | "clear" | "num";
 
 // @public
+export const TEXT_EFFECTS: readonly ["none", "blinkBackground", "lights", "antsBlack", "antsRed", "shimmer", "sparkle"];
+
+// @public (undocumented)
+export const TEXT_FORMATTING_FONT_FAMILY_FIELD_DESCRIPTORS: {
+    readonly ascii: {
+        readonly field: "ascii";
+        readonly validation: "string";
+    };
+    readonly hAnsi: {
+        readonly field: "hAnsi";
+        readonly validation: "string";
+    };
+    readonly eastAsia: {
+        readonly field: "eastAsia";
+        readonly validation: "string";
+    };
+    readonly cs: {
+        readonly field: "cs";
+        readonly validation: "string";
+    };
+    readonly hint: {
+        readonly field: "hint";
+        readonly validation: "font-hint";
+    };
+    readonly asciiTheme: {
+        readonly field: "asciiTheme";
+        readonly validation: "ascii-theme";
+    };
+    readonly hAnsiTheme: {
+        readonly field: "hAnsiTheme";
+        readonly validation: "string";
+    };
+    readonly eastAsiaTheme: {
+        readonly field: "eastAsiaTheme";
+        readonly validation: "string";
+    };
+    readonly csTheme: {
+        readonly field: "csTheme";
+        readonly validation: "string";
+    };
+};
+
+// @public (undocumented)
+export const TEXT_FORMATTING_LANGUAGE_FIELD_DESCRIPTORS: {
+    readonly val: {
+        readonly field: "val";
+        readonly validation: "string";
+    };
+    readonly eastAsia: {
+        readonly field: "eastAsia";
+        readonly validation: "string";
+    };
+    readonly bidi: {
+        readonly field: "bidi";
+        readonly validation: "string";
+    };
+};
+
+// @public
+export const TEXT_FORMATTING_PROPERTY_DESCRIPTORS: {
+    readonly bold: {
+        readonly field: "bold";
+        readonly comparison: "exact";
+        readonly validation: "boolean";
+        readonly visualGroup: "bold";
+        readonly fastPath: "visual";
+    };
+    readonly boldCs: {
+        readonly field: "boldCs";
+        readonly comparison: "exact";
+        readonly validation: "boolean";
+        readonly visualGroup: null;
+        readonly fastPath: "structural";
+    };
+    readonly italic: {
+        readonly field: "italic";
+        readonly comparison: "exact";
+        readonly validation: "boolean";
+        readonly visualGroup: "italic";
+        readonly fastPath: "visual";
+    };
+    readonly italicCs: {
+        readonly field: "italicCs";
+        readonly comparison: "exact";
+        readonly validation: "boolean";
+        readonly visualGroup: null;
+        readonly fastPath: "structural";
+    };
+    readonly underline: {
+        readonly field: "underline";
+        readonly comparison: "exact";
+        readonly validation: "underline";
+        readonly visualGroup: "underline";
+        readonly fastPath: "visual";
+    };
+    readonly strike: {
+        readonly field: "strike";
+        readonly comparison: "exact";
+        readonly validation: "boolean";
+        readonly visualGroup: "strike";
+        readonly fastPath: "visual";
+    };
+    readonly doubleStrike: {
+        readonly field: "doubleStrike";
+        readonly comparison: "exact";
+        readonly validation: "boolean";
+        readonly visualGroup: "strike";
+        readonly fastPath: "visual";
+    };
+    readonly vertAlign: {
+        readonly field: "vertAlign";
+        readonly comparison: "exact";
+        readonly validation: "vertical-alignment";
+        readonly visualGroup: "vertAlign";
+        readonly fastPath: "visual";
+    };
+    readonly smallCaps: {
+        readonly field: "smallCaps";
+        readonly comparison: "exact";
+        readonly validation: "boolean";
+        readonly visualGroup: "smallCaps";
+        readonly fastPath: "visual";
+    };
+    readonly allCaps: {
+        readonly field: "allCaps";
+        readonly comparison: "exact";
+        readonly validation: "boolean";
+        readonly visualGroup: "allCaps";
+        readonly fastPath: "visual";
+    };
+    readonly hidden: {
+        readonly field: "hidden";
+        readonly comparison: "exact";
+        readonly validation: "boolean";
+        readonly visualGroup: "hidden";
+        readonly fastPath: "visual";
+    };
+    readonly color: {
+        readonly field: "color";
+        readonly comparison: "exact";
+        readonly validation: "color";
+        readonly visualGroup: "color";
+        readonly fastPath: "visual";
+    };
+    readonly highlight: {
+        readonly field: "highlight";
+        readonly comparison: "exact";
+        readonly validation: "highlight";
+        readonly visualGroup: "highlight";
+        readonly fastPath: "visual";
+    };
+    readonly shading: {
+        readonly field: "shading";
+        readonly comparison: "exact";
+        readonly validation: "shading";
+        readonly visualGroup: "shading";
+        readonly fastPath: "visual";
+    };
+    readonly fontSize: {
+        readonly field: "fontSize";
+        readonly comparison: "exact";
+        readonly validation: "nonnegative-number";
+        readonly visualGroup: "fontSize";
+        readonly fastPath: "visual";
+    };
+    readonly fontSizeCs: {
+        readonly field: "fontSizeCs";
+        readonly comparison: "exact";
+        readonly validation: "nonnegative-number";
+        readonly visualGroup: null;
+        readonly fastPath: "structural";
+    };
+    readonly fontFamily: {
+        readonly field: "fontFamily";
+        readonly comparison: "exact";
+        readonly validation: "font-family";
+        readonly visualGroup: "fontFamily";
+        readonly fastPath: "visual";
+    };
+    readonly language: {
+        readonly field: "language";
+        readonly comparison: "exact";
+        readonly validation: "language";
+        readonly visualGroup: "language";
+        readonly fastPath: "visual";
+    };
+    readonly spacing: {
+        readonly field: "spacing";
+        readonly comparison: "exact";
+        readonly validation: "finite-number";
+        readonly visualGroup: "characterSpacing";
+        readonly fastPath: "visual";
+    };
+    readonly position: {
+        readonly field: "position";
+        readonly comparison: "exact";
+        readonly validation: "finite-number";
+        readonly visualGroup: "characterSpacing";
+        readonly fastPath: "visual";
+    };
+    readonly scale: {
+        readonly field: "scale";
+        readonly comparison: "exact";
+        readonly validation: "finite-number";
+        readonly visualGroup: "characterSpacing";
+        readonly fastPath: "visual";
+    };
+    readonly kerning: {
+        readonly field: "kerning";
+        readonly comparison: "exact";
+        readonly validation: "nonnegative-number";
+        readonly visualGroup: "characterSpacing";
+        readonly fastPath: "visual";
+    };
+    readonly effect: {
+        readonly field: "effect";
+        readonly comparison: "exact";
+        readonly validation: "effect";
+        readonly visualGroup: "effect";
+        readonly fastPath: "visual";
+    };
+    readonly emphasisMark: {
+        readonly field: "emphasisMark";
+        readonly comparison: "exact";
+        readonly validation: "emphasis";
+        readonly visualGroup: "emphasisMark";
+        readonly fastPath: "visual";
+    };
+    readonly emboss: {
+        readonly field: "emboss";
+        readonly comparison: "exact";
+        readonly validation: "boolean";
+        readonly visualGroup: "emboss";
+        readonly fastPath: "visual";
+    };
+    readonly imprint: {
+        readonly field: "imprint";
+        readonly comparison: "exact";
+        readonly validation: "boolean";
+        readonly visualGroup: "imprint";
+        readonly fastPath: "visual";
+    };
+    readonly outline: {
+        readonly field: "outline";
+        readonly comparison: "exact";
+        readonly validation: "boolean";
+        readonly visualGroup: "outline";
+        readonly fastPath: "visual";
+    };
+    readonly shadow: {
+        readonly field: "shadow";
+        readonly comparison: "exact";
+        readonly validation: "boolean";
+        readonly visualGroup: "shadow";
+        readonly fastPath: "visual";
+    };
+    readonly rtl: {
+        readonly field: "rtl";
+        readonly comparison: "exact";
+        readonly validation: "boolean";
+        readonly visualGroup: "rtl";
+        readonly fastPath: "visual";
+    };
+    readonly cs: {
+        readonly field: "cs";
+        readonly comparison: "exact";
+        readonly validation: "boolean";
+        readonly visualGroup: null;
+        readonly fastPath: "structural";
+    };
+    readonly styleId: {
+        readonly field: "styleId";
+        readonly comparison: "exact";
+        readonly validation: "string";
+        readonly visualGroup: null;
+        readonly fastPath: "character-style";
+    };
+};
+
+// @public (undocumented)
+export const TEXT_FORMATTING_UNDERLINE_FIELD_DESCRIPTORS: {
+    readonly style: {
+        readonly field: "style";
+        readonly validation: "underline-style";
+    };
+    readonly color: {
+        readonly field: "color";
+        readonly validation: "color";
+    };
+};
+
+// @public
 export type TextBox = {
     type: "textBox";
     id?: string;
@@ -1300,8 +1647,8 @@ export type TextContent = {
     preserveSpace?: boolean;
 };
 
-// @public
-export type TextEffect = "none" | "blinkBackground" | "lights" | "antsBlack" | "antsRed" | "shimmer" | "sparkle";
+// @public (undocumented)
+export type TextEffect = (typeof TEXT_EFFECTS)[number];
 
 // @public
 export type TextFormatting = {
@@ -1315,12 +1662,12 @@ export type TextFormatting = {
     };
     strike?: boolean;
     doubleStrike?: boolean;
-    vertAlign?: "baseline" | "superscript" | "subscript";
+    vertAlign?: (typeof VERTICAL_ALIGNMENTS)[number];
     smallCaps?: boolean;
     allCaps?: boolean;
     hidden?: boolean;
     color?: ColorValue;
-    highlight?: "black" | "blue" | "cyan" | "darkBlue" | "darkCyan" | "darkGray" | "darkGreen" | "darkMagenta" | "darkRed" | "darkYellow" | "green" | "lightGray" | "magenta" | "none" | "red" | "white" | "yellow";
+    highlight?: (typeof HIGHLIGHT_COLORS)[number];
     shading?: ShadingProperties;
     fontSize?: number;
     fontSizeCs?: number;
@@ -1329,8 +1676,8 @@ export type TextFormatting = {
         hAnsi?: string;
         eastAsia?: string;
         cs?: string;
-        hint?: "default" | "eastAsia" | "cs";
-        asciiTheme?: "majorAscii" | "majorHAnsi" | "majorEastAsia" | "majorBidi" | "minorAscii" | "minorHAnsi" | "minorEastAsia" | "minorBidi";
+        hint?: (typeof FONT_HINTS)[number];
+        asciiTheme?: (typeof ASCII_THEME_FONTS)[number];
         hAnsiTheme?: string;
         eastAsiaTheme?: string;
         csTheme?: string;
@@ -1376,6 +1723,9 @@ export type Theme = {
 };
 
 // @public
+export const THEME_COLOR_SLOTS: readonly ["dk1", "lt1", "dk2", "lt2", "accent1", "accent2", "accent3", "accent4", "accent5", "accent6", "hlink", "folHlink", "background1", "text1", "background2", "text2"];
+
+// @public
 export type ThemeColorScheme = {
     dk1?: string;
     lt1?: string;
@@ -1391,8 +1741,8 @@ export type ThemeColorScheme = {
     folHlink?: string;
 };
 
-// @public
-export type ThemeColorSlot = "dk1" | "lt1" | "dk2" | "lt2" | "accent1" | "accent2" | "accent3" | "accent4" | "accent5" | "accent6" | "hlink" | "folHlink" | "background1" | "text1" | "background2" | "text2";
+// @public (undocumented)
+export type ThemeColorSlot = (typeof THEME_COLOR_SLOTS)[number];
 
 // @public
 export type ThemeFont = {
@@ -1427,7 +1777,13 @@ export type TrackedRunChange = Insertion | Deletion | MoveFrom | MoveTo;
 export type TrackedRunContent = Run | Hyperlink | BookmarkStart | BookmarkEnd | SimpleField | ComplexField | TrackedRunChange;
 
 // @public
-export type UnderlineStyle = "none" | "single" | "words" | "double" | "thick" | "dotted" | "dottedHeavy" | "dash" | "dashedHeavy" | "dashLong" | "dashLongHeavy" | "dotDash" | "dashDotHeavy" | "dotDotDash" | "dashDotDotHeavy" | "wave" | "wavyHeavy" | "wavyDouble";
+export const UNDERLINE_STYLES: readonly ["none", "single", "words", "double", "thick", "dotted", "dottedHeavy", "dash", "dashedHeavy", "dashLong", "dashLongHeavy", "dotDash", "dashDotHeavy", "dotDotDash", "dashDotDotHeavy", "wave", "wavyHeavy", "wavyDouble"];
+
+// @public (undocumented)
+export type UnderlineStyle = (typeof UNDERLINE_STYLES)[number];
+
+// @public (undocumented)
+export const VERTICAL_ALIGNMENTS: readonly ["baseline", "superscript", "subscript"];
 
 // @public
 export type VerticalAlign = "top" | "center" | "both" | "bottom";

--- a/packages/core/src/ai-edits/headless.ts
+++ b/packages/core/src/ai-edits/headless.ts
@@ -75,10 +75,7 @@ import type {
   NumberingDefinitions,
 } from "../types/document";
 import { deterministicHexId } from "../utils/hexId";
-import {
-  recreateProseNodeWithParagraphPropertySource,
-  transferProseParagraphPropertySource,
-} from "../docx/paragraphPropertySource";
+import { recreateProseNode } from "../prosemirror/recreateNode";
 import {
   applyFolioDocumentOperations,
   FOLIO_DOCUMENT_OPERATION_CONTRACT_VERSION,
@@ -196,18 +193,17 @@ const ensureDeterministicParaIdsInDoc = (doc: PMNode): PMNode => {
             paraId = deterministicHexId(`${child.textContent}:${ordinal}:${salt}`);
           }
           seen.add(paraId);
-          next = recreateProseNodeWithParagraphPropertySource(child, {
+          next = recreateProseNode(child, {
             attrs: { ...child.attrs, paraId, idStability: "positional" },
           });
         }
         const paraId = next.attrs["paraId"];
         if (typeof paraId === "string") {
-          transferProseParagraphPropertySource(next, child, paraId);
         }
       } else if (child.childCount > 0) {
         const content = rewrite(child);
         if (content !== child.content) {
-          next = recreateProseNodeWithParagraphPropertySource(child, { content });
+          next = recreateProseNode(child, { content });
         }
       }
       if (next !== child) {
@@ -222,7 +218,7 @@ const ensureDeterministicParaIdsInDoc = (doc: PMNode): PMNode => {
   const content = rewrite(doc);
   return content === doc.content
     ? doc
-    : recreateProseNodeWithParagraphPropertySource(doc, { content });
+    : recreateProseNode(doc, { content });
 };
 
 /** Options for {@link FolioDocxReviewer.fromBuffer}. */

--- a/packages/core/src/docx/numberingProvenance.ts
+++ b/packages/core/src/docx/numberingProvenance.ts
@@ -1,0 +1,251 @@
+import {
+  isNonEmptyNumberingLevelIndentGeometry,
+  type NumberingIdentity,
+  type NumberingLevelIndentGeometry,
+} from "@stll/docx-core/model";
+import { panic } from "better-result";
+
+import type { ParagraphFormatting, ParagraphPropertyChange } from "../types/document";
+
+export type NumberingIdRemapper =
+  | ReadonlyMap<number, number>
+  | ((numId: number) => number | undefined);
+
+const remappedNumId = (remapper: NumberingIdRemapper, numId: number): number | undefined =>
+  typeof remapper === "function" ? remapper(numId) : remapper.get(numId);
+
+type NumberingLevelIndentProvenanceInput = {
+  numId: number;
+  ilvl: number;
+  baseline: NumberingLevelIndentGeometry;
+  owned?: NumberingLevelIndentGeometry;
+};
+
+/** Construct the only valid numbering-indent provenance branches. */
+export const createNumberingLevelIndentProvenance = ({
+  numId,
+  ilvl,
+  baseline,
+  owned,
+}: NumberingLevelIndentProvenanceInput): ParagraphFormatting["numberingLevelIndent"] => {
+  if (!isNonEmptyNumberingLevelIndentGeometry(baseline)) {
+    return undefined;
+  }
+  if (!isNonEmptyNumberingLevelIndentGeometry(owned)) {
+    return { type: "latent", numId, ilvl, baseline };
+  }
+  for (const key of [
+    "indentLeft",
+    "indentRight",
+    "indentFirstLine",
+    "hangingIndent",
+  ] as const) {
+    if (owned[key] !== undefined && owned[key] !== baseline[key]) {
+      panic("Numbering-owned indentation must match its level baseline.");
+    }
+  }
+  return { type: "owned", numId, ilvl, baseline, owned };
+};
+
+/** Remap every numbering identity carried by one paragraph-formatting snapshot. */
+export const remapParagraphFormattingNumbering = (
+  formatting: ParagraphFormatting | undefined,
+  numIdRemap: NumberingIdRemapper,
+): ParagraphFormatting | undefined => {
+  if (!formatting) {
+    return undefined;
+  }
+
+  let next = formatting;
+  const sourceNumIds = new Set(
+    [
+      formatting.numPr,
+      formatting.numPrFromStyle,
+      formatting.numberingLevelIndent,
+    ]
+      .map((identity) => identity?.numId)
+      .filter((numId): numId is number => numId !== undefined && numId !== 0),
+  );
+  for (const numId of sourceNumIds) {
+    if (remappedNumId(numIdRemap, numId) === undefined) {
+      next = dropParagraphNumberingReference(next, numId);
+    }
+  }
+
+  const remapIdentity = <T extends NumberingIdentity>(identity: T | undefined): T | undefined => {
+    const numId = identity?.numId;
+    if (numId === undefined || numId === 0) {
+      return identity;
+    }
+    const remapped = remappedNumId(numIdRemap, numId);
+    return remapped === undefined || remapped === numId
+      ? identity
+      : { ...identity, numId: remapped };
+  };
+  const numPr = remapIdentity(next.numPr);
+  const numPrFromStyle = remapIdentity(next.numPrFromStyle);
+  const numberingLevelIndent = remapIdentity(next.numberingLevelIndent);
+  if (
+    numPr === next.numPr &&
+    numPrFromStyle === next.numPrFromStyle &&
+    numberingLevelIndent === next.numberingLevelIndent
+  ) {
+    return next;
+  }
+  const remapped = { ...next };
+  const assignIdentity = <
+    K extends "numPr" | "numPrFromStyle" | "numberingLevelIndent",
+  >(
+    key: K,
+    identity: ParagraphFormatting[K],
+  ): void => {
+    if (identity === undefined) {
+      Reflect.deleteProperty(remapped, key);
+      return;
+    }
+    Object.assign(remapped, { [key]: identity });
+  };
+  assignIdentity("numPr", numPr);
+  assignIdentity("numPrFromStyle", numPrFromStyle);
+  assignIdentity("numberingLevelIndent", numberingLevelIndent);
+  return remapped;
+};
+
+/** Remap current and historical paragraph-property numbering identities together. */
+export const remapParagraphPropertyChangeNumbering = (
+  changes: ParagraphPropertyChange[] | undefined,
+  numIdRemap: NumberingIdRemapper,
+): ParagraphPropertyChange[] | undefined => {
+  if (!changes) {
+    return undefined;
+  }
+  let changed = false;
+  const remapped = changes.map((change) => {
+    const previousFormatting = remapParagraphFormattingNumbering(
+      change.previousFormatting,
+      numIdRemap,
+    );
+    const currentFormatting = remapParagraphFormattingNumbering(
+      change.currentFormatting,
+      numIdRemap,
+    );
+    if (
+      previousFormatting === change.previousFormatting &&
+      currentFormatting === change.currentFormatting
+    ) {
+      return change;
+    }
+    changed = true;
+    return {
+      ...change,
+      ...(previousFormatting === undefined ? {} : { previousFormatting }),
+      ...(currentFormatting === undefined ? {} : { currentFormatting }),
+    };
+  });
+  return changed ? remapped : changes;
+};
+
+const omitOwnedIndentValue = <K extends "indentLeft" | "indentRight">(
+  formatting: ParagraphFormatting,
+  provenance: NumberingLevelIndentGeometry,
+  key: K,
+): void => {
+  if (provenance[key] !== undefined && formatting[key] === provenance[key]) {
+    Reflect.deleteProperty(formatting, key);
+  }
+};
+
+/** Drop an invalid active numbering reference and only the effective indents it owned. */
+export const dropParagraphNumberingReference = (
+  formatting: ParagraphFormatting,
+  numId: number,
+): ParagraphFormatting => {
+  const next = { ...formatting };
+  const provenance = formatting.numberingLevelIndent;
+  if (formatting.numPr?.numId === numId) {
+    Reflect.deleteProperty(next, "numPr");
+  }
+  if (provenance?.numId === numId) {
+    const owned = provenance.type === "owned" ? provenance.owned : undefined;
+    if (owned) {
+      omitOwnedIndentValue(next, owned, "indentLeft");
+      omitOwnedIndentValue(next, owned, "indentRight");
+    }
+    const hasOwnedFirstLinePair =
+      owned?.indentFirstLine !== undefined || owned?.hangingIndent !== undefined;
+    const ownsFirstLinePair =
+      hasOwnedFirstLinePair &&
+      formatting.indentFirstLine === owned?.indentFirstLine &&
+      (formatting.hangingIndent ?? false) === (owned?.hangingIndent ?? false);
+    if (ownsFirstLinePair) {
+      Reflect.deleteProperty(next, "indentFirstLine");
+      Reflect.deleteProperty(next, "hangingIndent");
+    }
+    Reflect.deleteProperty(next, "numberingLevelIndent");
+  }
+  if (formatting.numPrFromStyle?.numId === numId) {
+    Reflect.deleteProperty(next, "numPrFromStyle");
+  }
+  return next;
+};
+
+/** Remove numbering-owned effective indents, leaving direct/style fields intact. */
+export const paragraphFormattingWithoutNumberingOwnedIndent = (
+  formatting: ParagraphFormatting,
+): ParagraphFormatting => {
+  const result = { ...formatting };
+  const provenance = formatting.numberingLevelIndent;
+  if (provenance?.type !== "owned") {
+    Reflect.deleteProperty(result, "numberingLevelIndent");
+    return result;
+  }
+  const owned = provenance.owned;
+  if (owned.indentLeft !== undefined && result.indentLeft === owned.indentLeft) {
+    Reflect.deleteProperty(result, "indentLeft");
+  }
+  if (owned.indentRight !== undefined && result.indentRight === owned.indentRight) {
+    Reflect.deleteProperty(result, "indentRight");
+  }
+  if (
+    (owned.indentFirstLine !== undefined || owned.hangingIndent !== undefined) &&
+    result.indentFirstLine === owned.indentFirstLine &&
+    (result.hangingIndent ?? false) === (owned.hangingIndent ?? false)
+  ) {
+    Reflect.deleteProperty(result, "indentFirstLine");
+    Reflect.deleteProperty(result, "hangingIndent");
+  }
+  Reflect.deleteProperty(result, "numberingLevelIndent");
+  return result;
+};
+
+export type NumberingIndentSide = "indentLeft" | "indentRight" | "firstLine";
+
+/** Reclassify rewritten numbering-derived geometry as direct paragraph formatting. */
+export const retireNumberingIndentOwnership = (
+  formatting: ParagraphFormatting,
+  sides: ReadonlySet<NumberingIndentSide>,
+): ParagraphFormatting => {
+  const provenance = formatting.numberingLevelIndent;
+  if (provenance?.type !== "owned") {
+    return formatting;
+  }
+  const nextOwned: NumberingLevelIndentGeometry = { ...provenance.owned };
+  if (sides.has("indentLeft")) {
+    Reflect.deleteProperty(nextOwned, "indentLeft");
+  }
+  if (sides.has("indentRight")) {
+    Reflect.deleteProperty(nextOwned, "indentRight");
+  }
+  if (sides.has("firstLine")) {
+    Reflect.deleteProperty(nextOwned, "indentFirstLine");
+    Reflect.deleteProperty(nextOwned, "hangingIndent");
+  }
+  const next = { ...formatting };
+  next.numberingLevelIndent = createNumberingLevelIndentProvenance({
+    numId: provenance.numId,
+    ilvl: provenance.ilvl,
+    baseline: provenance.baseline,
+    owned: nextOwned,
+  });
+  return next;
+};

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -40,9 +40,16 @@ import type {
 import { PARAGRAPH_MARK_CHANGE_KINDS } from "@stll/docx-core/model";
 import { panic } from "better-result";
 import { isValidHexId } from "../utils/hexId";
-import { canonicalJson } from "../utils/canonicalJson";
 import { paraIdInRange } from "./paraIdRangeNormalization";
-import { assignParagraphPropertySource } from "./paragraphPropertySource";
+import {
+  paragraphPropertySourceFingerprintFromParts,
+  selectAuthoredParagraphProperties,
+  selectParagraphMarkProperties,
+} from "./paragraphPropertyDescriptor";
+import {
+  assignAbsentParagraphPropertySource,
+  assignParagraphPropertySource,
+} from "./paragraphPropertySource";
 import {
   parseBookmarkStart as parseBookmarkStartFromModule,
   parseBookmarkEnd as parseBookmarkEndFromModule,
@@ -2007,8 +2014,12 @@ export function parseParagraph(
 
   // Parse paragraph properties (w:pPr)
   const pPr = findChild(node, "w", "pPr");
+  let authoredPPr: ParagraphFormatting | undefined;
   if (pPr) {
     const formattingResult = parseParagraphProperties(pPr, theme, styles ?? undefined);
+    // Keep the authored shape before effective style/numbering values are
+    // materialized below. An empty w:pPr is distinct from no w:pPr.
+    authoredPPr = structuredClone(formattingResult ?? {});
     if (formattingResult !== undefined) {
       paragraph.formatting = formattingResult;
     }
@@ -2271,9 +2282,14 @@ export function parseParagraph(
 
   if (pPr) {
     assignParagraphPropertySource(paragraph, {
+      fingerprint: paragraphPropertySourceFingerprintFromParts(
+        selectAuthoredParagraphProperties(authoredPPr),
+        selectParagraphMarkProperties(authoredPPr),
+      ),
       xml: captureParagraphPropertySource(pPr),
-      formattingJson: canonicalJson(paragraph.formatting ?? {}),
     });
+  } else {
+    assignAbsentParagraphPropertySource(paragraph);
   }
 
   return paragraph;

--- a/packages/core/src/docx/paragraphParser.ts
+++ b/packages/core/src/docx/paragraphParser.ts
@@ -45,7 +45,7 @@ import {
   paragraphPropertySourceFingerprintFromParts,
   selectAuthoredParagraphProperties,
   selectParagraphMarkProperties,
-} from "./paragraphPropertyDescriptor";
+} from "@stll/docx-core/model";
 import {
   assignAbsentParagraphPropertySource,
   assignParagraphPropertySource,

--- a/packages/core/src/docx/paragraphPropertyDescriptor.ts
+++ b/packages/core/src/docx/paragraphPropertyDescriptor.ts
@@ -25,10 +25,20 @@ export const PARAGRAPH_STYLE_TRANSITION = {
   preserve: "preserve",
 } as const;
 
+export const PARAGRAPH_PROPERTY_CASCADE = {
+  fieldwise: "fieldwise",
+  firstLine: "first-line",
+  preserveDerived: "preserve-derived",
+  replace: "replace",
+  runProperties: "run-properties",
+  tabStops: "tab-stops",
+} as const;
+
 export type ParagraphPropertyDescriptor = {
   owner: (typeof PARAGRAPH_PROPERTY_OWNER)[keyof typeof PARAGRAPH_PROPERTY_OWNER];
   projection: (typeof PARAGRAPH_PROPERTY_PROJECTION)[keyof typeof PARAGRAPH_PROPERTY_PROJECTION];
   styleTransition: (typeof PARAGRAPH_STYLE_TRANSITION)[keyof typeof PARAGRAPH_STYLE_TRANSITION];
+  cascade: (typeof PARAGRAPH_PROPERTY_CASCADE)[keyof typeof PARAGRAPH_PROPERTY_CASCADE];
 };
 
 /**
@@ -45,171 +55,205 @@ export const PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR = {
     owner: "pPr-base",
     projection: "alignment",
     styleTransition: "replace",
+    cascade: "replace",
   },
   bidi: {
     owner: "pPr-base",
     projection: "direction",
     styleTransition: "replace",
+    cascade: "replace",
   },
   kinsoku: {
     owner: "pPr-base",
     projection: "boolean",
     styleTransition: "replace",
+    cascade: "replace",
   },
   overflowPunctuation: {
     owner: "pPr-base",
     projection: "boolean",
     styleTransition: "replace",
+    cascade: "replace",
   },
   spaceBefore: {
     owner: "pPr-base",
     projection: "spacing",
     styleTransition: "replace",
+    cascade: "replace",
   },
   spaceAfter: {
     owner: "pPr-base",
     projection: "spacing",
     styleTransition: "replace",
+    cascade: "replace",
   },
   lineSpacing: {
     owner: "pPr-base",
     projection: "spacing",
     styleTransition: "replace",
+    cascade: "replace",
   },
   lineSpacingRule: {
     owner: "pPr-base",
     projection: "spacing",
     styleTransition: "replace",
+    cascade: "replace",
   },
   snapToGrid: {
     owner: "pPr-base",
     projection: "boolean",
     styleTransition: "replace",
+    cascade: "replace",
   },
   beforeAutospacing: {
     owner: "pPr-base",
     projection: "spacing",
     styleTransition: "replace",
+    cascade: "replace",
   },
   afterAutospacing: {
     owner: "pPr-base",
     projection: "spacing",
     styleTransition: "replace",
+    cascade: "replace",
   },
   spacingExplicit: {
     owner: "pPr-base",
     projection: "spacing",
     styleTransition: "replace",
+    cascade: "replace",
   },
   indentLeft: {
     owner: "pPr-base",
     projection: "indentation",
     styleTransition: "replace",
+    cascade: "replace",
   },
   indentRight: {
     owner: "pPr-base",
     projection: "indentation",
     styleTransition: "replace",
+    cascade: "replace",
   },
   indentFirstLine: {
     owner: "pPr-base",
     projection: "indentation",
     styleTransition: "replace",
+    cascade: "first-line",
   },
   hangingIndent: {
     owner: "pPr-base",
     projection: "indentation",
     styleTransition: "replace",
+    cascade: "replace",
   },
   numberingLevelIndent: {
     owner: "derived",
     projection: "numbering-provenance",
     styleTransition: "replace",
+    cascade: "preserve-derived",
   },
   borders: {
     owner: "pPr-base",
     projection: "direct",
     styleTransition: "replace",
+    cascade: "fieldwise",
   },
   shading: {
     owner: "pPr-base",
     projection: "direct",
     styleTransition: "replace",
+    cascade: "replace",
   },
   tabs: {
     owner: "pPr-base",
     projection: "direct",
     styleTransition: "replace",
+    cascade: "tab-stops",
   },
   keepNext: {
     owner: "pPr-base",
     projection: "boolean",
     styleTransition: "replace",
+    cascade: "replace",
   },
   keepLines: {
     owner: "pPr-base",
     projection: "boolean",
     styleTransition: "replace",
+    cascade: "replace",
   },
   widowControl: {
     owner: "pPr-base",
     projection: "boolean",
     styleTransition: "replace",
+    cascade: "replace",
   },
   pageBreakBefore: {
     owner: "pPr-base",
     projection: "boolean",
     styleTransition: "replace",
+    cascade: "replace",
   },
   contextualSpacing: {
     owner: "pPr-base",
     projection: "boolean",
     styleTransition: "replace",
+    cascade: "replace",
   },
   numPr: {
     owner: "pPr-base",
     projection: "direct",
     styleTransition: "numbering",
+    cascade: "fieldwise",
   },
   numPrFromStyle: {
     owner: "derived",
     projection: "numbering-provenance",
     styleTransition: "numbering",
+    cascade: "preserve-derived",
   },
   outlineLevel: {
     owner: "pPr-base",
     projection: "direct",
     styleTransition: "replace",
+    cascade: "replace",
   },
   styleId: {
     owner: "pPr-base",
     projection: "direct",
     styleTransition: "identity",
+    cascade: "replace",
   },
   frame: {
     owner: "pPr-base",
     projection: "opaque",
     styleTransition: "replace",
+    cascade: "fieldwise",
   },
   suppressLineNumbers: {
     owner: "pPr-base",
     projection: "boolean",
     styleTransition: "replace",
+    cascade: "replace",
   },
   suppressAutoHyphens: {
     owner: "pPr-base",
     projection: "boolean",
     styleTransition: "replace",
+    cascade: "replace",
   },
   runProperties: {
     owner: "paragraph-mark",
     projection: "preserve-live",
     styleTransition: "preserve",
+    cascade: "run-properties",
   },
   runInWithNext: {
     owner: "paragraph-mark",
     projection: "preserve-live",
     styleTransition: "preserve",
+    cascade: "replace",
   },
 } as const satisfies Record<keyof ParagraphFormatting, ParagraphPropertyDescriptor>;
 
@@ -311,6 +355,29 @@ export const paragraphPropertySourceFingerprintFromParts = (
   paragraphMark: selectParagraphMarkProperties(paragraphMark),
 });
 
+/**
+ * Replace every raw-source-owned field while retaining derived formatting.
+ * PM-to-model conversion uses this as the single inverse of the authored and
+ * paragraph-mark projections; effective values can never leak into save truth.
+ */
+export const paragraphFormattingWithPropertySourceFingerprint = (
+  formatting: ParagraphFormatting | null | undefined,
+  fingerprint: ParagraphPropertySourceFingerprint,
+): ParagraphFormatting | undefined => {
+  const result: ParagraphFormatting = { ...formatting };
+  for (const key of PARAGRAPH_FORMATTING_PROPERTY_KEY_LIST) {
+    if (PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR[key].owner !== PARAGRAPH_PROPERTY_OWNER.derived) {
+      Reflect.deleteProperty(result, key);
+    }
+  }
+  Object.assign(
+    result,
+    selectAuthoredParagraphProperties(fingerprint.pPrBase),
+    selectParagraphMarkProperties(fingerprint.paragraphMark),
+  );
+  return Object.keys(result).length === 0 ? undefined : result;
+};
+
 const canonicalJsonValue = (value: unknown): unknown => {
   if (Array.isArray(value)) {
     return value.map(canonicalJsonValue);
@@ -325,11 +392,6 @@ const canonicalJsonValue = (value: unknown): unknown => {
   return value;
 };
 
-/** Canonical raw-replay identity for the exact authored CT_PPrBase payload. */
-export const canonicalAuthoredParagraphPropertiesJson = (
-  formatting: ParagraphFormatting | null | undefined,
-): string => JSON.stringify(canonicalJsonValue(selectAuthoredParagraphProperties(formatting)));
-
 /** Canonical replay identity for every modeled property inside raw `w:pPr`. */
 export const canonicalParagraphPropertySourceFingerprintJson = (
   fingerprint: ParagraphPropertySourceFingerprint,
@@ -338,9 +400,11 @@ export const canonicalParagraphPropertySourceFingerprintJson = (
 const formattingKeys = (
   predicate: (descriptor: ParagraphPropertyDescriptor) => boolean,
 ): readonly string[] =>
-  Object.entries(PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR)
-    .filter(([, descriptor]) => predicate(descriptor))
-    .map(([key]) => key);
+  Object.freeze(
+    Object.entries(PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR)
+      .filter(([, descriptor]) => predicate(descriptor))
+      .map(([key]) => key),
+  );
 
 export const PPR_OPAQUE_FORMATTING_KEYS = formattingKeys(
   ({ owner, projection }) =>
@@ -360,6 +424,11 @@ export const PPR_STYLE_REPLACED_FORMATTING_KEYS = formattingKeys(
   ({ styleTransition }) => styleTransition === PARAGRAPH_STYLE_TRANSITION.replace,
 );
 
-export const PARAGRAPH_FORMATTING_PROPERTY_KEYS: ReadonlySet<string> = new Set(
+const PARAGRAPH_FORMATTING_PROPERTY_KEY_SET = new Set<string>(
   PARAGRAPH_FORMATTING_PROPERTY_KEY_LIST,
 );
+
+export const isParagraphFormattingPropertyKey = (
+  key: string,
+): key is keyof typeof PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR =>
+  PARAGRAPH_FORMATTING_PROPERTY_KEY_SET.has(key);

--- a/packages/core/src/docx/paragraphPropertyDescriptor.ts
+++ b/packages/core/src/docx/paragraphPropertyDescriptor.ts
@@ -1,0 +1,365 @@
+import type { ParagraphFormatting } from "../types/document";
+
+export const PARAGRAPH_PROPERTY_OWNER = {
+  pPrBase: "pPr-base",
+  derived: "derived",
+  paragraphMark: "paragraph-mark",
+} as const;
+
+export const PARAGRAPH_PROPERTY_PROJECTION = {
+  direct: "direct",
+  boolean: "boolean",
+  alignment: "alignment",
+  direction: "direction",
+  spacing: "spacing",
+  indentation: "indentation",
+  opaque: "opaque",
+  numberingProvenance: "numbering-provenance",
+  preserveLive: "preserve-live",
+} as const;
+
+export const PARAGRAPH_STYLE_TRANSITION = {
+  replace: "replace",
+  numbering: "numbering",
+  identity: "identity",
+  preserve: "preserve",
+} as const;
+
+export type ParagraphPropertyDescriptor = {
+  owner: (typeof PARAGRAPH_PROPERTY_OWNER)[keyof typeof PARAGRAPH_PROPERTY_OWNER];
+  projection: (typeof PARAGRAPH_PROPERTY_PROJECTION)[keyof typeof PARAGRAPH_PROPERTY_PROJECTION];
+  styleTransition: (typeof PARAGRAPH_STYLE_TRANSITION)[keyof typeof PARAGRAPH_STYLE_TRANSITION];
+};
+
+/**
+ * Total ownership/restoration contract for `ParagraphFormatting`.
+ *
+ * `w:pPrChange` stores CT_PPrBase, while paragraph-mark rPr and derived
+ * style/numbering provenance live outside that payload. Keeping every model
+ * property in one exhaustive descriptor prevents snapshots, rejection,
+ * serialization, and style transitions from silently growing different
+ * interpretations of that boundary when `ParagraphFormatting` gains a field.
+ */
+export const PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR = {
+  alignment: {
+    owner: "pPr-base",
+    projection: "alignment",
+    styleTransition: "replace",
+  },
+  bidi: {
+    owner: "pPr-base",
+    projection: "direction",
+    styleTransition: "replace",
+  },
+  kinsoku: {
+    owner: "pPr-base",
+    projection: "boolean",
+    styleTransition: "replace",
+  },
+  overflowPunctuation: {
+    owner: "pPr-base",
+    projection: "boolean",
+    styleTransition: "replace",
+  },
+  spaceBefore: {
+    owner: "pPr-base",
+    projection: "spacing",
+    styleTransition: "replace",
+  },
+  spaceAfter: {
+    owner: "pPr-base",
+    projection: "spacing",
+    styleTransition: "replace",
+  },
+  lineSpacing: {
+    owner: "pPr-base",
+    projection: "spacing",
+    styleTransition: "replace",
+  },
+  lineSpacingRule: {
+    owner: "pPr-base",
+    projection: "spacing",
+    styleTransition: "replace",
+  },
+  snapToGrid: {
+    owner: "pPr-base",
+    projection: "boolean",
+    styleTransition: "replace",
+  },
+  beforeAutospacing: {
+    owner: "pPr-base",
+    projection: "spacing",
+    styleTransition: "replace",
+  },
+  afterAutospacing: {
+    owner: "pPr-base",
+    projection: "spacing",
+    styleTransition: "replace",
+  },
+  spacingExplicit: {
+    owner: "pPr-base",
+    projection: "spacing",
+    styleTransition: "replace",
+  },
+  indentLeft: {
+    owner: "pPr-base",
+    projection: "indentation",
+    styleTransition: "replace",
+  },
+  indentRight: {
+    owner: "pPr-base",
+    projection: "indentation",
+    styleTransition: "replace",
+  },
+  indentFirstLine: {
+    owner: "pPr-base",
+    projection: "indentation",
+    styleTransition: "replace",
+  },
+  hangingIndent: {
+    owner: "pPr-base",
+    projection: "indentation",
+    styleTransition: "replace",
+  },
+  numberingLevelIndent: {
+    owner: "derived",
+    projection: "numbering-provenance",
+    styleTransition: "replace",
+  },
+  borders: {
+    owner: "pPr-base",
+    projection: "direct",
+    styleTransition: "replace",
+  },
+  shading: {
+    owner: "pPr-base",
+    projection: "direct",
+    styleTransition: "replace",
+  },
+  tabs: {
+    owner: "pPr-base",
+    projection: "direct",
+    styleTransition: "replace",
+  },
+  keepNext: {
+    owner: "pPr-base",
+    projection: "boolean",
+    styleTransition: "replace",
+  },
+  keepLines: {
+    owner: "pPr-base",
+    projection: "boolean",
+    styleTransition: "replace",
+  },
+  widowControl: {
+    owner: "pPr-base",
+    projection: "boolean",
+    styleTransition: "replace",
+  },
+  pageBreakBefore: {
+    owner: "pPr-base",
+    projection: "boolean",
+    styleTransition: "replace",
+  },
+  contextualSpacing: {
+    owner: "pPr-base",
+    projection: "boolean",
+    styleTransition: "replace",
+  },
+  numPr: {
+    owner: "pPr-base",
+    projection: "direct",
+    styleTransition: "numbering",
+  },
+  numPrFromStyle: {
+    owner: "derived",
+    projection: "numbering-provenance",
+    styleTransition: "numbering",
+  },
+  outlineLevel: {
+    owner: "pPr-base",
+    projection: "direct",
+    styleTransition: "replace",
+  },
+  styleId: {
+    owner: "pPr-base",
+    projection: "direct",
+    styleTransition: "identity",
+  },
+  frame: {
+    owner: "pPr-base",
+    projection: "opaque",
+    styleTransition: "replace",
+  },
+  suppressLineNumbers: {
+    owner: "pPr-base",
+    projection: "boolean",
+    styleTransition: "replace",
+  },
+  suppressAutoHyphens: {
+    owner: "pPr-base",
+    projection: "boolean",
+    styleTransition: "replace",
+  },
+  runProperties: {
+    owner: "paragraph-mark",
+    projection: "preserve-live",
+    styleTransition: "preserve",
+  },
+  runInWithNext: {
+    owner: "paragraph-mark",
+    projection: "preserve-live",
+    styleTransition: "preserve",
+  },
+} as const satisfies Record<keyof ParagraphFormatting, ParagraphPropertyDescriptor>;
+
+// SAFETY: `Object.keys` erases keys that the total descriptor establishes.
+export const PARAGRAPH_FORMATTING_PROPERTY_KEY_LIST = Object.freeze(
+  Object.keys(PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR) as (
+    keyof typeof PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR
+  )[],
+);
+
+type FormattingKeysOwnedBy<Owner extends ParagraphPropertyDescriptor["owner"]> = {
+  [Key in keyof typeof PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR]: (typeof PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR)[Key]["owner"] extends Owner
+    ? Key
+    : never;
+}[keyof typeof PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR];
+
+/** Exact authored CT_PPrBase payload, before style or numbering resolution. */
+export type AuthoredParagraphPropertyKey = FormattingKeysOwnedBy<"pPr-base">;
+export type AuthoredParagraphProperties = Pick<
+  ParagraphFormatting,
+  AuthoredParagraphPropertyKey
+>;
+
+/** Paragraph-mark properties intentionally kept outside CT_PPrBase provenance. */
+export type ParagraphMarkPropertyKey = FormattingKeysOwnedBy<"paragraph-mark">;
+export type ParagraphMarkProperties = Pick<ParagraphFormatting, ParagraphMarkPropertyKey>;
+
+/** Effective-only or derived properties intentionally kept outside authored pPr. */
+export type DerivedParagraphPropertyKey = FormattingKeysOwnedBy<"derived">;
+export type DerivedParagraphProperties = Pick<ParagraphFormatting, DerivedParagraphPropertyKey>;
+
+/** Exhaustive modeled contents of one raw `w:pPr` source capture. */
+export type ParagraphPropertySourceFingerprint = Readonly<{
+  pPrBase: AuthoredParagraphProperties;
+  paragraphMark: ParagraphMarkProperties;
+}>;
+
+const clonePropertyValue = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(clonePropertyValue);
+  }
+  if (typeof value === "object" && value !== null) {
+    const clone: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      clone[key] = clonePropertyValue(entry);
+    }
+    return clone;
+  }
+  return value;
+};
+
+const selectParagraphPropertiesOwnedBy = <
+  Owner extends ParagraphPropertyDescriptor["owner"],
+>(
+  formatting: ParagraphFormatting | null | undefined,
+  owner: Owner,
+): Pick<ParagraphFormatting, FormattingKeysOwnedBy<Owner>> => {
+  const selected: Partial<ParagraphFormatting> = {};
+  if (formatting) {
+    for (const rawKey of PARAGRAPH_FORMATTING_PROPERTY_KEY_LIST) {
+      const descriptor = PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR[rawKey];
+      if (descriptor.owner !== owner) {
+        continue;
+      }
+      const value = Reflect.get(formatting, rawKey);
+      if (value !== undefined) {
+        Reflect.set(selected, rawKey, clonePropertyValue(value));
+      }
+    }
+  }
+  // SAFETY: the total descriptor limits selected keys to the requested owner.
+  return selected as Pick<ParagraphFormatting, FormattingKeysOwnedBy<Owner>>;
+};
+
+/** Select exact CT_PPrBase-owned fields from a broader formatting object. */
+export const selectAuthoredParagraphProperties = (
+  formatting: ParagraphFormatting | null | undefined,
+): AuthoredParagraphProperties =>
+  selectParagraphPropertiesOwnedBy(formatting, PARAGRAPH_PROPERTY_OWNER.pPrBase);
+
+/** Select exact paragraph-mark `w:rPr` fields from broader formatting. */
+export const selectParagraphMarkProperties = (
+  formatting: ParagraphFormatting | null | undefined,
+): ParagraphMarkProperties =>
+  selectParagraphPropertiesOwnedBy(formatting, PARAGRAPH_PROPERTY_OWNER.paragraphMark);
+
+export const paragraphPropertySourceFingerprintFromFormatting = (
+  formatting: ParagraphFormatting | null | undefined,
+): ParagraphPropertySourceFingerprint => ({
+  pPrBase: selectAuthoredParagraphProperties(formatting),
+  paragraphMark: selectParagraphMarkProperties(formatting),
+});
+
+export const paragraphPropertySourceFingerprintFromParts = (
+  pPrBase: AuthoredParagraphProperties,
+  paragraphMark: ParagraphMarkProperties,
+): ParagraphPropertySourceFingerprint => ({
+  pPrBase: selectAuthoredParagraphProperties(pPrBase),
+  paragraphMark: selectParagraphMarkProperties(paragraphMark),
+});
+
+const canonicalJsonValue = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(canonicalJsonValue);
+  }
+  if (typeof value === "object" && value !== null) {
+    const result: Record<string, unknown> = {};
+    for (const key of Object.keys(value).toSorted()) {
+      result[key] = canonicalJsonValue(Reflect.get(value, key));
+    }
+    return result;
+  }
+  return value;
+};
+
+/** Canonical raw-replay identity for the exact authored CT_PPrBase payload. */
+export const canonicalAuthoredParagraphPropertiesJson = (
+  formatting: ParagraphFormatting | null | undefined,
+): string => JSON.stringify(canonicalJsonValue(selectAuthoredParagraphProperties(formatting)));
+
+/** Canonical replay identity for every modeled property inside raw `w:pPr`. */
+export const canonicalParagraphPropertySourceFingerprintJson = (
+  fingerprint: ParagraphPropertySourceFingerprint,
+): string => JSON.stringify(canonicalJsonValue(fingerprint));
+
+const formattingKeys = (
+  predicate: (descriptor: ParagraphPropertyDescriptor) => boolean,
+): readonly string[] =>
+  Object.entries(PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR)
+    .filter(([, descriptor]) => predicate(descriptor))
+    .map(([key]) => key);
+
+export const PPR_OPAQUE_FORMATTING_KEYS = formattingKeys(
+  ({ owner, projection }) =>
+    owner === PARAGRAPH_PROPERTY_OWNER.pPrBase &&
+    projection === PARAGRAPH_PROPERTY_PROJECTION.opaque,
+);
+
+export const PPR_CHANGE_SCOPED_FORMATTING_KEYS = formattingKeys(
+  ({ owner }) => owner === PARAGRAPH_PROPERTY_OWNER.pPrBase,
+);
+
+export const PPR_PARAGRAPH_MARK_FORMATTING_KEYS = formattingKeys(
+  ({ owner }) => owner === PARAGRAPH_PROPERTY_OWNER.paragraphMark,
+);
+
+export const PPR_STYLE_REPLACED_FORMATTING_KEYS = formattingKeys(
+  ({ styleTransition }) => styleTransition === PARAGRAPH_STYLE_TRANSITION.replace,
+);
+
+export const PARAGRAPH_FORMATTING_PROPERTY_KEYS: ReadonlySet<string> = new Set(
+  PARAGRAPH_FORMATTING_PROPERTY_KEY_LIST,
+);

--- a/packages/core/src/docx/paragraphPropertyRoundTrip.test.ts
+++ b/packages/core/src/docx/paragraphPropertyRoundTrip.test.ts
@@ -16,10 +16,8 @@ import { DATE_UTC_NAMESPACE_URI } from "./trackedChangeInfo";
 import {
   ParagraphPropertySourceValidationError,
   assignParagraphPropertySource,
-  getParagraphPropertySourceCandidate,
   getParagraphPropertySource,
   getParagraphPropertySourceToken,
-  transferProseParagraphPropertySource,
 } from "./paragraphPropertySource";
 import { createEmptyDocx, repackDocx } from "./rezip";
 import { consolidateParagraph } from "./runConsolidator";
@@ -210,12 +208,16 @@ describe("paragraph properties survive a no-edit full repack", () => {
 
     const restored = fromProseDoc(toProseDoc(parsed), parsed);
     const restoredParagraph = firstParagraph(restored);
-    expect(getParagraphPropertySourceCandidate(restoredParagraph)).toBe(sourceParagraph);
+    expect(getParagraphPropertySource(restoredParagraph)).toEqual(
+      getParagraphPropertySource(sourceParagraph),
+    );
 
     const cleaned = withoutOrphanCommentRanges(restored);
     const cleanedParagraph = firstParagraph(cleaned);
     expect(cleanedParagraph).not.toBe(restoredParagraph);
-    expect(getParagraphPropertySourceCandidate(cleanedParagraph)).toBe(sourceParagraph);
+    expect(getParagraphPropertySource(cleanedParagraph)).toEqual(
+      getParagraphPropertySource(sourceParagraph),
+    );
     expect(getParagraphPropertySource(cleanedParagraph)).toEqual(
       getParagraphPropertySource(sourceParagraph),
     );
@@ -432,7 +434,7 @@ describe("paragraph properties survive a no-edit full repack", () => {
     second.paraId = "22222222";
     const proseDoc = toProseDoc(parsed);
     const firstProseParagraph = proseDoc.child(0);
-    transferProseParagraphPropertySource(firstProseParagraph, firstProseParagraph, "22222222");
+    expect(firstProseParagraph.attrs["paraId"]).toBe("11111111");
 
     const detached = proseDoc.type.create(
       proseDoc.attrs,
@@ -480,7 +482,6 @@ describe("paragraph properties survive a no-edit full repack", () => {
       paragraph.content,
       paragraph.marks,
     );
-    transferProseParagraphPropertySource(copied, paragraph, "87654321");
     const copiedSlice = new Slice(Fragment.fromArray([paragraph, copied]), 0, 0);
     const duplicated = proseDoc.type.create(proseDoc.attrs, copiedSlice.content);
     expect(() => fromProseDoc(duplicated, parsed)).toThrow(ParagraphPropertySourceValidationError);

--- a/packages/core/src/docx/paragraphPropertyRoundTrip.test.ts
+++ b/packages/core/src/docx/paragraphPropertyRoundTrip.test.ts
@@ -16,6 +16,7 @@ import { DATE_UTC_NAMESPACE_URI } from "./trackedChangeInfo";
 import {
   ParagraphPropertySourceValidationError,
   assignParagraphPropertySource,
+  deriveDocumentWithParagraphPropertySources,
   getParagraphPropertySource,
   getParagraphPropertySourceToken,
 } from "./paragraphPropertySource";
@@ -394,7 +395,9 @@ describe("paragraph properties survive a no-edit full repack", () => {
     const parsed = await parseDocx(await documentWithDuplicateParagraphIds(), {
       preloadFonts: false,
     });
-    const derived = { ...parsed, package: { ...parsed.package } };
+    const derived = deriveDocumentWithParagraphPropertySources(parsed, {
+      package: { ...parsed.package },
+    });
     const normalized = ensureParaIdsInDoc(toProseDoc(parsed));
     const reconstructed = normalized.type.schema.nodeFromJSON(normalized.toJSON());
     const restored = fromProseDoc(reconstructed, derived);
@@ -410,7 +413,9 @@ describe("paragraph properties survive a no-edit full repack", () => {
     const parsed = await parseDocx(await documentWithSourceProperties(SOURCE_PROPERTIES, null), {
       preloadFonts: false,
     });
-    const derived = { ...parsed, package: { ...parsed.package } };
+    const derived = deriveDocumentWithParagraphPropertySources(parsed, {
+      package: { ...parsed.package },
+    });
     const normalized = ensureParaIdsInDoc(toProseDoc(parsed));
     const reconstructed = normalized.type.schema.nodeFromJSON(normalized.toJSON());
     const restored = fromProseDoc(reconstructed, derived);

--- a/packages/core/src/docx/paragraphPropertySource.test.ts
+++ b/packages/core/src/docx/paragraphPropertySource.test.ts
@@ -1,15 +1,32 @@
 import { describe, expect, test } from "bun:test";
 import { readFile } from "node:fs/promises";
 
-import type { BlockContent, Paragraph } from "../types/document";
+import type { BlockContent, Document, Paragraph } from "../types/document";
 import { parseDocx } from "./parser";
+import { paragraphPropertySourceFingerprintFromParts } from "./paragraphPropertyDescriptor";
+import { serializeParagraph } from "./serializer/paragraphSerializer";
 import {
+  assignAbsentParagraphPropertySource,
+  assignDocumentParagraphPropertySourceContract,
+  assignParagraphPropertySource,
   cloneDocumentWithParagraphPropertySources,
+  cloneParagraphWithPropertySource,
+  cloneParagraphWithoutPropertySource,
+  createParagraphPropertyTemplateStore,
+  deriveDocumentWithParagraphPropertySources,
   getDocumentParagraphPropertySourceContract,
   getParagraphPropertySource,
   getParagraphPropertySourceToken,
+  ParagraphPropertyStorySource,
   visitDocumentStoryParagraphs,
 } from "./paragraphPropertySource";
+import {
+  ParagraphPropertySourceContract,
+  ParagraphPropertySourceToken,
+  ParagraphPropertyTransientTemplateHandle,
+  ParagraphPropertyTransientTemplateStore,
+  type ParagraphPropertySourceStory,
+} from "./paragraphPropertySourceIdentity";
 
 const LAYOUT_FIXTURE = new URL(
   "../../../../parity/fixtures/layout-kitchen-sink.docx",
@@ -22,15 +39,17 @@ const BLOCK_SDT_FIXTURE = new URL(
 const LAYOUT_DIGEST = "96aef5ba6161127dc9b85ec487101c934ca1bc93f63fbb8caa53dde196a5fd5b";
 const BLOCK_SDT_DIGEST = "2c4d3273683c5a7a059711c5d2a6ba2d040e914cb6b84d72fa809b7419b42e11";
 
-const token = (digest: string, ordinal: number) =>
-  `p1d:${digest.slice(0, 32)}:${ordinal.toString(36)}`;
+const token = (digest: string, story: ParagraphPropertySourceStory, ordinal: number) =>
+  ParagraphPropertySourceContract.fromDigest(digest)
+    .bindStoryCensus(story, ordinal + 1)
+    .tokenAt(ordinal).serialized;
 
 const tokensIn = (content: BlockContent[]): string[] => {
   const tokens: string[] = [];
   visitDocumentStoryParagraphs(content, (paragraph) => {
     const sourceToken = getParagraphPropertySourceToken(paragraph);
     if (sourceToken) {
-      tokens.push(sourceToken);
+      tokens.push(sourceToken.serialized);
     }
   });
   return tokens;
@@ -61,14 +80,79 @@ const firstParagraphIn = (content: BlockContent[]): Paragraph | undefined => {
 };
 
 describe("paragraph-property source identity", () => {
+  test("only canonical serialized values cross into frozen trusted identities", () => {
+    const digest = "a".repeat(64);
+    const contract = ParagraphPropertySourceContract.fromDigest(digest);
+    const story = { relationshipId: "rId:header/1", type: "header" } as const;
+    const sourceToken = contract.bindStoryCensus(story, 13).tokenAt(12);
+
+    expect(Object.isFrozen(contract)).toBe(true);
+    expect(Object.isFrozen(sourceToken)).toBe(true);
+    expect(ParagraphPropertySourceContract.read(contract.serialized)).toEqual({
+      status: "valid",
+      value: expect.any(ParagraphPropertySourceContract),
+    });
+    expect(ParagraphPropertySourceContract.read(`folio-ppr-v2:${"A".repeat(64)}`)).toEqual({
+      raw: `folio-ppr-v2:${"A".repeat(64)}`,
+      status: "invalid",
+    });
+    expect(contract.readToken(sourceToken.serialized)).toEqual({
+      status: "valid",
+      value: expect.any(ParagraphPropertySourceToken),
+    });
+    expect(contract.readToken("p2s:bad:0")).toEqual({
+      raw: "p2s:bad:0",
+      status: "invalid",
+    });
+    expect(sourceToken.belongsTo(contract)).toBe(true);
+    expect(sourceToken.belongsToStory({ relationshipId: "rId:header/1", type: "header" })).toBe(
+      true,
+    );
+    expect(
+      contract.readToken("p2s:header:%72Id%3Aheader%2F1:c").status,
+    ).toBe("invalid");
+    expect(sourceToken.belongsToStory({ relationshipId: "other", type: "header" })).toBe(false);
+    expect(() =>
+      contract.bindStoryCensus({ relationshipId: "", type: "header" }, 1),
+    ).toThrow();
+    expect(() =>
+      contract.bindStoryCensus({ noteId: Number.NaN, type: "footnote" }, 1),
+    ).toThrow();
+    const collidingPrefixContract = ParagraphPropertySourceContract.fromDigest(
+      `${"a".repeat(32)}${"b".repeat(32)}`,
+    );
+    expect(sourceToken.belongsTo(collidingPrefixContract)).toBe(false);
+    const sameLocalToken = collidingPrefixContract.bindStoryCensus(story, 13).tokenAt(12);
+    expect(sameLocalToken.serialized).toBe(sourceToken.serialized);
+    expect(sourceToken.belongsTo(collidingPrefixContract)).toBe(false);
+    expect(sameLocalToken.belongsTo(contract)).toBe(false);
+  });
+
+  test("contract-local token construction and parsing agree over bounded story ordinals", () => {
+    const contract = ParagraphPropertySourceContract.fromDigest("b".repeat(64));
+    for (const ordinal of [0, 1, 35, 36, 1024]) {
+      const sourceToken = contract.bindStoryCensus({ type: "document" }, ordinal + 1).tokenAt(ordinal);
+      const parsed = contract.readToken(sourceToken.serialized);
+      expect(parsed.status).toBe("valid");
+      if (parsed.status === "valid") {
+        expect(parsed.value.ordinal).toBe(ordinal);
+        expect(parsed.value.belongsTo(contract)).toBe(true);
+      }
+    }
+  });
+
   test("the private contract follows immutable derivations without entering JSON", async () => {
     const document = await parseDocx(await readFile(LAYOUT_FIXTURE), { preloadFonts: false });
     const contract = getDocumentParagraphPropertySourceContract(document);
-    const derived = { ...document, package: { ...document.package } };
+    const weakened = { ...document, package: { ...document.package } };
+    const derived = deriveDocumentWithParagraphPropertySources(document, {
+      package: { ...document.package },
+    });
 
+    expect(() => getDocumentParagraphPropertySourceContract(weakened)).toThrow();
     expect(getDocumentParagraphPropertySourceContract(derived)).toBe(contract);
     expect(JSON.stringify(derived)).not.toContain("paragraphPropertySourceContract");
-    expect(JSON.stringify(derived)).not.toContain("folio-ppr-v1");
+    expect(JSON.stringify(derived)).not.toContain("folio-ppr-v2");
   });
 
   test("the sanctioned structured clone explicitly transfers private source identity", async () => {
@@ -76,29 +160,165 @@ describe("paragraph-property source identity", () => {
     const rawClone = structuredClone(document);
     const ownedClone = cloneDocumentWithParagraphPropertySources(document);
     const sourceParagraph = firstParagraphIn(document.package.document.content);
+    const rawClonedParagraph = firstParagraphIn(rawClone.package.document.content);
     const clonedParagraph = firstParagraphIn(ownedClone.package.document.content);
 
     expect(getDocumentParagraphPropertySourceContract(rawClone)).toBeUndefined();
     expect(getDocumentParagraphPropertySourceContract(ownedClone)).toBe(
       getDocumentParagraphPropertySourceContract(document),
     );
+    expect(rawClonedParagraph && getParagraphPropertySource(rawClonedParagraph)).toBeUndefined();
+    expect(rawClonedParagraph && getParagraphPropertySourceToken(rawClonedParagraph)).toBeUndefined();
     expect(sourceParagraph && getParagraphPropertySource(sourceParagraph)).toEqual(
       clonedParagraph && getParagraphPropertySource(clonedParagraph),
     );
   });
 
-  test("v1 traversal fixes body, text-box, and table ordinals across parse options", async () => {
+  test("the sanctioned clone retains comment captures and does not retoken derived sections", () => {
+    const bodyParagraph: Paragraph = { content: [], type: "paragraph" };
+    const commentParagraph: Paragraph = { content: [], type: "paragraph" };
+    assignAbsentParagraphPropertySource(bodyParagraph);
+    assignParagraphPropertySource(commentParagraph, {
+      fingerprint: paragraphPropertySourceFingerprintFromParts({}, {}),
+      xml: '<w:pPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:x="urn:test"><x:owner/></w:pPr>',
+    });
+    const document: Document = {
+      package: {
+        document: {
+          comments: [{ author: "Reviewer", content: [commentParagraph], id: 7 }],
+          content: [bodyParagraph],
+          sections: [{ content: [bodyParagraph], properties: {} }],
+        },
+      },
+    };
+    assignDocumentParagraphPropertySourceContract(document, "e".repeat(64));
+    const source = getParagraphPropertySource(commentParagraph);
+    const cloned = cloneDocumentWithParagraphPropertySources(document);
+    const clonedComment = cloned.package.document.comments?.at(0)?.content.at(0);
+    if (!clonedComment) {
+      throw new Error("Cloned comment fixture lost its comment paragraph");
+    }
+
+    expect(getParagraphPropertySource(clonedComment)).toEqual(source);
+    expect(getParagraphPropertySourceToken(clonedComment)?.story).toEqual({
+      commentId: 7,
+      type: "comment",
+    });
+    expect(serializeParagraph(clonedComment)).toBe(serializeParagraph(commentParagraph));
+
+    const clonedBodyParagraph = firstParagraphIn(cloned.package.document.content);
+    const sectionParagraph = cloned.package.document.sections?.at(0)?.content.at(0);
+    if (sectionParagraph?.type !== "paragraph" || clonedBodyParagraph !== sectionParagraph) {
+      throw new Error("Derived section must retain the body paragraph alias");
+    }
+    expect(getParagraphPropertySourceToken(sectionParagraph)).toBe(
+      clonedBodyParagraph && getParagraphPropertySourceToken(clonedBodyParagraph),
+    );
+  });
+
+  test("paragraph source bindings follow spreads, stay immutable, and never enter JSON", async () => {
+    const document = await parseDocx(await readFile(LAYOUT_FIXTURE), { preloadFonts: false });
+    let paragraph: Paragraph | undefined;
+    visitDocumentStoryParagraphs(document.package.document.content, (candidate) => {
+      if (!paragraph && getParagraphPropertySource(candidate)) {
+        paragraph = candidate;
+      }
+    });
+    if (!paragraph) {
+      throw new Error("Layout fixture must contain a paragraph");
+    }
+    const source = getParagraphPropertySource(paragraph);
+    const weakened = { ...paragraph };
+    const derived = cloneParagraphWithPropertySource(paragraph, {});
+
+    expect(() => getParagraphPropertySource(weakened)).toThrow();
+    expect(getParagraphPropertySource(derived)).toBe(source);
+    expect(getParagraphPropertySourceToken(derived)).toBe(
+      getParagraphPropertySourceToken(paragraph),
+    );
+    expect(Object.isFrozen(source)).toBe(true);
+    expect(source && Object.isFrozen(source.fingerprint)).toBe(true);
+    expect(source && Object.isFrozen(source.fingerprint.pPrBase)).toBe(true);
+    expect(JSON.stringify(derived)).not.toContain("p2s:");
+    expect(JSON.stringify(derived)).not.toContain("<w:pPr");
+
+    const detached = cloneParagraphWithoutPropertySource(paragraph, {});
+    expect(getParagraphPropertySource(detached)).toBeUndefined();
+    expect(getParagraphPropertySourceToken(detached)).toBeUndefined();
+  });
+
+  test("transient template captures are one-use and conversion scoped", async () => {
+    const document = await parseDocx(await readFile(LAYOUT_FIXTURE), { preloadFonts: false });
+    const source = firstParagraphIn(document.package.document.content);
+    if (!source) {
+      throw new Error("Layout fixture must contain a paragraph");
+    }
+    const store = createParagraphPropertyTemplateStore();
+    const sourceStory = ParagraphPropertyStorySource.fromDocument(document, { type: "document" });
+    const sourceToken = getParagraphPropertySourceToken(source);
+    if (!sourceToken) {
+      throw new Error("Layout fixture paragraph must carry its source token");
+    }
+    const capture = sourceStory.templateCapture(sourceToken);
+    const handle = store.registerAll([capture]).at(0);
+    if (!handle) {
+      throw new Error("Template capture registration must issue one handle");
+    }
+    const target: Paragraph = { content: [], type: "paragraph" };
+
+    expect(() => store.beginResolution([handle, handle])).toThrow();
+    const registry = store.beginResolution([handle]);
+    registry.consume(handle, target);
+    registry.assertFullyConsumed();
+    expect(getParagraphPropertySource(target)).toBe(getParagraphPropertySource(source));
+    expect(getParagraphPropertySourceToken(target)).toBeUndefined();
+    expect(() => registry.consume(handle, { content: [], type: "paragraph" })).toThrow();
+    const repeatedResolution = store.beginResolution([handle]);
+    repeatedResolution.consume(handle, { content: [], type: "paragraph" });
+    repeatedResolution.assertFullyConsumed();
+
+    const otherStore = createParagraphPropertyTemplateStore();
+    expect(() => otherStore.beginResolution([handle])).toThrow();
+
+    const unconsumedHandle = store.registerAll([capture]).at(0);
+    if (!unconsumedHandle) {
+      throw new Error("Template capture registration must issue one handle");
+    }
+    const unconsumedRegistry = store.beginResolution([unconsumedHandle]);
+    expect(() => unconsumedRegistry.assertFullyConsumed()).toThrow();
+    expect(handle).toBeInstanceOf(ParagraphPropertyTransientTemplateHandle);
+    expect(handle).not.toBe(otherStore.registerAll([capture]).at(0));
+  });
+
+  test("template capacity preflight is atomic", () => {
+    const store = new ParagraphPropertyTransientTemplateStore(1);
+
+    expect(() => store.registerAll(["first", "second"])).toThrow(
+      "template capture capacity was exceeded",
+    );
+    const handle = store.registerAll(["only"]).at(0);
+    if (!handle) {
+      throw new Error("Atomic registration must leave capacity untouched after refusal");
+    }
+    const registry = store.beginResolution([handle]);
+    expect(registry.consume(handle)).toBe("only");
+    registry.assertFullyConsumed();
+  });
+
+  test("v2 traversal fixes body, text-box, and table ordinals across parse options", async () => {
     const source = await readFile(LAYOUT_FIXTURE);
     const browser = await parseDocx(source, { preloadFonts: true });
     const materializer = await parseDocx(source, { preloadFonts: false });
     const browserTokens = tokensIn(browser.package.document.content);
     const materializerTokens = tokensIn(materializer.package.document.content);
 
-    expect(getDocumentParagraphPropertySourceContract(browser)).toBe(
-      `folio-ppr-v1:${LAYOUT_DIGEST}`,
+    expect(getDocumentParagraphPropertySourceContract(browser)?.serialized).toBe(
+      `folio-ppr-v2:${LAYOUT_DIGEST}`,
     );
     expect(browserTokens).toEqual(
-      Array.from({ length: 41 }, (_, ordinal) => token(LAYOUT_DIGEST, ordinal)),
+      Array.from({ length: 41 }, (_, ordinal) =>
+        token(LAYOUT_DIGEST, { type: "document" }, ordinal),
+      ),
     );
     expect(materializerTokens).toEqual(browserTokens);
 
@@ -114,29 +334,268 @@ describe("paragraph-property source identity", () => {
     const table = browser.package.document.content.find((block) => block.type === "table");
     const tableParagraph = table?.rows.at(0)?.cells.at(0)?.content.at(0);
 
-    expect(getParagraphPropertySourceToken(bodyParagraph)).toBe(token(LAYOUT_DIGEST, 0));
+    expect(getParagraphPropertySourceToken(bodyParagraph)?.serialized).toBe(
+      token(LAYOUT_DIGEST, { type: "document" }, 0),
+    );
     expect(textBoxParagraph?.type).toBe("paragraph");
     expect(
       textBoxParagraph?.type === "paragraph"
-        ? getParagraphPropertySourceToken(textBoxParagraph)
+        ? getParagraphPropertySourceToken(textBoxParagraph)?.serialized
         : undefined,
-    ).toBe(token(LAYOUT_DIGEST, 1));
+    ).toBe(token(LAYOUT_DIGEST, { type: "document" }, 1));
     expect(tableParagraph?.type).toBe("paragraph");
     expect(
       tableParagraph?.type === "paragraph"
-        ? getParagraphPropertySourceToken(tableParagraph)
+        ? getParagraphPropertySourceToken(tableParagraph)?.serialized
         : undefined,
-    ).toBe(token(LAYOUT_DIGEST, 7));
+    ).toBe(token(LAYOUT_DIGEST, { type: "document" }, 7));
   });
 
-  test("v1 traversal includes nested block content controls", async () => {
+  test("v2 traversal includes nested block content controls", async () => {
     const source = await readFile(BLOCK_SDT_FIXTURE);
     const document = await parseDocx(source, { preloadFonts: false });
     const paragraph = firstParagraphIn(document.package.document.content);
 
-    expect(tokensIn(document.package.document.content)).toEqual([token(BLOCK_SDT_DIGEST, 0)]);
-    expect(paragraph && getParagraphPropertySourceToken(paragraph)).toBe(
-      token(BLOCK_SDT_DIGEST, 0),
+    expect(tokensIn(document.package.document.content)).toEqual([
+      token(BLOCK_SDT_DIGEST, { type: "document" }, 0),
+    ]);
+    expect(paragraph && getParagraphPropertySourceToken(paragraph)?.serialized).toBe(
+      token(BLOCK_SDT_DIGEST, { type: "document" }, 0),
     );
   });
+
+  test("v2 all-story ordinals ignore package map and note array order", () => {
+    const paragraph = (text: string): Paragraph => ({
+      type: "paragraph",
+      content: [{ type: "run", content: [{ type: "text", text }] }],
+    });
+    const makeDocument = (reverse: boolean) => {
+      const body = paragraph("body");
+      const headerA = paragraph("header-a");
+      const headerB = paragraph("header-b");
+      const footerA = paragraph("footer-a");
+      const footerB = paragraph("footer-b");
+      const footnoteA = paragraph("footnote-a");
+      const footnoteB = paragraph("footnote-b");
+      const endnoteA = paragraph("endnote-a");
+      const commentA = paragraph("comment-a");
+      const commentB = paragraph("comment-b");
+      const ordered = reverse
+        ? [
+            body,
+            headerB,
+            headerA,
+            footerB,
+            footerA,
+            footnoteB,
+            footnoteA,
+            endnoteA,
+            commentB,
+            commentA,
+          ]
+        : [
+            body,
+            headerA,
+            headerB,
+            footerA,
+            footerB,
+            footnoteA,
+            footnoteB,
+            endnoteA,
+            commentA,
+            commentB,
+          ];
+      for (const source of ordered) {
+        assignAbsentParagraphPropertySource(source);
+      }
+      const document: Document = {
+        package: {
+          document: {
+            comments: reverse
+              ? [
+                  { author: "B", content: [commentB], id: 2 },
+                  { author: "A", content: [commentA], id: 1 },
+                ]
+              : [
+                  { author: "A", content: [commentA], id: 1 },
+                  { author: "B", content: [commentB], id: 2 },
+                ],
+            content: [body],
+            sections: [{ content: [body], properties: {} }],
+          },
+          headers: new Map(
+            reverse
+              ? [
+                  ["rIdB", { type: "header", hdrFtrType: "default", content: [headerB] }],
+                  ["rIdA", { type: "header", hdrFtrType: "default", content: [headerA] }],
+                ]
+              : [
+                  ["rIdA", { type: "header", hdrFtrType: "default", content: [headerA] }],
+                  ["rIdB", { type: "header", hdrFtrType: "default", content: [headerB] }],
+                ],
+          ),
+          footers: new Map(
+            reverse
+              ? [
+                  ["rIdD", { type: "footer", hdrFtrType: "default", content: [footerB] }],
+                  ["rIdC", { type: "footer", hdrFtrType: "default", content: [footerA] }],
+                ]
+              : [
+                  ["rIdC", { type: "footer", hdrFtrType: "default", content: [footerA] }],
+                  ["rIdD", { type: "footer", hdrFtrType: "default", content: [footerB] }],
+                ],
+          ),
+          footnotes: reverse
+            ? [
+                { type: "footnote", id: 2, content: [footnoteB] },
+                { type: "footnote", id: 1, content: [footnoteA] },
+              ]
+            : [
+                { type: "footnote", id: 1, content: [footnoteA] },
+                { type: "footnote", id: 2, content: [footnoteB] },
+              ],
+          endnotes: [{ type: "endnote", id: 1, content: [endnoteA] }],
+        },
+      };
+      assignDocumentParagraphPropertySourceContract(document, "c".repeat(64));
+      return [
+        body,
+        headerA,
+        headerB,
+        footerA,
+        footerB,
+        footnoteA,
+        footnoteB,
+        endnoteA,
+        commentA,
+        commentB,
+      ].map((source) => getParagraphPropertySourceToken(source)?.serialized);
+    };
+
+    expect(makeDocument(true)).toEqual(makeDocument(false));
+    expect(makeDocument(false)).toEqual(
+      [
+        token("c".repeat(64), { type: "document" }, 0),
+        token("c".repeat(64), { relationshipId: "rIdA", type: "header" }, 0),
+        token("c".repeat(64), { relationshipId: "rIdB", type: "header" }, 0),
+        token("c".repeat(64), { relationshipId: "rIdC", type: "footer" }, 0),
+        token("c".repeat(64), { relationshipId: "rIdD", type: "footer" }, 0),
+        token("c".repeat(64), { noteId: 1, type: "footnote" }, 0),
+        token("c".repeat(64), { noteId: 2, type: "footnote" }, 0),
+        token("c".repeat(64), { noteId: 1, type: "endnote" }, 0),
+        token("c".repeat(64), { commentId: 1, type: "comment" }, 0),
+        token("c".repeat(64), { commentId: 2, type: "comment" }, 0),
+      ],
+    );
+  });
+
+  test("contract assignment validates the whole story census before mutating provenance", () => {
+    const body: Paragraph = { content: [], type: "paragraph" };
+    const lateHeader: Paragraph = { content: [], type: "paragraph" };
+    assignAbsentParagraphPropertySource(body);
+    const document: Document = {
+      package: {
+        document: { content: [body] },
+        headers: new Map([
+          ["z", { content: [lateHeader], hdrFtrType: "default", type: "header" }],
+        ]),
+      },
+    };
+
+    expect(() => assignDocumentParagraphPropertySourceContract(document, "f".repeat(64))).toThrow();
+    expect(getDocumentParagraphPropertySourceContract(document)).toBeUndefined();
+    expect(getParagraphPropertySourceToken(body)).toBeUndefined();
+
+    assignAbsentParagraphPropertySource(lateHeader);
+    assignDocumentParagraphPropertySourceContract(document, "f".repeat(64));
+    expect(getParagraphPropertySourceToken(body)?.belongsToStory({ type: "document" })).toBe(true);
+    expect(
+      getParagraphPropertySourceToken(lateHeader)?.belongsToStory({
+        relationshipId: "z",
+        type: "header",
+      }),
+    ).toBe(true);
+  });
+
+  test("a late non-transitionable capture cannot partially bind earlier stories", () => {
+    const body: Paragraph = { content: [], type: "paragraph" };
+    const lateHeader: Paragraph = { content: [], type: "paragraph" };
+    assignAbsentParagraphPropertySource(body);
+    assignAbsentParagraphPropertySource(lateHeader);
+    Object.freeze(lateHeader);
+    const document: Document = {
+      package: {
+        document: { content: [body] },
+        headers: new Map([
+          ["z", { content: [lateHeader], hdrFtrType: "default", type: "header" }],
+        ]),
+      },
+    };
+
+    expect(() => assignDocumentParagraphPropertySourceContract(document, "e".repeat(64))).toThrow();
+    expect(getDocumentParagraphPropertySourceContract(document)).toBeUndefined();
+    expect(getParagraphPropertySourceToken(body)).toBeUndefined();
+    expect(() => getParagraphPropertySourceToken(lateHeader)).toThrow(
+      "weakened paragraph-property source binding",
+    );
+  });
+
+  test("derived sections cannot introduce a second paragraph ownership surface", () => {
+    const body: Paragraph = { content: [], type: "paragraph" };
+    const detachedSectionParagraph: Paragraph = { content: [], type: "paragraph" };
+    assignAbsentParagraphPropertySource(body);
+    assignAbsentParagraphPropertySource(detachedSectionParagraph);
+    const document: Document = {
+      package: {
+        document: {
+          content: [body],
+          sections: [{ content: [detachedSectionParagraph], properties: {} }],
+        },
+      },
+    };
+
+    expect(() => assignDocumentParagraphPropertySourceContract(document, "d".repeat(64))).toThrow();
+    expect(getDocumentParagraphPropertySourceContract(document)).toBeUndefined();
+    expect(getParagraphPropertySourceToken(body)).toBeUndefined();
+  });
+
+  test.each(["comment", "footnote"] as const)(
+    "duplicate %s story identities fail before any paragraph is bound",
+    (storyType) => {
+      const first: Paragraph = { content: [], type: "paragraph" };
+      const second: Paragraph = { content: [], type: "paragraph" };
+      assignAbsentParagraphPropertySource(first);
+      assignAbsentParagraphPropertySource(second);
+      const document: Document = {
+        package: {
+          document: {
+            ...(storyType === "comment"
+              ? {
+                  comments: [
+                    { author: "A", content: [first], id: 4 },
+                    { author: "B", content: [second], id: 4 },
+                  ],
+                }
+              : {}),
+            content: [],
+          },
+          ...(storyType === "footnote"
+            ? {
+                footnotes: [
+                  { content: [first], id: 4, type: "footnote" },
+                  { content: [second], id: 4, type: "footnote" },
+                ],
+              }
+            : {}),
+        },
+      };
+
+      expect(() =>
+        assignDocumentParagraphPropertySourceContract(document, "9".repeat(64)),
+      ).toThrow();
+      expect(getDocumentParagraphPropertySourceContract(document)).toBeUndefined();
+      expect(getParagraphPropertySourceToken(first)).toBeUndefined();
+      expect(getParagraphPropertySourceToken(second)).toBeUndefined();
+    },
+  );
 });

--- a/packages/core/src/docx/paragraphPropertySource.test.ts
+++ b/packages/core/src/docx/paragraphPropertySource.test.ts
@@ -12,6 +12,7 @@ import {
   cloneDocumentWithParagraphPropertySources,
   cloneParagraphWithPropertySource,
   cloneParagraphWithoutPropertySource,
+  copyParagraphPropertyCapture,
   createParagraphPropertyTemplateStore,
   deriveDocumentWithParagraphPropertySources,
   getDocumentParagraphPropertySourceContract,
@@ -22,6 +23,12 @@ import {
 } from "./paragraphPropertySource";
 import {
   ParagraphPropertySourceContract,
+  PARAGRAPH_PROPERTY_SOURCE_MAX_CONTRACT_CODE_UNITS,
+  PARAGRAPH_PROPERTY_SOURCE_MAX_PARAGRAPHS,
+  PARAGRAPH_PROPERTY_SOURCE_MAX_STORIES,
+  PARAGRAPH_PROPERTY_SOURCE_MAX_STORY_IDENTIFIER_CODE_UNITS,
+  paragraphPropertySourceTokenWire,
+  ParagraphPropertySourceValidationError,
   ParagraphPropertySourceToken,
   ParagraphPropertyTransientTemplateHandle,
   ParagraphPropertyTransientTemplateStore,
@@ -39,10 +46,8 @@ const BLOCK_SDT_FIXTURE = new URL(
 const LAYOUT_DIGEST = "96aef5ba6161127dc9b85ec487101c934ca1bc93f63fbb8caa53dde196a5fd5b";
 const BLOCK_SDT_DIGEST = "2c4d3273683c5a7a059711c5d2a6ba2d040e914cb6b84d72fa809b7419b42e11";
 
-const token = (digest: string, story: ParagraphPropertySourceStory, ordinal: number) =>
-  ParagraphPropertySourceContract.fromDigest(digest)
-    .bindStoryCensus(story, ordinal + 1)
-    .tokenAt(ordinal).serialized;
+const token = (_digest: string, story: ParagraphPropertySourceStory, ordinal: number) =>
+  paragraphPropertySourceTokenWire(story, ordinal);
 
 const tokensIn = (content: BlockContent[]): string[] => {
   const tokens: string[] = [];
@@ -82,9 +87,15 @@ const firstParagraphIn = (content: BlockContent[]): Paragraph | undefined => {
 describe("paragraph-property source identity", () => {
   test("only canonical serialized values cross into frozen trusted identities", () => {
     const digest = "a".repeat(64);
-    const contract = ParagraphPropertySourceContract.fromDigest(digest);
     const story = { relationshipId: "rId:header/1", type: "header" } as const;
-    const sourceToken = contract.bindStoryCensus(story, 13).tokenAt(12);
+    const contract = ParagraphPropertySourceContract.fromSourceCensus(digest, [
+      { paragraphCount: 13, story },
+    ]);
+    const sourceTokenResult = contract.readToken(paragraphPropertySourceTokenWire(story, 12));
+    if (sourceTokenResult.status !== "valid") {
+      throw new Error("Canonical source token failed reification");
+    }
+    const sourceToken = sourceTokenResult.value;
 
     expect(Object.isFrozen(contract)).toBe(true);
     expect(Object.isFrozen(sourceToken)).toBe(true);
@@ -92,53 +103,174 @@ describe("paragraph-property source identity", () => {
       status: "valid",
       value: expect.any(ParagraphPropertySourceContract),
     });
-    expect(ParagraphPropertySourceContract.read(`folio-ppr-v2:${"A".repeat(64)}`)).toEqual({
-      raw: `folio-ppr-v2:${"A".repeat(64)}`,
+    expect(ParagraphPropertySourceContract.read(`folio-ppr-v3:${"A".repeat(64)}:[]`)).toEqual({
+      raw: `folio-ppr-v3:${"A".repeat(64)}:[]`,
       status: "invalid",
     });
     expect(contract.readToken(sourceToken.serialized)).toEqual({
       status: "valid",
       value: expect.any(ParagraphPropertySourceToken),
     });
-    expect(contract.readToken("p2s:bad:0")).toEqual({
-      raw: "p2s:bad:0",
+    expect(contract.readToken("p3s:bad:0")).toEqual({
+      raw: "p3s:bad:0",
       status: "invalid",
     });
+    expect(contract.readToken(paragraphPropertySourceTokenWire(story, 13)).status).toBe("invalid");
     expect(sourceToken.belongsTo(contract)).toBe(true);
     expect(sourceToken.belongsToStory({ relationshipId: "rId:header/1", type: "header" })).toBe(
       true,
     );
-    expect(
-      contract.readToken("p2s:header:%72Id%3Aheader%2F1:c").status,
-    ).toBe("invalid");
+    expect(contract.readToken("p3s:header:%72Id%3Aheader%2F1:c").status).toBe("invalid");
     expect(sourceToken.belongsToStory({ relationshipId: "other", type: "header" })).toBe(false);
+    const rereadContract = ParagraphPropertySourceContract.read(contract.serialized);
+    if (rereadContract.status !== "valid") {
+      throw new Error("Canonical source contract failed independent reification");
+    }
+    expect(rereadContract.value.serialized).toBe(contract.serialized);
+    expect(sourceToken.belongsTo(rereadContract.value)).toBe(false);
+    const rereadToken = rereadContract.value.readToken(sourceToken.serialized);
+    if (rereadToken.status !== "valid") {
+      throw new Error("Canonical source token failed independent contract reification");
+    }
+    expect(rereadToken.value.belongsTo(rereadContract.value)).toBe(true);
+    expect(rereadToken.value.belongsTo(contract)).toBe(false);
     expect(() =>
-      contract.bindStoryCensus({ relationshipId: "", type: "header" }, 1),
+      ParagraphPropertySourceContract.fromSourceCensus(digest, [
+        { paragraphCount: 1, story: { relationshipId: "", type: "header" } },
+      ]),
     ).toThrow();
     expect(() =>
-      contract.bindStoryCensus({ noteId: Number.NaN, type: "footnote" }, 1),
+      ParagraphPropertySourceContract.fromSourceCensus(digest, [
+        { paragraphCount: 1, story: { noteId: Number.NaN, type: "footnote" } },
+      ]),
     ).toThrow();
-    const collidingPrefixContract = ParagraphPropertySourceContract.fromDigest(
+    const collidingPrefixContract = ParagraphPropertySourceContract.fromSourceCensus(
       `${"a".repeat(32)}${"b".repeat(32)}`,
+      [{ paragraphCount: 13, story }],
     );
     expect(sourceToken.belongsTo(collidingPrefixContract)).toBe(false);
-    const sameLocalToken = collidingPrefixContract.bindStoryCensus(story, 13).tokenAt(12);
+    const sameLocalTokenResult = collidingPrefixContract.readToken(
+      paragraphPropertySourceTokenWire(story, 12),
+    );
+    if (sameLocalTokenResult.status !== "valid") {
+      throw new Error("Canonical colliding-prefix token failed reification");
+    }
+    const sameLocalToken = sameLocalTokenResult.value;
     expect(sameLocalToken.serialized).toBe(sourceToken.serialized);
     expect(sourceToken.belongsTo(collidingPrefixContract)).toBe(false);
     expect(sameLocalToken.belongsTo(contract)).toBe(false);
   });
 
   test("contract-local token construction and parsing agree over bounded story ordinals", () => {
-    const contract = ParagraphPropertySourceContract.fromDigest("b".repeat(64));
+    const story = { type: "document" } as const;
+    const contract = ParagraphPropertySourceContract.fromSourceCensus("b".repeat(64), [
+      { paragraphCount: 1025, story },
+    ]);
     for (const ordinal of [0, 1, 35, 36, 1024]) {
-      const sourceToken = contract.bindStoryCensus({ type: "document" }, ordinal + 1).tokenAt(ordinal);
-      const parsed = contract.readToken(sourceToken.serialized);
+      const parsed = contract.readToken(paragraphPropertySourceTokenWire(story, ordinal));
       expect(parsed.status).toBe("valid");
       if (parsed.status === "valid") {
         expect(parsed.value.ordinal).toBe(ordinal);
         expect(parsed.value.belongsTo(contract)).toBe(true);
       }
     }
+  });
+
+  test("serialized token parsing is bounded before story decoding or ordinal parsing", () => {
+    const contract = ParagraphPropertySourceContract.fromSourceCensus("b".repeat(64), [
+      { paragraphCount: 1, story: { type: "document" } },
+    ]);
+    const oversizedRelationshipId = "r".repeat(
+      PARAGRAPH_PROPERTY_SOURCE_MAX_STORY_IDENTIFIER_CODE_UNITS + 1,
+    );
+    const oversizedEncodedIdentifier = "%41".repeat(
+      PARAGRAPH_PROPERTY_SOURCE_MAX_STORY_IDENTIFIER_CODE_UNITS + 1,
+    );
+
+    expect(() =>
+      ParagraphPropertySourceContract.fromSourceCensus("b".repeat(64), [
+        { paragraphCount: 1, story: { relationshipId: oversizedRelationshipId, type: "header" } },
+      ]),
+    ).toThrow();
+    expect(contract.readToken(`p3s:header:${oversizedEncodedIdentifier}:0`).status).toBe("invalid");
+    expect(contract.readToken("p3s:document::10000").status).toBe("invalid");
+    expect(() =>
+      ParagraphPropertySourceContract.fromSourceCensus("b".repeat(64), [
+        {
+          paragraphCount: PARAGRAPH_PROPERTY_SOURCE_MAX_PARAGRAPHS + 1,
+          story: { type: "document" },
+        },
+      ]),
+    ).toThrow(ParagraphPropertySourceValidationError);
+  });
+
+  test("serialized contracts are canonical, census-bound, and length-bounded", () => {
+    const digest = "b".repeat(64);
+    const canonical = ParagraphPropertySourceContract.fromSourceCensus(digest, [
+      { paragraphCount: 2, story: { type: "document" } },
+      { paragraphCount: 1, story: { relationshipId: "rId1", type: "header" } },
+    ]);
+
+    expect(ParagraphPropertySourceContract.read(canonical.serialized).status).toBe("valid");
+    expect(
+      ParagraphPropertySourceContract.read(
+        `folio-ppr-v3:${digest}:[["header","rId1",1],["document","",2]]`,
+      ).status,
+    ).toBe("invalid");
+    expect(
+      ParagraphPropertySourceContract.read(
+        `folio-ppr-v3:${digest}:[["document","",1],["document","",1]]`,
+      ).status,
+    ).toBe("invalid");
+    expect(
+      ParagraphPropertySourceContract.read(
+        "x".repeat(PARAGRAPH_PROPERTY_SOURCE_MAX_CONTRACT_CODE_UNITS + 1),
+      ).status,
+    ).toBe("invalid");
+    expect(
+      canonical.readToken(paragraphPropertySourceTokenWire({ type: "document" }, 2)).status,
+    ).toBe("invalid");
+    expect(
+      canonical.readToken(
+        paragraphPropertySourceTokenWire({ relationshipId: "rId2", type: "header" }, 0),
+      ).status,
+    ).toBe("invalid");
+  });
+
+  test("document contract assignment bounds the complete story and paragraph census atomically", () => {
+    const tooManyParagraphs: Document = {
+      package: {
+        document: {
+          content: Array.from(
+            { length: PARAGRAPH_PROPERTY_SOURCE_MAX_PARAGRAPHS + 1 },
+            () => ({ content: [], type: "paragraph" }) satisfies Paragraph,
+          ),
+        },
+      },
+    };
+    expect(() =>
+      assignDocumentParagraphPropertySourceContract(tooManyParagraphs, "b".repeat(64)),
+    ).toThrow(ParagraphPropertySourceValidationError);
+    expect(getDocumentParagraphPropertySourceContract(tooManyParagraphs)).toBeUndefined();
+
+    const headers = new Map<
+      string,
+      NonNullable<Document["package"]["headers"]> extends Map<string, infer Header> ? Header : never
+    >();
+    for (let index = 0; index < PARAGRAPH_PROPERTY_SOURCE_MAX_STORIES; index += 1) {
+      headers.set(`r${index}`, {
+        content: [],
+        hdrFtrType: "default",
+        type: "header",
+      });
+    }
+    const tooManyStories: Document = {
+      package: { document: { content: [] }, headers },
+    };
+    expect(() =>
+      assignDocumentParagraphPropertySourceContract(tooManyStories, "c".repeat(64)),
+    ).toThrow(ParagraphPropertySourceValidationError);
+    expect(getDocumentParagraphPropertySourceContract(tooManyStories)).toBeUndefined();
   });
 
   test("the private contract follows immutable derivations without entering JSON", async () => {
@@ -152,7 +284,7 @@ describe("paragraph-property source identity", () => {
     expect(() => getDocumentParagraphPropertySourceContract(weakened)).toThrow();
     expect(getDocumentParagraphPropertySourceContract(derived)).toBe(contract);
     expect(JSON.stringify(derived)).not.toContain("paragraphPropertySourceContract");
-    expect(JSON.stringify(derived)).not.toContain("folio-ppr-v2");
+    expect(JSON.stringify(derived)).not.toContain("folio-ppr-v3");
   });
 
   test("the sanctioned structured clone explicitly transfers private source identity", async () => {
@@ -168,7 +300,9 @@ describe("paragraph-property source identity", () => {
       getDocumentParagraphPropertySourceContract(document),
     );
     expect(rawClonedParagraph && getParagraphPropertySource(rawClonedParagraph)).toBeUndefined();
-    expect(rawClonedParagraph && getParagraphPropertySourceToken(rawClonedParagraph)).toBeUndefined();
+    expect(
+      rawClonedParagraph && getParagraphPropertySourceToken(rawClonedParagraph),
+    ).toBeUndefined();
     expect(sourceParagraph && getParagraphPropertySource(sourceParagraph)).toEqual(
       clonedParagraph && getParagraphPropertySource(clonedParagraph),
     );
@@ -239,7 +373,7 @@ describe("paragraph-property source identity", () => {
     expect(Object.isFrozen(source)).toBe(true);
     expect(source && Object.isFrozen(source.fingerprint)).toBe(true);
     expect(source && Object.isFrozen(source.fingerprint.pPrBase)).toBe(true);
-    expect(JSON.stringify(derived)).not.toContain("p2s:");
+    expect(JSON.stringify(derived)).not.toContain("p3s:");
     expect(JSON.stringify(derived)).not.toContain("<w:pPr");
 
     const detached = cloneParagraphWithoutPropertySource(paragraph, {});
@@ -290,6 +424,48 @@ describe("paragraph-property source identity", () => {
     expect(handle).not.toBe(otherStore.registerAll([capture]).at(0));
   });
 
+  test("a template capture remains exact but outside the durable census on later saves", () => {
+    const imported: Paragraph = { content: [], type: "paragraph" };
+    assignAbsentParagraphPropertySource(imported);
+    const source: Document = { package: { document: { content: [imported] } } };
+    assignDocumentParagraphPropertySourceContract(source, "d".repeat(64));
+
+    const templateDerived: Paragraph = { content: [], type: "paragraph" };
+    copyParagraphPropertyCapture(templateDerived, imported);
+    const reused = deriveDocumentWithParagraphPropertySources(source, {
+      package: {
+        ...source.package,
+        document: {
+          ...source.package.document,
+          content: [imported, templateDerived],
+        },
+      },
+    });
+    const sourceStory = ParagraphPropertyStorySource.fromDocument(reused, {
+      type: "document",
+    });
+    const importedToken = getParagraphPropertySourceToken(imported);
+    if (!importedToken) {
+      throw new Error("Imported fixture lost its durable token");
+    }
+
+    expect(sourceStory.readToken(importedToken.serialized).serialized).toBe(
+      importedToken.serialized,
+    );
+    expect(getParagraphPropertySource(templateDerived)).toBe(getParagraphPropertySource(imported));
+    expect(getParagraphPropertySourceToken(templateDerived)).toBeUndefined();
+
+    const cloned = cloneDocumentWithParagraphPropertySources(reused);
+    expect(() =>
+      ParagraphPropertyStorySource.fromDocument(cloned, { type: "document" }),
+    ).not.toThrow();
+    const clonedTemplate = cloned.package.document.content.at(1);
+    expect(clonedTemplate?.type).toBe("paragraph");
+    expect(
+      clonedTemplate?.type === "paragraph" ? getParagraphPropertySource(clonedTemplate) : undefined,
+    ).toEqual(getParagraphPropertySource(imported));
+  });
+
   test("template capacity preflight is atomic", () => {
     const store = new ParagraphPropertyTransientTemplateStore(1);
 
@@ -305,15 +481,15 @@ describe("paragraph-property source identity", () => {
     registry.assertFullyConsumed();
   });
 
-  test("v2 traversal fixes body, text-box, and table ordinals across parse options", async () => {
+  test("v3 census fixes body, text-box, and table ordinals across parse options", async () => {
     const source = await readFile(LAYOUT_FIXTURE);
     const browser = await parseDocx(source, { preloadFonts: true });
     const materializer = await parseDocx(source, { preloadFonts: false });
     const browserTokens = tokensIn(browser.package.document.content);
     const materializerTokens = tokensIn(materializer.package.document.content);
 
-    expect(getDocumentParagraphPropertySourceContract(browser)?.serialized).toBe(
-      `folio-ppr-v2:${LAYOUT_DIGEST}`,
+    expect(getDocumentParagraphPropertySourceContract(browser)?.serialized).toStartWith(
+      `folio-ppr-v3:${LAYOUT_DIGEST}:`,
     );
     expect(browserTokens).toEqual(
       Array.from({ length: 41 }, (_, ordinal) =>
@@ -351,7 +527,7 @@ describe("paragraph-property source identity", () => {
     ).toBe(token(LAYOUT_DIGEST, { type: "document" }, 7));
   });
 
-  test("v2 traversal includes nested block content controls", async () => {
+  test("v3 census includes nested block content controls", async () => {
     const source = await readFile(BLOCK_SDT_FIXTURE);
     const document = await parseDocx(source, { preloadFonts: false });
     const paragraph = firstParagraphIn(document.package.document.content);
@@ -364,7 +540,7 @@ describe("paragraph-property source identity", () => {
     );
   });
 
-  test("v2 all-story ordinals ignore package map and note array order", () => {
+  test("v3 all-story ordinals ignore package map and note array order", () => {
     const paragraph = (text: string): Paragraph => ({
       type: "paragraph",
       content: [{ type: "run", content: [{ type: "text", text }] }],
@@ -473,20 +649,18 @@ describe("paragraph-property source identity", () => {
     };
 
     expect(makeDocument(true)).toEqual(makeDocument(false));
-    expect(makeDocument(false)).toEqual(
-      [
-        token("c".repeat(64), { type: "document" }, 0),
-        token("c".repeat(64), { relationshipId: "rIdA", type: "header" }, 0),
-        token("c".repeat(64), { relationshipId: "rIdB", type: "header" }, 0),
-        token("c".repeat(64), { relationshipId: "rIdC", type: "footer" }, 0),
-        token("c".repeat(64), { relationshipId: "rIdD", type: "footer" }, 0),
-        token("c".repeat(64), { noteId: 1, type: "footnote" }, 0),
-        token("c".repeat(64), { noteId: 2, type: "footnote" }, 0),
-        token("c".repeat(64), { noteId: 1, type: "endnote" }, 0),
-        token("c".repeat(64), { commentId: 1, type: "comment" }, 0),
-        token("c".repeat(64), { commentId: 2, type: "comment" }, 0),
-      ],
-    );
+    expect(makeDocument(false)).toEqual([
+      token("c".repeat(64), { type: "document" }, 0),
+      token("c".repeat(64), { relationshipId: "rIdA", type: "header" }, 0),
+      token("c".repeat(64), { relationshipId: "rIdB", type: "header" }, 0),
+      token("c".repeat(64), { relationshipId: "rIdC", type: "footer" }, 0),
+      token("c".repeat(64), { relationshipId: "rIdD", type: "footer" }, 0),
+      token("c".repeat(64), { noteId: 1, type: "footnote" }, 0),
+      token("c".repeat(64), { noteId: 2, type: "footnote" }, 0),
+      token("c".repeat(64), { noteId: 1, type: "endnote" }, 0),
+      token("c".repeat(64), { commentId: 1, type: "comment" }, 0),
+      token("c".repeat(64), { commentId: 2, type: "comment" }, 0),
+    ]);
   });
 
   test("contract assignment validates the whole story census before mutating provenance", () => {
@@ -496,9 +670,7 @@ describe("paragraph-property source identity", () => {
     const document: Document = {
       package: {
         document: { content: [body] },
-        headers: new Map([
-          ["z", { content: [lateHeader], hdrFtrType: "default", type: "header" }],
-        ]),
+        headers: new Map([["z", { content: [lateHeader], hdrFtrType: "default", type: "header" }]]),
       },
     };
 
@@ -526,9 +698,7 @@ describe("paragraph-property source identity", () => {
     const document: Document = {
       package: {
         document: { content: [body] },
-        headers: new Map([
-          ["z", { content: [lateHeader], hdrFtrType: "default", type: "header" }],
-        ]),
+        headers: new Map([["z", { content: [lateHeader], hdrFtrType: "default", type: "header" }]]),
       },
     };
 

--- a/packages/core/src/docx/paragraphPropertySource.test.ts
+++ b/packages/core/src/docx/paragraphPropertySource.test.ts
@@ -3,7 +3,7 @@ import { readFile } from "node:fs/promises";
 
 import type { BlockContent, Document, Paragraph } from "../types/document";
 import { parseDocx } from "./parser";
-import { paragraphPropertySourceFingerprintFromParts } from "./paragraphPropertyDescriptor";
+import { paragraphPropertySourceFingerprintFromParts } from "@stll/docx-core/model";
 import { serializeParagraph } from "./serializer/paragraphSerializer";
 import {
   assignAbsentParagraphPropertySource,

--- a/packages/core/src/docx/paragraphPropertySource.ts
+++ b/packages/core/src/docx/paragraphPropertySource.ts
@@ -9,7 +9,7 @@ import {
   paragraphPropertySourceFingerprintFromParts,
   type AuthoredParagraphProperties,
   type ParagraphPropertySourceFingerprint,
-} from "./paragraphPropertyDescriptor";
+} from "@stll/docx-core/model";
 import {
   ParagraphPropertySourceContract,
   ParagraphPropertySourceToken,

--- a/packages/core/src/docx/paragraphPropertySource.ts
+++ b/packages/core/src/docx/paragraphPropertySource.ts
@@ -1,111 +1,233 @@
-import { panic, TaggedError } from "better-result";
+import { panic } from "better-result";
 import type { Fragment, Mark, Node as PMNode, NodeType } from "prosemirror-model";
 import { PluginKey, type Transaction } from "prosemirror-state";
 
-import type { Document, Paragraph, TableCell } from "../types/document";
+import type { BlockContent, Document, Paragraph, TableCell } from "../types/document";
 import { visitDocxParagraphs } from "./paragraphTraversal";
+import {
+  canonicalParagraphPropertySourceFingerprintJson,
+  paragraphPropertySourceFingerprintFromParts,
+  type AuthoredParagraphProperties,
+  type ParagraphPropertySourceFingerprint,
+} from "./paragraphPropertyDescriptor";
+import {
+  ParagraphPropertySourceContract,
+  ParagraphPropertySourceToken,
+  ParagraphPropertyTransientTemplateResolution,
+  ParagraphPropertyTransientTemplateStore,
+  ParagraphPropertyTransientTemplateHandle,
+  ParagraphPropertySourceValidationError,
+  paragraphPropertySourceStoryKey,
+} from "./paragraphPropertySourceIdentity";
+import type {
+  ParagraphPropertySourceAttribute,
+  ParagraphPropertySourceStory,
+  ParagraphPropertySourceValidationCode,
+} from "./paragraphPropertySourceIdentity";
 
-type ParagraphPropertySource = {
+export {
+  PARAGRAPH_PROPERTY_SOURCE_VALIDATION_CODES,
+  ParagraphPropertySourceContract,
+  ParagraphPropertySourceToken,
+  ParagraphPropertyTransientTemplateHandle,
+  ParagraphPropertySourceValidationError,
+} from "./paragraphPropertySourceIdentity";
+export type {
+  ParagraphPropertySourceAttribute,
+  ParagraphPropertySourceStory,
+  ParagraphPropertySourceValidationCode,
+} from "./paragraphPropertySourceIdentity";
+
+export type ParagraphPropertySource = {
+  fingerprint: ParagraphPropertySourceFingerprint;
+  fingerprintJson: string;
+  type: "present";
   xml: string;
-  formattingJson: string;
 };
 
-const paragraphPropertySources = new WeakMap<Paragraph, ParagraphPropertySource>();
-const paragraphPropertySourceOwners = new WeakMap<Paragraph, Paragraph>();
-const proseParagraphSourceOwners = new WeakMap<PMNode, Paragraph>();
-const paragraphPropertySourceCandidates = new WeakMap<Paragraph, Paragraph>();
-const paragraphPropertySourceTransferIds = new WeakMap<Paragraph, string>();
-const paragraphPropertySourceTokens = new WeakMap<Paragraph, string>();
+type ParagraphPropertyCapture =
+  | { fingerprint: ParagraphPropertySourceFingerprint; fingerprintJson: string; type: "absent" }
+  | ParagraphPropertySource;
+
+type ParagraphPropertySourceBinding =
+  | { capture: ParagraphPropertyCapture; type: "captured-unbound" }
+  | { type: "editor-created" }
+  | {
+      capture: ParagraphPropertyCapture;
+      token: ParagraphPropertySourceToken;
+      type: "imported";
+    }
+  | { capture: ParagraphPropertyCapture; type: "resolved-template" };
+
 // Enumerable symbols follow ordinary immutable `{ ...document }` derivations,
 // while JSON and other string-key serialization cannot expose the contract.
 // `structuredClone` deliberately drops symbols, so the one sanctioned deep
 // clone path transfers this value explicitly below.
 const documentParagraphPropertySourceContract = Symbol("paragraphPropertySourceContract");
+// Enumerable so immutable `{ ...paragraph }` derivations retain the capture.
+// Symbols are excluded from JSON and OOXML serialization. Structured-clone
+// call sites must transfer this binding through the sanctioned helper below.
+const paragraphPropertySource = Symbol("paragraphPropertySource");
+
+const freezeDeep = (value: object): void => {
+  for (const key of Reflect.ownKeys(value)) {
+    const child = Reflect.get(value, key);
+    if (typeof child === "object" && child !== null && !Object.isFrozen(child)) {
+      freezeDeep(child);
+    }
+  }
+  Object.freeze(value);
+};
+
+const immutableFingerprint = (
+  fingerprint: ParagraphPropertySourceFingerprint,
+): ParagraphPropertySourceFingerprint => {
+  const cloned = structuredClone(fingerprint);
+  freezeDeep(cloned);
+  return cloned;
+};
+
+const isDeepFrozen = (value: object): boolean => {
+  if (!Object.isFrozen(value)) {
+    return false;
+  }
+  for (const key of Reflect.ownKeys(value)) {
+    const child = Reflect.get(value, key);
+    if (typeof child === "object" && child !== null && !isDeepFrozen(child)) {
+      return false;
+    }
+  }
+  return true;
+};
+
+const isParagraphPropertyCapture = (value: unknown): value is ParagraphPropertyCapture => {
+  if (typeof value !== "object" || value === null || !("type" in value)) {
+    return false;
+  }
+  if (value.type === "absent") {
+    return (
+      "fingerprint" in value &&
+      typeof value.fingerprint === "object" &&
+      value.fingerprint !== null &&
+      "fingerprintJson" in value &&
+      typeof value.fingerprintJson === "string" &&
+      isDeepFrozen(value.fingerprint) &&
+      canonicalParagraphPropertySourceFingerprintJson(value.fingerprint) ===
+        value.fingerprintJson &&
+      canonicalParagraphPropertySourceFingerprintJson(
+        paragraphPropertySourceFingerprintFromParts({}, {}),
+      ) === value.fingerprintJson &&
+      Object.isFrozen(value)
+    );
+  }
+  if (
+    value.type !== "present" ||
+    !("fingerprint" in value) ||
+    typeof value.fingerprint !== "object" ||
+    value.fingerprint === null ||
+    !("fingerprintJson" in value) ||
+    typeof value.fingerprintJson !== "string" ||
+    !("xml" in value) ||
+    typeof value.xml !== "string"
+  ) {
+    return false;
+  }
+  return (
+    Object.isFrozen(value) &&
+    isDeepFrozen(value.fingerprint) &&
+    canonicalParagraphPropertySourceFingerprintJson(value.fingerprint) === value.fingerprintJson
+  );
+};
+
+const isParagraphPropertySourceBinding = (
+  value: unknown,
+): value is ParagraphPropertySourceBinding => {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("type" in value) ||
+    !Object.isFrozen(value)
+  ) {
+    return false;
+  }
+  if (value.type === "editor-created") {
+    return Object.keys(value).length === 1;
+  }
+  if (!("capture" in value) || !isParagraphPropertyCapture(value.capture)) {
+    return false;
+  }
+  switch (value.type) {
+    case "captured-unbound":
+    case "resolved-template":
+      return true;
+    case "imported":
+      return "token" in value && value.token instanceof ParagraphPropertySourceToken;
+    default:
+      return false;
+  }
+};
 
 export const PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR = "_docxParagraphSourceToken";
 export const PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR = "_docxParagraphSourceContract";
 
-const PARAGRAPH_SOURCE_TOKEN_VERSION = "folio-ppr-v1";
-const PARAGRAPH_SOURCE_TOKEN_PREFIX = "p1d";
-const SHA256_HEX = /^[0-9a-f]{64}$/;
-const SOURCE_TOKEN = /^p1d:([0-9a-f]{32}):(0|[1-9a-z][0-9a-z]*)$/;
-
-export const PARAGRAPH_PROPERTY_SOURCE_VALIDATION_CODES = [
-  "contract_mismatch",
-  "duplicate_token",
-  "invalid_token",
-  "unknown_token",
-] as const;
-
-export type ParagraphPropertySourceValidationCode =
-  (typeof PARAGRAPH_PROPERTY_SOURCE_VALIDATION_CODES)[number];
-
-export class ParagraphPropertySourceValidationError extends TaggedError(
-  "ParagraphPropertySourceValidationError",
-)<{
-  code: ParagraphPropertySourceValidationCode;
-  message: string;
-  token?: unknown;
-}> {}
-
-const contractForDigest = (sourceDigest: string): string => {
-  if (!SHA256_HEX.test(sourceDigest)) {
-    panic("Paragraph-property source digest must be lowercase SHA-256 hex");
-  }
-  return `${PARAGRAPH_SOURCE_TOKEN_VERSION}:${sourceDigest}`;
-};
-
-const fingerprintFromContract = (contract: string): string | null => {
-  const prefix = `${PARAGRAPH_SOURCE_TOKEN_VERSION}:`;
-  const digest = contract.startsWith(prefix) ? contract.slice(prefix.length) : "";
-  return SHA256_HEX.test(digest) ? digest.slice(0, 32) : null;
-};
-
-const tokenForOrdinal = (contract: string, ordinal: number): string => {
-  const fingerprint = fingerprintFromContract(contract);
-  if (!fingerprint) {
-    panic("Cannot mint a paragraph-property token for an invalid source contract");
-  }
-  return `${PARAGRAPH_SOURCE_TOKEN_PREFIX}:${fingerprint}:${ordinal.toString(36)}`;
-};
-
-const setDocumentParagraphPropertySourceContract = (document: Document, contract: string): void => {
-  if (!fingerprintFromContract(contract)) {
-    panic("Cannot attach an invalid paragraph-property source contract");
-  }
+const setDocumentParagraphPropertySourceContract = (
+  document: Document,
+  contract: ParagraphPropertySourceContract,
+): void => {
   const existing = Object.hasOwn(document, documentParagraphPropertySourceContract)
     ? Reflect.get(document, documentParagraphPropertySourceContract)
     : undefined;
-  if (existing === contract) {
-    return;
-  }
   if (
     !Reflect.defineProperty(document, documentParagraphPropertySourceContract, {
+      configurable: false,
       enumerable: true,
       value: contract,
+      writable: false,
     })
   ) {
     panic("Cannot attach the paragraph-property source contract to the document");
   }
 };
 
-export const isParagraphPropertySourceToken = (token: unknown): token is string =>
-  typeof token === "string" && SOURCE_TOKEN.test(token);
-
-/** True only for a body-story token derived from the exact source contract. */
-export const paragraphPropertySourceTokenMatchesContract = (
-  token: unknown,
-  contract: string,
-): token is string => {
-  if (!isParagraphPropertySourceToken(token)) {
-    return false;
+const paragraphPropertySourceBinding = (
+  paragraph: Paragraph,
+): ParagraphPropertySourceBinding | undefined => {
+  if (!Object.hasOwn(paragraph, paragraphPropertySource)) {
+    return undefined;
   }
-  const match = SOURCE_TOKEN.exec(token);
-  const fingerprint = fingerprintFromContract(contract);
-  return match !== null && fingerprint !== null && match[1] === fingerprint;
+  const binding = Reflect.get(paragraph, paragraphPropertySource);
+  if (!isParagraphPropertySourceBinding(binding)) {
+    panic("A paragraph carries an invalid paragraph-property source binding");
+  }
+  const descriptor = Object.getOwnPropertyDescriptor(paragraph, paragraphPropertySource);
+  if (
+    !descriptor ||
+    descriptor.enumerable !== true ||
+    descriptor.writable === true ||
+    descriptor.configurable !== (binding.type === "captured-unbound")
+  ) {
+    panic("A paragraph carries a weakened paragraph-property source binding");
+  }
+  return binding;
 };
 
-/** Visit the v1 provenance scope in canonical OOXML body-story order. */
+const setParagraphPropertySourceBinding = (
+  paragraph: Paragraph,
+  binding: ParagraphPropertySourceBinding,
+): void => {
+  if (
+    !Reflect.defineProperty(paragraph, paragraphPropertySource, {
+      configurable: binding.type === "captured-unbound",
+      enumerable: true,
+      value: Object.freeze(binding),
+      writable: false,
+    })
+  ) {
+    panic("Cannot attach paragraph-property source provenance to a paragraph");
+  }
+};
+
+/** Visit one story in canonical OOXML paragraph order. */
 export const visitDocumentStoryParagraphs = (
   content: Document["package"]["document"]["content"],
   visit: (paragraph: Paragraph) => void,
@@ -115,79 +237,329 @@ export const visitDocumentStoryParagraphs = (
 
 export const assignParagraphPropertySource = (
   paragraph: Paragraph,
-  source: ParagraphPropertySource,
+  source: { fingerprint: ParagraphPropertySourceFingerprint; xml: string },
 ): void => {
-  paragraphPropertySources.set(paragraph, source);
-  paragraphPropertySourceOwners.set(paragraph, paragraph);
+  const existing = paragraphPropertySourceBinding(paragraph);
+  const fingerprint = immutableFingerprint(source.fingerprint);
+  const capture = Object.freeze({
+    fingerprint,
+    fingerprintJson: canonicalParagraphPropertySourceFingerprintJson(fingerprint),
+    type: "present",
+    xml: source.xml,
+  }) satisfies ParagraphPropertyCapture;
+  switch (existing?.type) {
+    case undefined:
+      setParagraphPropertySourceBinding(paragraph, {
+        capture,
+        type: "captured-unbound",
+      });
+      return;
+    case "captured-unbound":
+    case "editor-created":
+    case "imported":
+    case "resolved-template":
+      panic("A paragraph-property capture can only be assigned once");
+      return;
+    default: {
+      const exhaustive: never = existing;
+      return exhaustive;
+    }
+  }
+};
+
+/** Record that a parsed paragraph had no authored `w:pPr` element. */
+export const assignAbsentParagraphPropertySource = (paragraph: Paragraph): void => {
+  if (paragraphPropertySourceBinding(paragraph)) {
+    panic("A paragraph-property capture can only be assigned once");
+  }
+  const fingerprint = immutableFingerprint(
+    paragraphPropertySourceFingerprintFromParts({}, {}),
+  );
+  setParagraphPropertySourceBinding(paragraph, {
+    capture: Object.freeze({
+      fingerprint,
+      fingerprintJson: canonicalParagraphPropertySourceFingerprintJson(fingerprint),
+      type: "absent",
+    }),
+    type: "captured-unbound",
+  });
 };
 
 export const getParagraphPropertySource = (
   paragraph: Paragraph,
-): ParagraphPropertySource | undefined => paragraphPropertySources.get(paragraph);
+): ParagraphPropertySource | undefined => {
+  const binding = paragraphPropertySourceBinding(paragraph);
+  if (!binding || binding.type === "editor-created" || binding.capture.type === "absent") {
+    return undefined;
+  }
+  return binding.capture;
+};
+
+/** Authored `w:pPr` before style and numbering defaults are materialized. */
+export const getParagraphAuthoredPPr = (
+  paragraph: Paragraph,
+): AuthoredParagraphProperties | undefined => {
+  const binding = paragraphPropertySourceBinding(paragraph);
+  if (!binding || binding.type === "editor-created") {
+    return undefined;
+  }
+  return structuredClone(binding.capture.fingerprint.pPrBase);
+};
+
+/** Exact modeled properties captured from the paragraph's authored `w:pPr`. */
+export const getParagraphPropertySourceFingerprint = (
+  paragraph: Paragraph,
+): ParagraphPropertySourceFingerprint | undefined => {
+  const binding = paragraphPropertySourceBinding(paragraph);
+  return binding && binding.type !== "editor-created" ? binding.capture.fingerprint : undefined;
+};
+
+/** Mark a model paragraph as deliberately created outside the parsed source census. */
+export const assignEditorCreatedParagraphPropertySource = (paragraph: Paragraph): void => {
+  if (paragraphPropertySourceBinding(paragraph)) {
+    panic("Paragraph-property provenance can only be assigned once");
+  }
+  setParagraphPropertySourceBinding(paragraph, { type: "editor-created" });
+};
+
+const tokenFromBinding = (
+  binding: ParagraphPropertySourceBinding | undefined,
+): ParagraphPropertySourceToken | null => {
+  switch (binding?.type) {
+    case "imported":
+      return binding.token;
+    case "captured-unbound":
+    case "editor-created":
+    case "resolved-template":
+    case undefined:
+      return null;
+    default: {
+      const exhaustive: never = binding;
+      return exhaustive;
+    }
+  }
+};
 
 /** Copy the captured `w:pPr` without claiming the source paragraph's durable identity. */
 export const copyParagraphPropertyCapture = (target: Paragraph, source: Paragraph): void => {
-  const propertySource = paragraphPropertySources.get(source);
-  if (propertySource) {
-    paragraphPropertySources.set(target, { ...propertySource });
-    paragraphPropertySourceOwners.set(target, paragraphPropertySourceOwners.get(source) ?? source);
+  const sourceBinding = paragraphPropertySourceBinding(source);
+  if (!sourceBinding || sourceBinding.type === "editor-created") {
+    return;
   }
+  setParagraphPropertySourceBinding(target, {
+    capture: sourceBinding.capture,
+    type: "resolved-template",
+  });
 };
+
+export const PARAGRAPH_PROPERTY_TEMPLATE_STORE_MAX_CAPTURES = 100_000;
+
+const paragraphPropertyTemplateCaptureIssuer = Symbol("paragraphPropertyTemplateCaptureIssuer");
+type ParagraphPropertyTemplateCaptureIssuer = typeof paragraphPropertyTemplateCaptureIssuer;
+
+/** Immutable authority to transfer one parsed capture without exposing its paragraph owner. */
+export class ParagraphPropertyTemplateCapture {
+  readonly #capture: ParagraphPropertyCapture;
+
+  constructor(issuer: ParagraphPropertyTemplateCaptureIssuer, capture: ParagraphPropertyCapture) {
+    if (issuer !== paragraphPropertyTemplateCaptureIssuer) {
+      panic("Only a bound paragraph story may issue template capture capabilities");
+    }
+    this.#capture = capture;
+    Object.freeze(this);
+  }
+
+  capture(issuer: ParagraphPropertyTemplateCaptureIssuer): ParagraphPropertyCapture {
+    if (issuer !== paragraphPropertyTemplateCaptureIssuer) {
+      return panic("Only the paragraph-property source kernel may resolve a template capture");
+    }
+    return this.#capture;
+  }
+}
+
+export class ParagraphPropertyTemplateResolutionRegistry {
+  readonly #resolution: ParagraphPropertyTransientTemplateResolution<ParagraphPropertyCapture>;
+
+  constructor(
+    issuer: ParagraphPropertyTemplateCaptureIssuer,
+    resolution: ParagraphPropertyTransientTemplateResolution<ParagraphPropertyCapture>,
+  ) {
+    if (issuer !== paragraphPropertyTemplateCaptureIssuer) {
+      panic("Only a paragraph-property template store may create a resolution registry");
+    }
+    this.#resolution = resolution;
+    Object.freeze(this);
+  }
+
+  assertFullyConsumed(): void {
+    this.#resolution.assertFullyConsumed();
+  }
+
+  consume(handle: ParagraphPropertyTransientTemplateHandle, target: Paragraph): void {
+    if (paragraphPropertySourceBinding(target)) {
+      panic("A paragraph-property template target already has source provenance");
+    }
+    const capture = this.#resolution.consume(handle);
+    setParagraphPropertySourceBinding(target, { capture, type: "resolved-template" });
+  }
+}
+
+/** Bounded session owner for opaque captures retained by edit and undo history. */
+export class ParagraphPropertyTemplateStore {
+  readonly #store = new ParagraphPropertyTransientTemplateStore<ParagraphPropertyCapture>(
+    PARAGRAPH_PROPERTY_TEMPLATE_STORE_MAX_CAPTURES,
+  );
+
+  beginResolution(
+    handles: readonly ParagraphPropertyTransientTemplateHandle[],
+  ): ParagraphPropertyTemplateResolutionRegistry {
+    return new ParagraphPropertyTemplateResolutionRegistry(
+      paragraphPropertyTemplateCaptureIssuer,
+      this.#store.beginResolution(handles),
+    );
+  }
+
+  registerAll(
+    capabilities: readonly ParagraphPropertyTemplateCapture[],
+  ): readonly ParagraphPropertyTransientTemplateHandle[] {
+    return this.#store.registerAll(
+      capabilities.map((capability) =>
+        capability.capture(paragraphPropertyTemplateCaptureIssuer),
+      ),
+    );
+  }
+}
+
+export const createParagraphPropertyTemplateStore = (): ParagraphPropertyTemplateStore =>
+  new ParagraphPropertyTemplateStore();
 
 export const copyParagraphPropertySource = (target: Paragraph, source: Paragraph): void => {
-  copyParagraphPropertyCapture(target, source);
-  const transferId = paragraphPropertySourceTransferIds.get(source);
-  if (transferId) {
-    paragraphPropertySourceTransferIds.set(target, transferId);
+  const binding = paragraphPropertySourceBinding(source);
+  if (!binding) {
+    return;
   }
-  const candidate = paragraphPropertySourceCandidates.get(source);
-  if (candidate) {
-    paragraphPropertySourceCandidates.set(target, candidate);
-  }
-  const token = paragraphPropertySourceTokens.get(source);
-  if (token) {
-    paragraphPropertySourceTokens.set(target, token);
+  switch (binding.type) {
+    case "imported":
+      setParagraphPropertySourceBinding(target, binding);
+      return;
+    case "captured-unbound":
+      setParagraphPropertySourceBinding(target, binding);
+      return;
+    case "editor-created":
+      setParagraphPropertySourceBinding(target, binding);
+      return;
+    case "resolved-template":
+      setParagraphPropertySourceBinding(target, binding);
+      return;
+    default: {
+      const exhaustive: never = binding;
+      return exhaustive;
+    }
   }
 };
 
-/** Bind parsed body paragraphs to one exact source package. */
+/** Bind every parsed story paragraph to one exact source package. */
 export const assignDocumentParagraphPropertySourceContract = (
   document: Document,
   sourceDigest: string,
 ): void => {
-  const contract = contractForDigest(sourceDigest);
-  setDocumentParagraphPropertySourceContract(document, contract);
-  let ordinal = 0;
-  // The traversal is part of the v1 durable identity contract. Any ordering
+  if (Object.hasOwn(document, documentParagraphPropertySourceContract)) {
+    panic("A document paragraph-property source contract can only be assigned once");
+  }
+  const contract = ParagraphPropertySourceContract.fromDigest(sourceDigest);
+  const seenStories = new Set<string>();
+  const seenParagraphs = new WeakSet<Paragraph>();
+  const bodyParagraphs = new WeakSet<Paragraph>();
+  const census: {
+    capture: ParagraphPropertyCapture;
+    paragraph: Paragraph;
+    token: ParagraphPropertySourceToken;
+  }[] = [];
+  if (!Object.isExtensible(document)) {
+    panic("A document must be extensible before binding paragraph-property provenance");
+  }
+  // The traversal is part of the v2 durable identity contract. Any ordering
   // change requires a token-version bump and collaboration reseed.
-  visitDocumentStoryParagraphs(document.package.document.content, (paragraph) => {
-    paragraphPropertySourceTokens.set(paragraph, tokenForOrdinal(contract, ordinal));
-    ordinal += 1;
-  });
+  for (const { content, story } of documentSourceStories(document)) {
+    const storyKey = paragraphPropertySourceStoryKey(story);
+    if (seenStories.has(storyKey)) {
+      panic("A document contains duplicate paragraph-property story identity", { storyKey });
+    }
+    seenStories.add(storyKey);
+    const paragraphs: Paragraph[] = [];
+    visitDocumentStoryParagraphs(content, (paragraph) => paragraphs.push(paragraph));
+    const tokenCensus = contract.bindStoryCensus(story, paragraphs.length);
+    for (const [ordinal, paragraph] of paragraphs.entries()) {
+      if (seenParagraphs.has(paragraph)) {
+        panic("A paragraph cannot belong to more than one source story", { storyKey });
+      }
+      seenParagraphs.add(paragraph);
+      if (story.type === "document") {
+        bodyParagraphs.add(paragraph);
+      }
+      const binding = paragraphPropertySourceBinding(paragraph);
+      if (binding?.type !== "captured-unbound") {
+        panic("A document paragraph must have exactly one parsed property capture before binding");
+      }
+      const descriptor = Object.getOwnPropertyDescriptor(paragraph, paragraphPropertySource);
+      if (!descriptor?.configurable) {
+        panic("A parsed paragraph capture cannot transition to its durable source identity");
+      }
+      census.push({ capture: binding.capture, paragraph, token: tokenCensus.tokenAt(ordinal) });
+    }
+  }
+  for (const section of document.package.document.sections ?? []) {
+    visitDocumentStoryParagraphs(section.content, (paragraph) => {
+      if (!bodyParagraphs.has(paragraph)) {
+        panic("A derived document section must alias paragraphs from the body story");
+      }
+    });
+  }
+
+  setDocumentParagraphPropertySourceContract(document, contract);
+  for (const { capture, paragraph, token } of census) {
+    setParagraphPropertySourceBinding(paragraph, {
+      capture,
+      token,
+      type: "imported",
+    });
+  }
 };
 
 export const getDocumentParagraphPropertySourceContract = (
   document: Document,
-): string | undefined => {
+): ParagraphPropertySourceContract | undefined => {
   if (!Object.hasOwn(document, documentParagraphPropertySourceContract)) {
     return undefined;
   }
   const contract = Reflect.get(document, documentParagraphPropertySourceContract);
-  if (typeof contract !== "string" || !fingerprintFromContract(contract)) {
+  if (!(contract instanceof ParagraphPropertySourceContract)) {
     panic("The document carries an invalid paragraph-property source contract");
+  }
+  const descriptor = Object.getOwnPropertyDescriptor(
+    document,
+    documentParagraphPropertySourceContract,
+  );
+  if (
+    !descriptor ||
+    descriptor.enumerable !== true ||
+    descriptor.writable === true ||
+    descriptor.configurable === true
+  ) {
+    panic("The document carries a weakened paragraph-property source contract");
   }
   return contract;
 };
 
-export const getProseDocumentParagraphPropertySourceContract = (
+export const readProseDocumentParagraphPropertySourceContract = (
   document: PMNode,
-): string | null => {
-  const contract = document.attrs[PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR];
-  return typeof contract === "string" && fingerprintFromContract(contract) ? contract : null;
-};
+): ParagraphPropertySourceAttribute<ParagraphPropertySourceContract> =>
+  ParagraphPropertySourceContract.read(document.attrs[PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR]);
 
-export const getProseParagraphPropertySourceToken = (paragraph: PMNode): unknown =>
-  paragraph.attrs[PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR];
+export const readProseParagraphPropertySourceToken = (
+  paragraph: PMNode,
+): ParagraphPropertySourceAttribute<ParagraphPropertySourceToken> =>
+  ParagraphPropertySourceToken.read(paragraph.attrs[PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR]);
 
 export const copyDocumentParagraphPropertySourceContract = (
   target: Document,
@@ -199,8 +571,167 @@ export const copyDocumentParagraphPropertySourceContract = (
   }
 };
 
-export const getParagraphPropertySourceToken = (paragraph: Paragraph): string | undefined =>
-  paragraphPropertySourceTokens.get(paragraph);
+type DocumentDerivationOverrides = Partial<Document>;
+
+/** Shallow document derivation that re-hardens its private source contract. */
+export const deriveDocumentWithParagraphPropertySources = (
+  document: Document,
+  overrides: DocumentDerivationOverrides,
+): Document => {
+  const derived: Document = { ...document, ...overrides };
+  copyDocumentParagraphPropertySourceContract(derived, document);
+  return derived;
+};
+
+export const getParagraphPropertySourceToken = (
+  paragraph: Paragraph,
+): ParagraphPropertySourceToken | undefined => tokenFromBinding(paragraphPropertySourceBinding(paragraph)) ?? undefined;
+
+const indexParagraphPropertySources = (
+  content: BlockContent[],
+  story: ParagraphPropertySourceStory,
+  contract: ParagraphPropertySourceContract,
+): ReadonlyMap<string, ParagraphPropertyTemplateCapture> => {
+  const sources = new Map<string, ParagraphPropertyTemplateCapture>();
+  visitDocumentStoryParagraphs(content, (paragraph) => {
+    const binding = paragraphPropertySourceBinding(paragraph);
+    if (binding?.type === "editor-created") {
+      return;
+    }
+    const token = getParagraphPropertySourceToken(paragraph);
+    if (!token || !token.belongsToStory(story) || !contract.owns(token)) {
+      throw new ParagraphPropertySourceValidationError({
+        code: "invalid_token",
+        message: "The source story contains an invalid paragraph-property token.",
+        token,
+      });
+    }
+    if (sources.has(token.serialized)) {
+      throw new ParagraphPropertySourceValidationError({
+        code: "duplicate_token",
+        message: "The source story contains a duplicate paragraph-property token.",
+        token: token.serialized,
+      });
+    }
+    const capture = binding?.type === "imported" ? binding.capture : undefined;
+    if (!capture) {
+      panic("A validated imported paragraph lost its source capture");
+    }
+    sources.set(
+      token.serialized,
+      new ParagraphPropertyTemplateCapture(paragraphPropertyTemplateCaptureIssuer, capture),
+    );
+  });
+  return sources;
+};
+
+/** Bound source story whose content, identity, and package contract cannot diverge. */
+export class ParagraphPropertyStorySource {
+  readonly #contract: ParagraphPropertySourceContract;
+  readonly #captures: ReadonlyMap<string, ParagraphPropertyTemplateCapture>;
+  readonly #story: ParagraphPropertySourceStory;
+
+  private constructor(
+    contract: ParagraphPropertySourceContract,
+    story: ParagraphPropertySourceStory,
+    captures: ReadonlyMap<string, ParagraphPropertyTemplateCapture>,
+  ) {
+    this.#contract = contract;
+    this.#story = story;
+    this.#captures = captures;
+    Object.freeze(this);
+  }
+
+  static fromDocument(
+    document: Document,
+    requestedStory: ParagraphPropertySourceStory,
+  ): ParagraphPropertyStorySource {
+    const contract = getDocumentParagraphPropertySourceContract(document);
+    if (!contract) {
+      throw new ParagraphPropertySourceValidationError({
+        code: "contract_mismatch",
+        message: "A paragraph-property story source requires a bound document contract.",
+      });
+    }
+    const requestedKey = paragraphPropertySourceStoryKey(requestedStory);
+    const matches = documentSourceStories(document).filter(
+      ({ story }) => paragraphPropertySourceStoryKey(story) === requestedKey,
+    );
+    if (matches.length !== 1) {
+      throw new ParagraphPropertySourceValidationError({
+        code: "ambiguous_source",
+        message: "The document does not contain exactly one requested paragraph-property story.",
+      });
+    }
+    const match = matches.at(0);
+    if (!match) {
+      return panic("A unique paragraph-property story match disappeared");
+    }
+    return new ParagraphPropertyStorySource(
+      contract,
+      match.story,
+      indexParagraphPropertySources(match.content, match.story, contract),
+    );
+  }
+
+  owns(token: ParagraphPropertySourceToken): boolean {
+    return (
+      this.#contract.owns(token) &&
+      token.belongsToStory(this.#story) &&
+      this.#captures.has(token.serialized)
+    );
+  }
+
+  readToken(raw: unknown): ParagraphPropertySourceToken {
+    const token = this.#contract.readToken(raw);
+    if (token.status !== "valid") {
+      throw new ParagraphPropertySourceValidationError({
+        code: "invalid_token",
+        message: "A paragraph-property source token is malformed.",
+        token: token.status === "invalid" ? token.raw : raw,
+      });
+    }
+    if (!this.owns(token.value)) {
+      throw new ParagraphPropertySourceValidationError({
+        code: "unknown_token",
+        message: "A paragraph-property source token is not owned by this story.",
+        token: token.value.serialized,
+      });
+    }
+    return token.value;
+  }
+
+  bindImportedParagraph(target: Paragraph, token: ParagraphPropertySourceToken): void {
+    if (paragraphPropertySourceBinding(target)) {
+      panic("An imported paragraph target already has source provenance");
+    }
+    const capability = this.owns(token) ? this.#captures.get(token.serialized) : undefined;
+    if (!capability) {
+      throw new ParagraphPropertySourceValidationError({
+        code: "unknown_token",
+        message: "A paragraph-property token is not owned by this source story.",
+        token: token.serialized,
+      });
+    }
+    setParagraphPropertySourceBinding(target, {
+      capture: capability.capture(paragraphPropertyTemplateCaptureIssuer),
+      token,
+      type: "imported",
+    });
+  }
+
+  templateCapture(token: ParagraphPropertySourceToken): ParagraphPropertyTemplateCapture {
+    const capability = this.owns(token) ? this.#captures.get(token.serialized) : undefined;
+    if (!capability) {
+      throw new ParagraphPropertySourceValidationError({
+        code: "unknown_token",
+        message: "A paragraph-property token is not owned by this source story.",
+        token: token.serialized,
+      });
+    }
+    return capability;
+  }
+}
 
 type ParagraphCloneOverrides = Omit<Partial<Paragraph>, "type">;
 
@@ -218,20 +749,78 @@ export const cloneParagraphWithPropertySource = (
 export const cloneParagraphWithoutPropertySource = (
   paragraph: Paragraph,
   overrides: ParagraphCloneOverrides,
-): Paragraph => ({ ...paragraph, ...overrides });
+): Paragraph => {
+  const cloned: Paragraph = { ...paragraph, ...overrides };
+  if (!Reflect.deleteProperty(cloned, paragraphPropertySource)) {
+    panic("Cannot detach paragraph-property source provenance from a paragraph clone");
+  }
+  return cloned;
+};
+
+type DocumentSourceStory = {
+  content: Document["package"]["document"]["content"];
+  story: ParagraphPropertySourceStory;
+};
+
+const compareCanonicalStoryKeys = (left: string, right: string): number => {
+  if (left < right) {
+    return -1;
+  }
+  return left > right ? 1 : 0;
+};
+
+const documentSourceStories = (document: Document): DocumentSourceStory[] => {
+  const stories: DocumentSourceStory[] = [
+    { content: document.package.document.content, story: Object.freeze({ type: "document" }) },
+  ];
+  for (const [relationshipId, story] of [...(document.package.headers ?? [])].toSorted(
+    ([left], [right]) => compareCanonicalStoryKeys(left, right),
+  )) {
+    stories.push({
+      content: story.content,
+      story: Object.freeze({ relationshipId, type: "header" }),
+    });
+  }
+  for (const [relationshipId, story] of [...(document.package.footers ?? [])].toSorted(
+    ([left], [right]) => compareCanonicalStoryKeys(left, right),
+  )) {
+    stories.push({
+      content: story.content,
+      story: Object.freeze({ relationshipId, type: "footer" }),
+    });
+  }
+  for (const story of [...(document.package.footnotes ?? [])].toSorted(
+    (left, right) => left.id - right.id,
+  )) {
+    stories.push({
+      content: story.content,
+      story: Object.freeze({ noteId: story.id, type: "footnote" }),
+    });
+  }
+  for (const story of [...(document.package.endnotes ?? [])].toSorted(
+    (left, right) => left.id - right.id,
+  )) {
+    stories.push({
+      content: story.content,
+      story: Object.freeze({ noteId: story.id, type: "endnote" }),
+    });
+  }
+  for (const comment of [...(document.package.document.comments ?? [])].toSorted(
+    (left, right) => left.id - right.id,
+  )) {
+    stories.push({
+      content: comment.content,
+      story: Object.freeze({ commentId: comment.id, type: "comment" }),
+    });
+  }
+  return stories;
+};
 
 const paragraphsIn = (document: Document): Paragraph[] => {
   const paragraphs: Paragraph[] = [];
-  visitDocxParagraphs(
-    {
-      documentBody: document.package.document,
-      headers: document.package.headers,
-      footers: document.package.footers,
-      footnotes: document.package.footnotes,
-      endnotes: document.package.endnotes,
-    },
-    (paragraph) => paragraphs.push(paragraph),
-  );
+  for (const { content } of documentSourceStories(document)) {
+    visitDocumentStoryParagraphs(content, (paragraph) => paragraphs.push(paragraph));
+  }
   return paragraphs;
 };
 
@@ -289,18 +878,6 @@ export const cloneTableCellsWithParagraphPropertyCaptures = (cells: TableCell[])
   return cloned;
 };
 
-export const linkProseParagraphPropertySource = (
-  proseParagraph: PMNode,
-  sourceParagraph: Paragraph,
-): void => {
-  if (paragraphPropertySources.has(sourceParagraph)) {
-    proseParagraphSourceOwners.set(
-      proseParagraph,
-      paragraphPropertySourceOwners.get(sourceParagraph) ?? sourceParagraph,
-    );
-  }
-};
-
 type CreateProseParagraphOptions = {
   attrs?: PMNode["attrs"];
   content?: Fragment | PMNode | readonly PMNode[] | null;
@@ -316,17 +893,15 @@ export const createProseParagraphWithPropertySource = (
   if (!nodeType || nodeType.name !== "paragraph") {
     panic("Paragraph-property provenance can only seed a paragraph node");
   }
-  const paragraph = nodeType.create(
+  return nodeType.create(
     {
       ...options.attrs,
       [PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR]:
-        paragraphPropertySourceTokens.get(sourceParagraph) ?? null,
+        getParagraphPropertySourceToken(sourceParagraph)?.serialized ?? null,
     },
     options.content,
     options.marks,
   );
-  linkProseParagraphPropertySource(paragraph, sourceParagraph);
-  return paragraph;
 };
 
 type ParagraphPropertySourceTransfer = {
@@ -356,8 +931,15 @@ export const joinProseParagraphsWithRightPropertySource = ({
   if (!left || !right || left.type.name !== "paragraph" || right.type.name !== "paragraph") {
     panic("Paragraph-property ownership can only join adjacent paragraphs");
   }
-  const leftToken = getProseParagraphPropertySourceToken(left);
-  const rightToken = getProseParagraphPropertySourceToken(right);
+  const leftToken = readProseParagraphPropertySourceToken(left);
+  const rightToken = readProseParagraphPropertySourceToken(right);
+  if (leftToken.status === "invalid" || rightToken.status === "invalid") {
+    throw new ParagraphPropertySourceValidationError({
+      code: "invalid_token",
+      message: "Cannot join a paragraph carrying a malformed paragraph-property token.",
+      token: leftToken.status === "invalid" ? leftToken.raw : rightToken.raw,
+    });
+  }
   const leftPos = pos - left.nodeSize;
   transaction.join(pos);
   const joined = transaction.doc.nodeAt(leftPos);
@@ -367,15 +949,19 @@ export const joinProseParagraphsWithRightPropertySource = ({
   transaction.setNodeMarkup(
     leftPos,
     undefined,
-    { ...attrs, [PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR]: rightToken ?? null },
+    {
+      ...attrs,
+      [PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR]:
+        rightToken.status === "valid" ? rightToken.value.serialized : null,
+    },
     joined.marks,
   );
   const transfers = transaction.getMeta(paragraphPropertySourceTransfersKey) ?? [];
   transaction.setMeta(paragraphPropertySourceTransfersKey, [
     ...transfers,
     {
-      displacedToken: typeof leftToken === "string" ? leftToken : null,
-      selectedToken: typeof rightToken === "string" ? rightToken : null,
+      displacedToken: leftToken.status === "valid" ? leftToken.value.serialized : null,
+      selectedToken: rightToken.status === "valid" ? rightToken.value.serialized : null,
     },
   ]);
   return transaction;
@@ -385,17 +971,6 @@ export const getExplicitParagraphPropertySourceTransfers = (
   transaction: Transaction,
 ): readonly ParagraphPropertySourceTransfer[] =>
   transaction.getMeta(paragraphPropertySourceTransfersKey) ?? [];
-
-/** Carry a parser-linked paragraph owner across an immutable PM node rebuild. */
-const copyProseParagraphPropertySource = (target: PMNode, source: PMNode): void => {
-  if (target.type.name !== "paragraph" || source.type.name !== "paragraph") {
-    return;
-  }
-  const sourceOwner = proseParagraphSourceOwners.get(source);
-  if (sourceOwner) {
-    proseParagraphSourceOwners.set(target, sourceOwner);
-  }
-};
 
 type RecreateProseNodeOptions = {
   attrs?: PMNode["attrs"];
@@ -408,13 +983,11 @@ export const recreateProseNodeWithParagraphPropertySource = (
   source: PMNode,
   options: RecreateProseNodeOptions = {},
 ): PMNode => {
-  const target = source.type.create(
+  return source.type.create(
     options.attrs ?? source.attrs,
     options.content === undefined ? source.content : options.content,
     options.marks ?? source.marks,
   );
-  copyProseParagraphPropertySource(target, source);
-  return target;
 };
 
 /**
@@ -443,60 +1016,9 @@ type SetProseParagraphMarkupOptions = {
   transaction: Transaction;
 };
 
-/** Replace paragraph markup without losing its private parser-owner link. */
+/** Replace paragraph markup while retaining the caller's explicit attrs. */
 export const setProseParagraphMarkupWithPropertySource = ({
   attrs,
-  ownership,
   pos,
   transaction,
-}: SetProseParagraphMarkupOptions): void => {
-  const source = transaction.doc.nodeAt(pos);
-  transaction.setNodeMarkup(pos, undefined, attrs);
-  const target = transaction.doc.nodeAt(pos);
-  if (!source || !target) {
-    return;
-  }
-  if (ownership === "preserve") {
-    copyProseParagraphPropertySource(target, source);
-    return;
-  }
-  const paraId = target.attrs["paraId"];
-  if (typeof paraId === "string") {
-    transferProseParagraphPropertySource(target, source, paraId);
-  }
-};
-
-/**
- * Carry the parser-owned source identity across load-time paraId allocation.
- * The generated id is safe to use later because it was assigned while the
- * ProseMirror node still had an unambiguous source paragraph owner.
- */
-export const transferProseParagraphPropertySource = (
-  target: PMNode,
-  source: PMNode,
-  paraId: string,
-): void => {
-  const sourceOwner = proseParagraphSourceOwners.get(source);
-  if (!sourceOwner) {
-    return;
-  }
-  proseParagraphSourceOwners.set(target, sourceOwner);
-  paragraphPropertySourceTransferIds.set(sourceOwner, paraId);
-};
-
-export const linkParagraphPropertySourceCandidate = (target: Paragraph, source: PMNode): void => {
-  const token = source.attrs[PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR];
-  if (typeof token === "string") {
-    paragraphPropertySourceTokens.set(target, token);
-  }
-  const sourceOwner = proseParagraphSourceOwners.get(source);
-  if (sourceOwner) {
-    paragraphPropertySourceCandidates.set(target, sourceOwner);
-  }
-};
-
-export const getParagraphPropertySourceCandidate = (paragraph: Paragraph): Paragraph | undefined =>
-  paragraphPropertySourceCandidates.get(paragraph);
-
-export const getParagraphPropertySourceTransferId = (paragraph: Paragraph): string | undefined =>
-  paragraphPropertySourceTransferIds.get(paragraph);
+}: SetProseParagraphMarkupOptions): void => transaction.setNodeMarkup(pos, undefined, attrs);

--- a/packages/core/src/docx/paragraphPropertySource.ts
+++ b/packages/core/src/docx/paragraphPropertySource.ts
@@ -1,6 +1,6 @@
 import { panic } from "better-result";
-import type { Fragment, Mark, Node as PMNode, NodeType } from "prosemirror-model";
-import { PluginKey, type Transaction } from "prosemirror-state";
+import type { Fragment, Mark, Node as PMNode } from "prosemirror-model";
+import type { Transaction } from "prosemirror-state";
 
 import type { BlockContent, Document, Paragraph, TableCell } from "../types/document";
 import { visitDocxParagraphs } from "./paragraphTraversal";
@@ -12,11 +12,14 @@ import {
 } from "@stll/docx-core/model";
 import {
   ParagraphPropertySourceContract,
+  PARAGRAPH_PROPERTY_SOURCE_MAX_PARAGRAPHS,
+  PARAGRAPH_PROPERTY_SOURCE_MAX_STORIES,
   ParagraphPropertySourceToken,
   ParagraphPropertyTransientTemplateResolution,
   ParagraphPropertyTransientTemplateStore,
   ParagraphPropertyTransientTemplateHandle,
   ParagraphPropertySourceValidationError,
+  paragraphPropertySourceTokenWire,
   paragraphPropertySourceStoryKey,
 } from "./paragraphPropertySourceIdentity";
 import type {
@@ -49,15 +52,19 @@ type ParagraphPropertyCapture =
   | { fingerprint: ParagraphPropertySourceFingerprint; fingerprintJson: string; type: "absent" }
   | ParagraphPropertySource;
 
-type ParagraphPropertySourceBinding =
-  | { capture: ParagraphPropertyCapture; type: "captured-unbound" }
-  | { type: "editor-created" }
-  | {
-      capture: ParagraphPropertyCapture;
-      token: ParagraphPropertySourceToken;
-      type: "imported";
-    }
-  | { capture: ParagraphPropertyCapture; type: "resolved-template" };
+type ParagraphPropertyCaptureAxis =
+  | { type: "none" }
+  | { capture: ParagraphPropertyCapture; type: "captured" };
+
+type ParagraphPropertyOwnershipAxis =
+  | { type: "none" }
+  | { type: "parsed-unbound" }
+  | { token: ParagraphPropertySourceToken; type: "imported" };
+
+type ParagraphPropertySourceBinding = {
+  capture: ParagraphPropertyCaptureAxis;
+  ownership: ParagraphPropertyOwnershipAxis;
+};
 
 // Enumerable symbols follow ordinary immutable `{ ...document }` derivations,
 // while JSON and other string-key serialization cannot expose the contract.
@@ -145,27 +152,64 @@ const isParagraphPropertySourceBinding = (
   if (
     typeof value !== "object" ||
     value === null ||
-    !("type" in value) ||
+    !("capture" in value) ||
+    !("ownership" in value) ||
     !Object.isFrozen(value)
   ) {
     return false;
   }
-  if (value.type === "editor-created") {
-    return Object.keys(value).length === 1;
-  }
-  if (!("capture" in value) || !isParagraphPropertyCapture(value.capture)) {
+  const capture = value.capture;
+  const ownership = value.ownership;
+  if (
+    typeof capture !== "object" ||
+    capture === null ||
+    typeof ownership !== "object" ||
+    ownership === null ||
+    !("type" in capture) ||
+    !("type" in ownership) ||
+    !Object.isFrozen(capture) ||
+    !Object.isFrozen(ownership)
+  ) {
     return false;
   }
-  switch (value.type) {
-    case "captured-unbound":
-    case "resolved-template":
+  if (
+    capture.type !== "none" &&
+    (capture.type !== "captured" ||
+      !("capture" in capture) ||
+      !isParagraphPropertyCapture(capture.capture))
+  ) {
+    return false;
+  }
+  switch (ownership.type) {
+    case "none":
       return true;
+    case "parsed-unbound":
+      return capture.type === "captured";
     case "imported":
-      return "token" in value && value.token instanceof ParagraphPropertySourceToken;
+      return (
+        capture.type === "captured" &&
+        "token" in ownership &&
+        ownership.token instanceof ParagraphPropertySourceToken
+      );
     default:
       return false;
   }
 };
+
+const bindingWithCapture = (
+  capture: ParagraphPropertyCapture,
+  ownership: ParagraphPropertyOwnershipAxis,
+): ParagraphPropertySourceBinding =>
+  Object.freeze({
+    capture: Object.freeze({ capture, type: "captured" }),
+    ownership: Object.freeze(ownership),
+  });
+
+const editorCreatedBinding = (): ParagraphPropertySourceBinding =>
+  Object.freeze({
+    capture: Object.freeze({ type: "none" }),
+    ownership: Object.freeze({ type: "none" }),
+  });
 
 export const PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR = "_docxParagraphSourceToken";
 export const PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR = "_docxParagraphSourceContract";
@@ -204,7 +248,7 @@ const paragraphPropertySourceBinding = (
     !descriptor ||
     descriptor.enumerable !== true ||
     descriptor.writable === true ||
-    descriptor.configurable !== (binding.type === "captured-unbound")
+    descriptor.configurable !== (binding.ownership.type === "parsed-unbound")
   ) {
     panic("A paragraph carries a weakened paragraph-property source binding");
   }
@@ -217,7 +261,7 @@ const setParagraphPropertySourceBinding = (
 ): void => {
   if (
     !Reflect.defineProperty(paragraph, paragraphPropertySource, {
-      configurable: binding.type === "captured-unbound",
+      configurable: binding.ownership.type === "parsed-unbound",
       enumerable: true,
       value: Object.freeze(binding),
       writable: false,
@@ -247,24 +291,13 @@ export const assignParagraphPropertySource = (
     type: "present",
     xml: source.xml,
   }) satisfies ParagraphPropertyCapture;
-  switch (existing?.type) {
-    case undefined:
-      setParagraphPropertySourceBinding(paragraph, {
-        capture,
-        type: "captured-unbound",
-      });
-      return;
-    case "captured-unbound":
-    case "editor-created":
-    case "imported":
-    case "resolved-template":
-      panic("A paragraph-property capture can only be assigned once");
-      return;
-    default: {
-      const exhaustive: never = existing;
-      return exhaustive;
-    }
+  if (existing) {
+    panic("A paragraph-property capture can only be assigned once");
   }
+  setParagraphPropertySourceBinding(
+    paragraph,
+    bindingWithCapture(capture, { type: "parsed-unbound" }),
+  );
 };
 
 /** Record that a parsed paragraph had no authored `w:pPr` element. */
@@ -272,27 +305,26 @@ export const assignAbsentParagraphPropertySource = (paragraph: Paragraph): void 
   if (paragraphPropertySourceBinding(paragraph)) {
     panic("A paragraph-property capture can only be assigned once");
   }
-  const fingerprint = immutableFingerprint(
-    paragraphPropertySourceFingerprintFromParts({}, {}),
+  const fingerprint = immutableFingerprint(paragraphPropertySourceFingerprintFromParts({}, {}));
+  const capture = Object.freeze({
+    fingerprint,
+    fingerprintJson: canonicalParagraphPropertySourceFingerprintJson(fingerprint),
+    type: "absent",
+  }) satisfies ParagraphPropertyCapture;
+  setParagraphPropertySourceBinding(
+    paragraph,
+    bindingWithCapture(capture, { type: "parsed-unbound" }),
   );
-  setParagraphPropertySourceBinding(paragraph, {
-    capture: Object.freeze({
-      fingerprint,
-      fingerprintJson: canonicalParagraphPropertySourceFingerprintJson(fingerprint),
-      type: "absent",
-    }),
-    type: "captured-unbound",
-  });
 };
 
 export const getParagraphPropertySource = (
   paragraph: Paragraph,
 ): ParagraphPropertySource | undefined => {
   const binding = paragraphPropertySourceBinding(paragraph);
-  if (!binding || binding.type === "editor-created" || binding.capture.type === "absent") {
+  if (!binding || binding.capture.type === "none" || binding.capture.capture.type === "absent") {
     return undefined;
   }
-  return binding.capture;
+  return binding.capture.capture;
 };
 
 /** Authored `w:pPr` before style and numbering defaults are materialized. */
@@ -300,10 +332,10 @@ export const getParagraphAuthoredPPr = (
   paragraph: Paragraph,
 ): AuthoredParagraphProperties | undefined => {
   const binding = paragraphPropertySourceBinding(paragraph);
-  if (!binding || binding.type === "editor-created") {
+  if (!binding || binding.capture.type === "none") {
     return undefined;
   }
-  return structuredClone(binding.capture.fingerprint.pPrBase);
+  return structuredClone(binding.capture.capture.fingerprint.pPrBase);
 };
 
 /** Exact modeled properties captured from the paragraph's authored `w:pPr`. */
@@ -311,7 +343,7 @@ export const getParagraphPropertySourceFingerprint = (
   paragraph: Paragraph,
 ): ParagraphPropertySourceFingerprint | undefined => {
   const binding = paragraphPropertySourceBinding(paragraph);
-  return binding && binding.type !== "editor-created" ? binding.capture.fingerprint : undefined;
+  return binding?.capture.type === "captured" ? binding.capture.capture.fingerprint : undefined;
 };
 
 /** Mark a model paragraph as deliberately created outside the parsed source census. */
@@ -319,22 +351,21 @@ export const assignEditorCreatedParagraphPropertySource = (paragraph: Paragraph)
   if (paragraphPropertySourceBinding(paragraph)) {
     panic("Paragraph-property provenance can only be assigned once");
   }
-  setParagraphPropertySourceBinding(paragraph, { type: "editor-created" });
+  setParagraphPropertySourceBinding(paragraph, editorCreatedBinding());
 };
 
 const tokenFromBinding = (
   binding: ParagraphPropertySourceBinding | undefined,
 ): ParagraphPropertySourceToken | null => {
-  switch (binding?.type) {
+  switch (binding?.ownership.type) {
     case "imported":
-      return binding.token;
-    case "captured-unbound":
-    case "editor-created":
-    case "resolved-template":
+      return binding.ownership.token;
+    case "parsed-unbound":
+    case "none":
     case undefined:
       return null;
     default: {
-      const exhaustive: never = binding;
+      const exhaustive: never = binding.ownership;
       return exhaustive;
     }
   }
@@ -343,13 +374,13 @@ const tokenFromBinding = (
 /** Copy the captured `w:pPr` without claiming the source paragraph's durable identity. */
 export const copyParagraphPropertyCapture = (target: Paragraph, source: Paragraph): void => {
   const sourceBinding = paragraphPropertySourceBinding(source);
-  if (!sourceBinding || sourceBinding.type === "editor-created") {
+  if (!sourceBinding || sourceBinding.capture.type === "none") {
     return;
   }
-  setParagraphPropertySourceBinding(target, {
-    capture: sourceBinding.capture,
-    type: "resolved-template",
-  });
+  setParagraphPropertySourceBinding(
+    target,
+    bindingWithCapture(sourceBinding.capture.capture, { type: "none" }),
+  );
 };
 
 export const PARAGRAPH_PROPERTY_TEMPLATE_STORE_MAX_CAPTURES = 100_000;
@@ -400,7 +431,7 @@ export class ParagraphPropertyTemplateResolutionRegistry {
       panic("A paragraph-property template target already has source provenance");
     }
     const capture = this.#resolution.consume(handle);
-    setParagraphPropertySourceBinding(target, { capture, type: "resolved-template" });
+    setParagraphPropertySourceBinding(target, bindingWithCapture(capture, { type: "none" }));
   }
 }
 
@@ -423,9 +454,7 @@ export class ParagraphPropertyTemplateStore {
     capabilities: readonly ParagraphPropertyTemplateCapture[],
   ): readonly ParagraphPropertyTransientTemplateHandle[] {
     return this.#store.registerAll(
-      capabilities.map((capability) =>
-        capability.capture(paragraphPropertyTemplateCaptureIssuer),
-      ),
+      capabilities.map((capability) => capability.capture(paragraphPropertyTemplateCaptureIssuer)),
     );
   }
 }
@@ -438,24 +467,7 @@ export const copyParagraphPropertySource = (target: Paragraph, source: Paragraph
   if (!binding) {
     return;
   }
-  switch (binding.type) {
-    case "imported":
-      setParagraphPropertySourceBinding(target, binding);
-      return;
-    case "captured-unbound":
-      setParagraphPropertySourceBinding(target, binding);
-      return;
-    case "editor-created":
-      setParagraphPropertySourceBinding(target, binding);
-      return;
-    case "resolved-template":
-      setParagraphPropertySourceBinding(target, binding);
-      return;
-    default: {
-      const exhaustive: never = binding;
-      return exhaustive;
-    }
-  }
+  setParagraphPropertySourceBinding(target, binding);
 };
 
 /** Bind every parsed story paragraph to one exact source package. */
@@ -466,21 +478,29 @@ export const assignDocumentParagraphPropertySourceContract = (
   if (Object.hasOwn(document, documentParagraphPropertySourceContract)) {
     panic("A document paragraph-property source contract can only be assigned once");
   }
-  const contract = ParagraphPropertySourceContract.fromDigest(sourceDigest);
   const seenStories = new Set<string>();
   const seenParagraphs = new WeakSet<Paragraph>();
   const bodyParagraphs = new WeakSet<Paragraph>();
   const census: {
     capture: ParagraphPropertyCapture;
+    ordinal: number;
     paragraph: Paragraph;
-    token: ParagraphPropertySourceToken;
+    story: ParagraphPropertySourceStory;
   }[] = [];
+  const sourceCensus: { paragraphCount: number; story: ParagraphPropertySourceStory }[] = [];
+  let totalParagraphCount = 0;
   if (!Object.isExtensible(document)) {
     panic("A document must be extensible before binding paragraph-property provenance");
   }
-  // The traversal is part of the v2 durable identity contract. Any ordering
+  // The traversal is part of the v3 durable identity contract. Any ordering
   // change requires a token-version bump and collaboration reseed.
   for (const { content, story } of documentSourceStories(document)) {
+    if (seenStories.size >= PARAGRAPH_PROPERTY_SOURCE_MAX_STORIES) {
+      throw new ParagraphPropertySourceValidationError({
+        code: "source_capacity_exceeded",
+        message: "Paragraph-property source story capacity was exceeded.",
+      });
+    }
     const storyKey = paragraphPropertySourceStoryKey(story);
     if (seenStories.has(storyKey)) {
       panic("A document contains duplicate paragraph-property story identity", { storyKey });
@@ -488,7 +508,14 @@ export const assignDocumentParagraphPropertySourceContract = (
     seenStories.add(storyKey);
     const paragraphs: Paragraph[] = [];
     visitDocumentStoryParagraphs(content, (paragraph) => paragraphs.push(paragraph));
-    const tokenCensus = contract.bindStoryCensus(story, paragraphs.length);
+    totalParagraphCount += paragraphs.length;
+    if (totalParagraphCount > PARAGRAPH_PROPERTY_SOURCE_MAX_PARAGRAPHS) {
+      throw new ParagraphPropertySourceValidationError({
+        code: "source_capacity_exceeded",
+        message: "Paragraph-property source paragraph capacity was exceeded.",
+      });
+    }
+    sourceCensus.push({ paragraphCount: paragraphs.length, story });
     for (const [ordinal, paragraph] of paragraphs.entries()) {
       if (seenParagraphs.has(paragraph)) {
         panic("A paragraph cannot belong to more than one source story", { storyKey });
@@ -498,14 +525,19 @@ export const assignDocumentParagraphPropertySourceContract = (
         bodyParagraphs.add(paragraph);
       }
       const binding = paragraphPropertySourceBinding(paragraph);
-      if (binding?.type !== "captured-unbound") {
+      if (binding?.ownership.type !== "parsed-unbound" || binding.capture.type !== "captured") {
         panic("A document paragraph must have exactly one parsed property capture before binding");
       }
       const descriptor = Object.getOwnPropertyDescriptor(paragraph, paragraphPropertySource);
       if (!descriptor?.configurable) {
         panic("A parsed paragraph capture cannot transition to its durable source identity");
       }
-      census.push({ capture: binding.capture, paragraph, token: tokenCensus.tokenAt(ordinal) });
+      census.push({
+        capture: binding.capture.capture,
+        ordinal,
+        paragraph,
+        story,
+      });
     }
   }
   for (const section of document.package.document.sections ?? []) {
@@ -516,13 +548,20 @@ export const assignDocumentParagraphPropertySourceContract = (
     });
   }
 
+  const contract = ParagraphPropertySourceContract.fromSourceCensus(sourceDigest, sourceCensus);
+  const boundCensus = census.map(({ capture, ordinal, paragraph, story }) => {
+    const token = contract.readToken(paragraphPropertySourceTokenWire(story, ordinal));
+    if (token.status !== "valid") {
+      return panic("A canonical paragraph-property source token failed contract reification");
+    }
+    return { capture, paragraph, token: token.value };
+  });
   setDocumentParagraphPropertySourceContract(document, contract);
-  for (const { capture, paragraph, token } of census) {
-    setParagraphPropertySourceBinding(paragraph, {
-      capture,
-      token,
-      type: "imported",
-    });
+  for (const { capture, paragraph, token } of boundCensus) {
+    setParagraphPropertySourceBinding(
+      paragraph,
+      bindingWithCapture(capture, { token, type: "imported" }),
+    );
   }
 };
 
@@ -556,11 +595,6 @@ export const readProseDocumentParagraphPropertySourceContract = (
 ): ParagraphPropertySourceAttribute<ParagraphPropertySourceContract> =>
   ParagraphPropertySourceContract.read(document.attrs[PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR]);
 
-export const readProseParagraphPropertySourceToken = (
-  paragraph: PMNode,
-): ParagraphPropertySourceAttribute<ParagraphPropertySourceToken> =>
-  ParagraphPropertySourceToken.read(paragraph.attrs[PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR]);
-
 export const copyDocumentParagraphPropertySourceContract = (
   target: Document,
   source: Document,
@@ -585,7 +619,8 @@ export const deriveDocumentWithParagraphPropertySources = (
 
 export const getParagraphPropertySourceToken = (
   paragraph: Paragraph,
-): ParagraphPropertySourceToken | undefined => tokenFromBinding(paragraphPropertySourceBinding(paragraph)) ?? undefined;
+): ParagraphPropertySourceToken | undefined =>
+  tokenFromBinding(paragraphPropertySourceBinding(paragraph)) ?? undefined;
 
 const indexParagraphPropertySources = (
   content: BlockContent[],
@@ -595,8 +630,14 @@ const indexParagraphPropertySources = (
   const sources = new Map<string, ParagraphPropertyTemplateCapture>();
   visitDocumentStoryParagraphs(content, (paragraph) => {
     const binding = paragraphPropertySourceBinding(paragraph);
-    if (binding?.type === "editor-created") {
+    if (binding?.ownership.type === "none") {
       return;
+    }
+    if (binding?.ownership.type === "parsed-unbound") {
+      throw new ParagraphPropertySourceValidationError({
+        code: "invalid_token",
+        message: "A bound source story contains unbound parsed provenance.",
+      });
     }
     const token = getParagraphPropertySourceToken(paragraph);
     if (!token || !token.belongsToStory(story) || !contract.owns(token)) {
@@ -613,8 +654,8 @@ const indexParagraphPropertySources = (
         token: token.serialized,
       });
     }
-    const capture = binding?.type === "imported" ? binding.capture : undefined;
-    if (!capture) {
+    const capture = binding?.capture.type === "captured" ? binding.capture.capture : undefined;
+    if (!capture || binding.ownership.type !== "imported") {
       panic("A validated imported paragraph lost its source capture");
     }
     sources.set(
@@ -713,11 +754,13 @@ export class ParagraphPropertyStorySource {
         token: token.serialized,
       });
     }
-    setParagraphPropertySourceBinding(target, {
-      capture: capability.capture(paragraphPropertyTemplateCaptureIssuer),
-      token,
-      type: "imported",
-    });
+    setParagraphPropertySourceBinding(
+      target,
+      bindingWithCapture(capability.capture(paragraphPropertyTemplateCaptureIssuer), {
+        token,
+        type: "imported",
+      }),
+    );
   }
 
   templateCapture(token: ParagraphPropertySourceToken): ParagraphPropertyTemplateCapture {
@@ -877,100 +920,6 @@ export const cloneTableCellsWithParagraphPropertyCaptures = (cells: TableCell[])
   }
   return cloned;
 };
-
-type CreateProseParagraphOptions = {
-  attrs?: PMNode["attrs"];
-  content?: Fragment | PMNode | readonly PMNode[] | null;
-  marks?: readonly Mark[];
-};
-
-/** Create a parsed paragraph with both its same-process owner and durable body token. */
-export const createProseParagraphWithPropertySource = (
-  nodeType: NodeType | undefined,
-  sourceParagraph: Paragraph,
-  options: CreateProseParagraphOptions = {},
-): PMNode => {
-  if (!nodeType || nodeType.name !== "paragraph") {
-    panic("Paragraph-property provenance can only seed a paragraph node");
-  }
-  return nodeType.create(
-    {
-      ...options.attrs,
-      [PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR]:
-        getParagraphPropertySourceToken(sourceParagraph)?.serialized ?? null,
-    },
-    options.content,
-    options.marks,
-  );
-};
-
-type ParagraphPropertySourceTransfer = {
-  displacedToken: string | null;
-  selectedToken: string | null;
-};
-
-const paragraphPropertySourceTransfersKey = new PluginKey<
-  readonly ParagraphPropertySourceTransfer[]
->("paragraphPropertySourceTransfers");
-
-type JoinProseParagraphsWithRightPropertySourceOptions = {
-  attrs: PMNode["attrs"];
-  pos: number;
-  transaction: Transaction;
-};
-
-/** Join adjacent paragraphs when revision semantics deliberately select the right owner. */
-export const joinProseParagraphsWithRightPropertySource = ({
-  attrs,
-  pos,
-  transaction,
-}: JoinProseParagraphsWithRightPropertySourceOptions): Transaction => {
-  const $pos = transaction.doc.resolve(pos);
-  const left = $pos.nodeBefore;
-  const right = $pos.nodeAfter;
-  if (!left || !right || left.type.name !== "paragraph" || right.type.name !== "paragraph") {
-    panic("Paragraph-property ownership can only join adjacent paragraphs");
-  }
-  const leftToken = readProseParagraphPropertySourceToken(left);
-  const rightToken = readProseParagraphPropertySourceToken(right);
-  if (leftToken.status === "invalid" || rightToken.status === "invalid") {
-    throw new ParagraphPropertySourceValidationError({
-      code: "invalid_token",
-      message: "Cannot join a paragraph carrying a malformed paragraph-property token.",
-      token: leftToken.status === "invalid" ? leftToken.raw : rightToken.raw,
-    });
-  }
-  const leftPos = pos - left.nodeSize;
-  transaction.join(pos);
-  const joined = transaction.doc.nodeAt(leftPos);
-  if (!joined || joined.type.name !== "paragraph") {
-    panic("Joining paragraphs did not produce a paragraph");
-  }
-  transaction.setNodeMarkup(
-    leftPos,
-    undefined,
-    {
-      ...attrs,
-      [PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR]:
-        rightToken.status === "valid" ? rightToken.value.serialized : null,
-    },
-    joined.marks,
-  );
-  const transfers = transaction.getMeta(paragraphPropertySourceTransfersKey) ?? [];
-  transaction.setMeta(paragraphPropertySourceTransfersKey, [
-    ...transfers,
-    {
-      displacedToken: leftToken.status === "valid" ? leftToken.value.serialized : null,
-      selectedToken: rightToken.status === "valid" ? rightToken.value.serialized : null,
-    },
-  ]);
-  return transaction;
-};
-
-export const getExplicitParagraphPropertySourceTransfers = (
-  transaction: Transaction,
-): readonly ParagraphPropertySourceTransfer[] =>
-  transaction.getMeta(paragraphPropertySourceTransfersKey) ?? [];
 
 type RecreateProseNodeOptions = {
   attrs?: PMNode["attrs"];

--- a/packages/core/src/docx/paragraphPropertySourceIdentity.ts
+++ b/packages/core/src/docx/paragraphPropertySourceIdentity.ts
@@ -1,0 +1,297 @@
+import { panic, TaggedError } from "better-result";
+
+const PARAGRAPH_SOURCE_TOKEN_VERSION = "folio-ppr-v2";
+const PARAGRAPH_SOURCE_TOKEN_PREFIX = "p2d";
+const SHA256_HEX = /^[0-9a-f]{64}$/;
+const SOURCE_TOKEN =
+  /^p2d:([0-9a-f]{64}):(comment|document|header|footer|footnote|endnote):([^:]*):(0|[1-9a-z][0-9a-z]*)$/;
+const TRANSIENT_TEMPLATE_HANDLE = /^folio-ppr-template-v1:(0|[1-9a-z][0-9a-z]*)$/;
+
+/** Result of reifying serialized paragraph-source metadata at a trust boundary. */
+export type ParagraphPropertySourceAttribute<T> =
+  | { status: "absent" }
+  | { raw: unknown; status: "invalid" }
+  | { status: "valid"; value: T };
+
+/** Stable identity of one independently editable story in a source package. */
+export type ParagraphPropertySourceStory =
+  | { type: "document" }
+  | { relationshipId: string; type: "footer" | "header" }
+  | { noteId: number; type: "endnote" | "footnote" }
+  | { commentId: number; type: "comment" };
+
+const serializedStoryIdentifier = (story: ParagraphPropertySourceStory): string => {
+  switch (story.type) {
+    case "document":
+      return "";
+    case "comment":
+      return String(story.commentId);
+    case "footer":
+    case "header":
+      return encodeURIComponent(story.relationshipId);
+    case "endnote":
+    case "footnote":
+      return String(story.noteId);
+    default: {
+      const exhaustive: never = story;
+      return exhaustive;
+    }
+  }
+};
+
+export const paragraphPropertySourceStoryKey = (
+  story: ParagraphPropertySourceStory,
+): string => `${story.type}:${serializedStoryIdentifier(story)}`;
+
+const readStory = (type: string, identifier: string): ParagraphPropertySourceStory | null => {
+  switch (type) {
+    case "document":
+      return identifier === "" ? Object.freeze({ type: "document" }) : null;
+    case "comment": {
+      if (!/^-?(0|[1-9][0-9]*)$/.test(identifier)) {
+        return null;
+      }
+      const commentId = Number(identifier);
+      return Number.isSafeInteger(commentId) && String(commentId) === identifier
+        ? Object.freeze({ commentId, type })
+        : null;
+    }
+    case "footer":
+    case "header": {
+      let relationshipId: string;
+      try {
+        relationshipId = decodeURIComponent(identifier);
+      } catch {
+        return null;
+      }
+      if (!relationshipId || encodeURIComponent(relationshipId) !== identifier) {
+        return null;
+      }
+      return Object.freeze({ relationshipId, type });
+    }
+    case "endnote":
+    case "footnote": {
+      if (!/^-?(0|[1-9][0-9]*)$/.test(identifier)) {
+        return null;
+      }
+      const noteId = Number(identifier);
+      return Number.isSafeInteger(noteId) && String(noteId) === identifier
+        ? Object.freeze({ noteId, type })
+        : null;
+    }
+    default:
+      return null;
+  }
+};
+
+export const paragraphPropertySourceStoriesEqual = (
+  left: ParagraphPropertySourceStory,
+  right: ParagraphPropertySourceStory,
+): boolean => {
+  if (left.type !== right.type) {
+    return false;
+  }
+  switch (left.type) {
+    case "document":
+      return true;
+    case "comment":
+      return right.type === left.type && right.commentId === left.commentId;
+    case "footer":
+    case "header":
+      return right.type === left.type && right.relationshipId === left.relationshipId;
+    case "endnote":
+    case "footnote":
+      return right.type === left.type && right.noteId === left.noteId;
+    default: {
+      const exhaustive: never = left;
+      return exhaustive;
+    }
+  }
+};
+
+/** A source-package contract that has passed the canonical grammar check. */
+export class ParagraphPropertySourceContract {
+  readonly #validated = true;
+
+  private constructor(
+    readonly serialized: string,
+    readonly fingerprint: string,
+  ) {
+    Object.freeze(this);
+  }
+
+  static fromDigest(sourceDigest: string): ParagraphPropertySourceContract {
+    if (!SHA256_HEX.test(sourceDigest)) {
+      panic("Paragraph-property source digest must be lowercase SHA-256 hex");
+    }
+    return new ParagraphPropertySourceContract(
+      `${PARAGRAPH_SOURCE_TOKEN_VERSION}:${sourceDigest}`,
+      sourceDigest,
+    );
+  }
+
+  static read(raw: unknown): ParagraphPropertySourceAttribute<ParagraphPropertySourceContract> {
+    if (raw === null || raw === undefined) {
+      return { status: "absent" };
+    }
+    if (typeof raw !== "string") {
+      return { raw, status: "invalid" };
+    }
+    const prefix = `${PARAGRAPH_SOURCE_TOKEN_VERSION}:`;
+    const digest = raw.startsWith(prefix) ? raw.slice(prefix.length) : "";
+    if (!SHA256_HEX.test(digest)) {
+      return { raw, status: "invalid" };
+    }
+    return {
+      status: "valid",
+      value: new ParagraphPropertySourceContract(raw, digest),
+    };
+  }
+
+  owns(token: ParagraphPropertySourceToken): boolean {
+    return this.#validated && this.fingerprint === token.fingerprint;
+  }
+}
+
+/** A paragraph token whose syntax has passed the canonical grammar check. */
+export class ParagraphPropertySourceToken {
+  readonly #validated = true;
+
+  private constructor(
+    readonly serialized: string,
+    readonly fingerprint: string,
+    readonly story: ParagraphPropertySourceStory,
+    readonly ordinal: number,
+  ) {
+    Object.freeze(this);
+  }
+
+  static forOrdinal(
+    contract: ParagraphPropertySourceContract,
+    story: ParagraphPropertySourceStory,
+    ordinal: number,
+  ): ParagraphPropertySourceToken {
+    if (!Number.isSafeInteger(ordinal) || ordinal < 0) {
+      panic("Paragraph-property source ordinal must be a non-negative safe integer");
+    }
+    return new ParagraphPropertySourceToken(
+      `${PARAGRAPH_SOURCE_TOKEN_PREFIX}:${contract.fingerprint}:${story.type}:${serializedStoryIdentifier(story)}:${ordinal.toString(36)}`,
+      contract.fingerprint,
+      Object.freeze({ ...story }),
+      ordinal,
+    );
+  }
+
+  static read(raw: unknown): ParagraphPropertySourceAttribute<ParagraphPropertySourceToken> {
+    if (raw === null || raw === undefined) {
+      return { status: "absent" };
+    }
+    if (typeof raw !== "string") {
+      return { raw, status: "invalid" };
+    }
+    const match = SOURCE_TOKEN.exec(raw);
+    if (!match) {
+      return { raw, status: "invalid" };
+    }
+    const fingerprint = match.at(1);
+    const storyType = match.at(2);
+    const storyIdentifier = match.at(3);
+    const serializedOrdinal = match.at(4);
+    if (!fingerprint || !storyType || storyIdentifier === undefined || !serializedOrdinal) {
+      return { raw, status: "invalid" };
+    }
+    const story = readStory(storyType, storyIdentifier);
+    const ordinal = Number.parseInt(serializedOrdinal, 36);
+    if (!story || !Number.isSafeInteger(ordinal) || ordinal.toString(36) !== serializedOrdinal) {
+      return { raw, status: "invalid" };
+    }
+    return {
+      status: "valid",
+      value: new ParagraphPropertySourceToken(raw, fingerprint, story, ordinal),
+    };
+  }
+
+  belongsTo(contract: ParagraphPropertySourceContract): boolean {
+    return this.#validated && contract.owns(this);
+  }
+
+  belongsToStory(story: ParagraphPropertySourceStory): boolean {
+    return this.#validated && paragraphPropertySourceStoriesEqual(this.story, story);
+  }
+}
+
+/** One conversion-scoped reference to an opaque target-template capture. */
+export class ParagraphPropertyTransientTemplateHandle {
+  readonly #validated = true;
+
+  private constructor(
+    readonly serialized: string,
+    readonly ordinal: number,
+  ) {
+    Object.freeze(this);
+  }
+
+  static forOrdinal(ordinal: number): ParagraphPropertyTransientTemplateHandle {
+    if (!Number.isSafeInteger(ordinal) || ordinal < 0) {
+      panic("Paragraph-property template ordinal must be a non-negative safe integer");
+    }
+    return new ParagraphPropertyTransientTemplateHandle(
+      `folio-ppr-template-v1:${ordinal.toString(36)}`,
+      ordinal,
+    );
+  }
+
+  static read(
+    raw: unknown,
+  ): ParagraphPropertySourceAttribute<ParagraphPropertyTransientTemplateHandle> {
+    if (raw === null || raw === undefined) {
+      return { status: "absent" };
+    }
+    if (typeof raw !== "string") {
+      return { raw, status: "invalid" };
+    }
+    const match = TRANSIENT_TEMPLATE_HANDLE.exec(raw);
+    if (!match) {
+      return { raw, status: "invalid" };
+    }
+    const serializedOrdinal = match.at(1);
+    if (!serializedOrdinal) {
+      return { raw, status: "invalid" };
+    }
+    const ordinal = Number.parseInt(serializedOrdinal, 36);
+    if (!Number.isSafeInteger(ordinal) || ordinal.toString(36) !== serializedOrdinal) {
+      return { raw, status: "invalid" };
+    }
+    return {
+      status: "valid",
+      value: new ParagraphPropertyTransientTemplateHandle(raw, ordinal),
+    };
+  }
+
+  isValidated(): boolean {
+    return this.#validated;
+  }
+}
+
+export const PARAGRAPH_PROPERTY_SOURCE_VALIDATION_CODES = [
+  "ambiguous_source",
+  "contract_mismatch",
+  "duplicate_template_handle",
+  "duplicate_token",
+  "invalid_template_handle",
+  "invalid_token",
+  "unconsumed_template_handle",
+  "unknown_template_handle",
+  "unknown_token",
+] as const;
+
+export type ParagraphPropertySourceValidationCode =
+  (typeof PARAGRAPH_PROPERTY_SOURCE_VALIDATION_CODES)[number];
+
+export class ParagraphPropertySourceValidationError extends TaggedError(
+  "ParagraphPropertySourceValidationError",
+)<{
+  code: ParagraphPropertySourceValidationCode;
+  message: string;
+  token?: unknown;
+}> {}

--- a/packages/core/src/docx/paragraphPropertySourceIdentity.ts
+++ b/packages/core/src/docx/paragraphPropertySourceIdentity.ts
@@ -1,11 +1,10 @@
 import { panic, TaggedError } from "better-result";
 
 const PARAGRAPH_SOURCE_TOKEN_VERSION = "folio-ppr-v2";
-const PARAGRAPH_SOURCE_TOKEN_PREFIX = "p2d";
+const PARAGRAPH_SOURCE_TOKEN_PREFIX = "p2s";
 const SHA256_HEX = /^[0-9a-f]{64}$/;
 const SOURCE_TOKEN =
-  /^p2d:([0-9a-f]{64}):(comment|document|header|footer|footnote|endnote):([^:]*):(0|[1-9a-z][0-9a-z]*)$/;
-const TRANSIENT_TEMPLATE_HANDLE = /^folio-ppr-template-v1:(0|[1-9a-z][0-9a-z]*)$/;
+  /^p2s:(comment|document|header|footer|footnote|endnote):([^:]*):(0|[1-9a-z][0-9a-z]*)$/;
 
 /** Result of reifying serialized paragraph-source metadata at a trust boundary. */
 export type ParagraphPropertySourceAttribute<T> =
@@ -38,10 +37,6 @@ const serializedStoryIdentifier = (story: ParagraphPropertySourceStory): string 
     }
   }
 };
-
-export const paragraphPropertySourceStoryKey = (
-  story: ParagraphPropertySourceStory,
-): string => `${story.type}:${serializedStoryIdentifier(story)}`;
 
 const readStory = (type: string, identifier: string): ParagraphPropertySourceStory | null => {
   switch (type) {
@@ -82,6 +77,24 @@ const readStory = (type: string, identifier: string): ParagraphPropertySourceSto
     default:
       return null;
   }
+};
+
+export const canonicalParagraphPropertySourceStory = (
+  story: ParagraphPropertySourceStory,
+): ParagraphPropertySourceStory => {
+  const identifier = serializedStoryIdentifier(story);
+  const canonical = readStory(story.type, identifier);
+  if (!canonical) {
+    panic("Paragraph-property source story must have a canonical identity");
+  }
+  return canonical;
+};
+
+export const paragraphPropertySourceStoryKey = (
+  story: ParagraphPropertySourceStory,
+): string => {
+  const canonical = canonicalParagraphPropertySourceStory(story);
+  return `${canonical.type}:${serializedStoryIdentifier(canonical)}`;
 };
 
 export const paragraphPropertySourceStoriesEqual = (
@@ -148,41 +161,7 @@ export class ParagraphPropertySourceContract {
     };
   }
 
-  owns(token: ParagraphPropertySourceToken): boolean {
-    return this.#validated && this.fingerprint === token.fingerprint;
-  }
-}
-
-/** A paragraph token whose syntax has passed the canonical grammar check. */
-export class ParagraphPropertySourceToken {
-  readonly #validated = true;
-
-  private constructor(
-    readonly serialized: string,
-    readonly fingerprint: string,
-    readonly story: ParagraphPropertySourceStory,
-    readonly ordinal: number,
-  ) {
-    Object.freeze(this);
-  }
-
-  static forOrdinal(
-    contract: ParagraphPropertySourceContract,
-    story: ParagraphPropertySourceStory,
-    ordinal: number,
-  ): ParagraphPropertySourceToken {
-    if (!Number.isSafeInteger(ordinal) || ordinal < 0) {
-      panic("Paragraph-property source ordinal must be a non-negative safe integer");
-    }
-    return new ParagraphPropertySourceToken(
-      `${PARAGRAPH_SOURCE_TOKEN_PREFIX}:${contract.fingerprint}:${story.type}:${serializedStoryIdentifier(story)}:${ordinal.toString(36)}`,
-      contract.fingerprint,
-      Object.freeze({ ...story }),
-      ordinal,
-    );
-  }
-
-  static read(raw: unknown): ParagraphPropertySourceAttribute<ParagraphPropertySourceToken> {
+  readToken(raw: unknown): ParagraphPropertySourceAttribute<ParagraphPropertySourceToken> {
     if (raw === null || raw === undefined) {
       return { status: "absent" };
     }
@@ -193,11 +172,10 @@ export class ParagraphPropertySourceToken {
     if (!match) {
       return { raw, status: "invalid" };
     }
-    const fingerprint = match.at(1);
-    const storyType = match.at(2);
-    const storyIdentifier = match.at(3);
-    const serializedOrdinal = match.at(4);
-    if (!fingerprint || !storyType || storyIdentifier === undefined || !serializedOrdinal) {
+    const storyType = match.at(1);
+    const storyIdentifier = match.at(2);
+    const serializedOrdinal = match.at(3);
+    if (!storyType || storyIdentifier === undefined || !serializedOrdinal) {
       return { raw, status: "invalid" };
     }
     const story = readStory(storyType, storyIdentifier);
@@ -207,8 +185,48 @@ export class ParagraphPropertySourceToken {
     }
     return {
       status: "valid",
-      value: new ParagraphPropertySourceToken(raw, fingerprint, story, ordinal),
+      value: new ParagraphPropertySourceToken(
+        paragraphPropertySourceTokenIssuer,
+        this.fingerprint,
+        raw,
+        story,
+        ordinal,
+      ),
     };
+  }
+
+  bindStoryCensus(
+    story: ParagraphPropertySourceStory,
+    paragraphCount: number,
+  ): ParagraphPropertySourceTokenCensus {
+    return ParagraphPropertySourceTokenCensus.bind(this, story, paragraphCount);
+  }
+
+  owns(token: ParagraphPropertySourceToken): boolean {
+    return this.#validated && token.belongsToContract(this.fingerprint);
+  }
+}
+
+const paragraphPropertySourceTokenIssuer = Symbol("paragraphPropertySourceTokenIssuer");
+type ParagraphPropertySourceTokenIssuer = typeof paragraphPropertySourceTokenIssuer;
+
+/** A paragraph token whose syntax has passed the canonical grammar check. */
+export class ParagraphPropertySourceToken {
+  readonly #validated = true;
+  readonly #contractFingerprint: string;
+
+  constructor(
+    issuer: ParagraphPropertySourceTokenIssuer,
+    contractFingerprint: string,
+    readonly serialized: string,
+    readonly story: ParagraphPropertySourceStory,
+    readonly ordinal: number,
+  ) {
+    if (issuer !== paragraphPropertySourceTokenIssuer) {
+      panic("Only a paragraph-property source census may issue tokens");
+    }
+    this.#contractFingerprint = contractFingerprint;
+    Object.freeze(this);
   }
 
   belongsTo(contract: ParagraphPropertySourceContract): boolean {
@@ -218,58 +236,71 @@ export class ParagraphPropertySourceToken {
   belongsToStory(story: ParagraphPropertySourceStory): boolean {
     return this.#validated && paragraphPropertySourceStoriesEqual(this.story, story);
   }
+
+  belongsToContract(fingerprint: string): boolean {
+    return this.#validated && this.#contractFingerprint === fingerprint;
+  }
 }
 
-/** One conversion-scoped reference to an opaque target-template capture. */
-export class ParagraphPropertyTransientTemplateHandle {
-  readonly #validated = true;
+/** The only token issuer: one complete, canonical story census. */
+class ParagraphPropertySourceTokenCensus {
+  readonly #tokens: readonly ParagraphPropertySourceToken[];
 
-  private constructor(
-    readonly serialized: string,
-    readonly ordinal: number,
-  ) {
+  private constructor(tokens: readonly ParagraphPropertySourceToken[]) {
+    this.#tokens = Object.freeze(tokens);
     Object.freeze(this);
   }
 
-  static forOrdinal(ordinal: number): ParagraphPropertyTransientTemplateHandle {
-    if (!Number.isSafeInteger(ordinal) || ordinal < 0) {
-      panic("Paragraph-property template ordinal must be a non-negative safe integer");
+  static bind(
+    contract: ParagraphPropertySourceContract,
+    story: ParagraphPropertySourceStory,
+    paragraphCount: number,
+  ): ParagraphPropertySourceTokenCensus {
+    if (!Number.isSafeInteger(paragraphCount) || paragraphCount < 0) {
+      panic("A paragraph-property source census requires a non-negative safe paragraph count");
     }
-    return new ParagraphPropertyTransientTemplateHandle(
-      `folio-ppr-template-v1:${ordinal.toString(36)}`,
-      ordinal,
+    const canonicalStory = canonicalParagraphPropertySourceStory(story);
+    const tokens = Array.from({ length: paragraphCount }, (_, ordinal) =>
+      new ParagraphPropertySourceToken(
+        paragraphPropertySourceTokenIssuer,
+        contract.fingerprint,
+        `${PARAGRAPH_SOURCE_TOKEN_PREFIX}:${canonicalStory.type}:${serializedStoryIdentifier(canonicalStory)}:${ordinal.toString(36)}`,
+        canonicalStory,
+        ordinal,
+      ),
     );
+    return new ParagraphPropertySourceTokenCensus(tokens);
   }
 
-  static read(
-    raw: unknown,
-  ): ParagraphPropertySourceAttribute<ParagraphPropertyTransientTemplateHandle> {
-    if (raw === null || raw === undefined) {
-      return { status: "absent" };
+  tokenAt(ordinal: number): ParagraphPropertySourceToken {
+    const token = this.#tokens.at(ordinal);
+    if (!token) {
+      return panic("Paragraph-property source census ordinal is outside its bound story");
     }
-    if (typeof raw !== "string") {
-      return { raw, status: "invalid" };
+    return token;
+  }
+}
+
+const transientTemplateHandleIssuer = Symbol("paragraphPropertyTransientTemplateHandleIssuer");
+type TransientTemplateHandleIssuer = typeof transientTemplateHandleIssuer;
+
+export class ParagraphPropertyTransientTemplateHandle {
+  readonly #owner: object;
+
+  constructor(issuer: TransientTemplateHandleIssuer, owner: object, readonly ordinal: number) {
+    if (issuer !== transientTemplateHandleIssuer) {
+      panic("Only a paragraph-property template store may issue transient handles");
     }
-    const match = TRANSIENT_TEMPLATE_HANDLE.exec(raw);
-    if (!match) {
-      return { raw, status: "invalid" };
-    }
-    const serializedOrdinal = match.at(1);
-    if (!serializedOrdinal) {
-      return { raw, status: "invalid" };
-    }
-    const ordinal = Number.parseInt(serializedOrdinal, 36);
-    if (!Number.isSafeInteger(ordinal) || ordinal.toString(36) !== serializedOrdinal) {
-      return { raw, status: "invalid" };
-    }
-    return {
-      status: "valid",
-      value: new ParagraphPropertyTransientTemplateHandle(raw, ordinal),
-    };
+    this.#owner = owner;
+    Object.freeze(this);
   }
 
   isValidated(): boolean {
-    return this.#validated;
+    return this.#owner !== undefined;
+  }
+
+  belongsTo(owner: object): boolean {
+    return this.#owner === owner;
   }
 }
 
@@ -278,7 +309,10 @@ export const PARAGRAPH_PROPERTY_SOURCE_VALIDATION_CODES = [
   "contract_mismatch",
   "duplicate_template_handle",
   "duplicate_token",
+  "invalid_state",
   "invalid_template_handle",
+  "template_capacity_exceeded",
+  "transient_state",
   "invalid_token",
   "unconsumed_template_handle",
   "unknown_template_handle",
@@ -295,3 +329,124 @@ export class ParagraphPropertySourceValidationError extends TaggedError(
   message: string;
   token?: unknown;
 }> {}
+
+export class ParagraphPropertyTransientTemplateResolution<Capture> {
+  readonly #owner: object;
+  readonly #remaining: Map<ParagraphPropertyTransientTemplateHandle, Capture>;
+  readonly #consumed = new Set<ParagraphPropertyTransientTemplateHandle>();
+
+  constructor(
+    issuer: TransientTemplateHandleIssuer,
+    owner: object,
+    selected: ReadonlyMap<ParagraphPropertyTransientTemplateHandle, Capture>,
+  ) {
+    if (issuer !== transientTemplateHandleIssuer) {
+      panic("Only a paragraph-property template store may begin handle resolution");
+    }
+    this.#owner = owner;
+    this.#remaining = new Map(selected);
+    Object.freeze(this);
+  }
+
+  consume(handle: ParagraphPropertyTransientTemplateHandle): Capture {
+    if (!handle.isValidated() || !handle.belongsTo(this.#owner)) {
+      throw new ParagraphPropertySourceValidationError({
+        code: "unknown_template_handle",
+        message: "A paragraph-property template handle belongs to a different store.",
+      });
+    }
+    if (this.#consumed.has(handle)) {
+      throw new ParagraphPropertySourceValidationError({
+        code: "duplicate_template_handle",
+        message: "A paragraph-property template handle was consumed more than once.",
+      });
+    }
+    const capture = this.#remaining.get(handle);
+    if (capture === undefined) {
+      throw new ParagraphPropertySourceValidationError({
+        code: "unknown_template_handle",
+        message: "A paragraph-property template handle is outside this resolution.",
+      });
+    }
+    this.#remaining.delete(handle);
+    this.#consumed.add(handle);
+    return capture;
+  }
+
+  assertFullyConsumed(): void {
+    if (this.#remaining.size !== 0) {
+      throw new ParagraphPropertySourceValidationError({
+        code: "unconsumed_template_handle",
+        message: "A paragraph-property template was not consumed during conversion.",
+      });
+    }
+  }
+}
+
+/** Bounded process-local owner for opaque template captures. */
+export class ParagraphPropertyTransientTemplateStore<Capture> {
+  readonly #capacity: number;
+  readonly #captures = new Map<ParagraphPropertyTransientTemplateHandle, Capture>();
+  readonly #owner = Object.freeze({});
+  #nextOrdinal = 0;
+
+  constructor(capacity: number) {
+    if (!Number.isSafeInteger(capacity) || capacity < 1) {
+      panic("A paragraph-property template store requires a positive safe capacity");
+    }
+    this.#capacity = capacity;
+  }
+
+  registerAll(captures: readonly Capture[]): readonly ParagraphPropertyTransientTemplateHandle[] {
+    if (this.#captures.size + captures.length > this.#capacity) {
+      throw new ParagraphPropertySourceValidationError({
+        code: "template_capacity_exceeded",
+        message: "Paragraph-property template capture capacity was exceeded.",
+      });
+    }
+    const handles = captures.map((capture) => {
+      const handle = new ParagraphPropertyTransientTemplateHandle(
+        transientTemplateHandleIssuer,
+        this.#owner,
+        this.#nextOrdinal,
+      );
+      this.#nextOrdinal += 1;
+      this.#captures.set(handle, capture);
+      return handle;
+    });
+    return Object.freeze(handles);
+  }
+
+  beginResolution(
+    handles: readonly ParagraphPropertyTransientTemplateHandle[],
+  ): ParagraphPropertyTransientTemplateResolution<Capture> {
+    const selected = new Map<ParagraphPropertyTransientTemplateHandle, Capture>();
+    for (const handle of handles) {
+      if (!handle.isValidated() || !handle.belongsTo(this.#owner)) {
+        throw new ParagraphPropertySourceValidationError({
+          code: "unknown_template_handle",
+          message: "A paragraph-property template handle belongs to a different store.",
+        });
+      }
+      if (selected.has(handle)) {
+        throw new ParagraphPropertySourceValidationError({
+          code: "duplicate_template_handle",
+          message: "A paragraph-property template handle occurs more than once.",
+        });
+      }
+      const capture = this.#captures.get(handle);
+      if (capture === undefined) {
+        throw new ParagraphPropertySourceValidationError({
+          code: "unknown_template_handle",
+          message: "A paragraph-property template handle is unknown to this store.",
+        });
+      }
+      selected.set(handle, capture);
+    }
+    return new ParagraphPropertyTransientTemplateResolution(
+      transientTemplateHandleIssuer,
+      this.#owner,
+      selected,
+    );
+  }
+}

--- a/packages/core/src/docx/paragraphPropertySourceIdentity.ts
+++ b/packages/core/src/docx/paragraphPropertySourceIdentity.ts
@@ -1,10 +1,19 @@
 import { panic, TaggedError } from "better-result";
 
-const PARAGRAPH_SOURCE_TOKEN_VERSION = "folio-ppr-v2";
-const PARAGRAPH_SOURCE_TOKEN_PREFIX = "p2s";
+const PARAGRAPH_SOURCE_TOKEN_VERSION = "folio-ppr-v3";
+const PARAGRAPH_SOURCE_TOKEN_PREFIX = "p3s";
+export const PARAGRAPH_PROPERTY_SOURCE_MAX_PARAGRAPHS = 100_000;
+export const PARAGRAPH_PROPERTY_SOURCE_MAX_STORIES = 10_000;
+export const PARAGRAPH_PROPERTY_SOURCE_MAX_STORY_IDENTIFIER_CODE_UNITS = 1_024;
+export const PARAGRAPH_PROPERTY_SOURCE_MAX_CONTRACT_CODE_UNITS = 2_000_000;
+const PARAGRAPH_PROPERTY_SOURCE_MAX_SERIALIZED_TOKEN_CODE_UNITS =
+  PARAGRAPH_PROPERTY_SOURCE_MAX_STORY_IDENTIFIER_CODE_UNITS * 3 + 32;
+const PARAGRAPH_PROPERTY_SOURCE_MAX_SERIALIZED_ORDINAL_CODE_UNITS = (
+  PARAGRAPH_PROPERTY_SOURCE_MAX_PARAGRAPHS - 1
+).toString(36).length;
 const SHA256_HEX = /^[0-9a-f]{64}$/;
 const SOURCE_TOKEN =
-  /^p2s:(comment|document|header|footer|footnote|endnote):([^:]*):(0|[1-9a-z][0-9a-z]*)$/;
+  /^p3s:(comment|document|header|footer|footnote|endnote):([^:]*):(0|[1-9a-z][0-9a-z]*)$/;
 
 /** Result of reifying serialized paragraph-source metadata at a trust boundary. */
 export type ParagraphPropertySourceAttribute<T> =
@@ -26,8 +35,15 @@ const serializedStoryIdentifier = (story: ParagraphPropertySourceStory): string 
     case "comment":
       return String(story.commentId);
     case "footer":
-    case "header":
+    case "header": {
+      if (
+        story.relationshipId.length === 0 ||
+        story.relationshipId.length > PARAGRAPH_PROPERTY_SOURCE_MAX_STORY_IDENTIFIER_CODE_UNITS
+      ) {
+        panic("Paragraph-property relationship identity exceeds its bounded wire contract");
+      }
       return encodeURIComponent(story.relationshipId);
+    }
     case "endnote":
     case "footnote":
       return String(story.noteId);
@@ -53,13 +69,23 @@ const readStory = (type: string, identifier: string): ParagraphPropertySourceSto
     }
     case "footer":
     case "header": {
+      if (
+        identifier.length === 0 ||
+        identifier.length > PARAGRAPH_PROPERTY_SOURCE_MAX_STORY_IDENTIFIER_CODE_UNITS * 3
+      ) {
+        return null;
+      }
       let relationshipId: string;
       try {
         relationshipId = decodeURIComponent(identifier);
       } catch {
         return null;
       }
-      if (!relationshipId || encodeURIComponent(relationshipId) !== identifier) {
+      if (
+        !relationshipId ||
+        relationshipId.length > PARAGRAPH_PROPERTY_SOURCE_MAX_STORY_IDENTIFIER_CODE_UNITS ||
+        encodeURIComponent(relationshipId) !== identifier
+      ) {
         return null;
       }
       return Object.freeze({ relationshipId, type });
@@ -90,9 +116,7 @@ export const canonicalParagraphPropertySourceStory = (
   return canonical;
 };
 
-export const paragraphPropertySourceStoryKey = (
-  story: ParagraphPropertySourceStory,
-): string => {
+export const paragraphPropertySourceStoryKey = (story: ParagraphPropertySourceStory): string => {
   const canonical = canonicalParagraphPropertySourceStory(story);
   return `${canonical.type}:${serializedStoryIdentifier(canonical)}`;
 };
@@ -122,42 +146,190 @@ export const paragraphPropertySourceStoriesEqual = (
   }
 };
 
+export const paragraphPropertySourceTokenWire = (
+  story: ParagraphPropertySourceStory,
+  ordinal: number,
+): string => {
+  if (
+    !Number.isSafeInteger(ordinal) ||
+    ordinal < 0 ||
+    ordinal >= PARAGRAPH_PROPERTY_SOURCE_MAX_PARAGRAPHS
+  ) {
+    panic("Paragraph-property source token ordinal is outside its bounded wire contract");
+  }
+  const canonicalStory = canonicalParagraphPropertySourceStory(story);
+  return `${PARAGRAPH_SOURCE_TOKEN_PREFIX}:${canonicalStory.type}:${serializedStoryIdentifier(canonicalStory)}:${ordinal.toString(36)}`;
+};
+
+type ParagraphPropertySourceCensusEntry = {
+  paragraphCount: number;
+  story: ParagraphPropertySourceStory;
+};
+
+type SerializedParagraphPropertySourceCensusEntry = readonly [
+  type: ParagraphPropertySourceStory["type"],
+  identifier: string,
+  paragraphCount: number,
+];
+
+const canonicalSourceCensus = (
+  entries: readonly ParagraphPropertySourceCensusEntry[],
+): readonly SerializedParagraphPropertySourceCensusEntry[] => {
+  if (entries.length > PARAGRAPH_PROPERTY_SOURCE_MAX_STORIES) {
+    throw new ParagraphPropertySourceValidationError({
+      code: "source_capacity_exceeded",
+      message: "Paragraph-property source story capacity was exceeded.",
+    });
+  }
+  let totalParagraphCount = 0;
+  const seen = new Set<string>();
+  const serialized: SerializedParagraphPropertySourceCensusEntry[] = [];
+  for (const { paragraphCount, story } of entries) {
+    if (
+      !Number.isSafeInteger(paragraphCount) ||
+      paragraphCount < 0 ||
+      paragraphCount > PARAGRAPH_PROPERTY_SOURCE_MAX_PARAGRAPHS
+    ) {
+      throw new ParagraphPropertySourceValidationError({
+        code: "source_capacity_exceeded",
+        message: "Paragraph-property source paragraph capacity was exceeded.",
+      });
+    }
+    totalParagraphCount += paragraphCount;
+    if (totalParagraphCount > PARAGRAPH_PROPERTY_SOURCE_MAX_PARAGRAPHS) {
+      throw new ParagraphPropertySourceValidationError({
+        code: "source_capacity_exceeded",
+        message: "Paragraph-property source paragraph capacity was exceeded.",
+      });
+    }
+    const canonicalStory = canonicalParagraphPropertySourceStory(story);
+    const key = paragraphPropertySourceStoryKey(canonicalStory);
+    if (seen.has(key)) {
+      throw new ParagraphPropertySourceValidationError({
+        code: "ambiguous_source",
+        message: "Paragraph-property source census contains duplicate story identity.",
+      });
+    }
+    seen.add(key);
+    serialized.push(
+      Object.freeze([
+        canonicalStory.type,
+        serializedStoryIdentifier(canonicalStory),
+        paragraphCount,
+      ]),
+    );
+  }
+  serialized.sort((left, right) => {
+    const leftKey = `${left[0]}:${left[1]}`;
+    const rightKey = `${right[0]}:${right[1]}`;
+    if (leftKey < rightKey) {
+      return -1;
+    }
+    return leftKey > rightKey ? 1 : 0;
+  });
+  return Object.freeze(serialized);
+};
+
+const censusCounts = (
+  entries: readonly SerializedParagraphPropertySourceCensusEntry[],
+): ReadonlyMap<string, number> => {
+  const counts = new Map<string, number>();
+  for (const [type, identifier, paragraphCount] of entries) {
+    const story = readStory(type, identifier);
+    if (!story) {
+      panic("Canonical paragraph-property source census became invalid");
+    }
+    counts.set(paragraphPropertySourceStoryKey(story), paragraphCount);
+  }
+  return counts;
+};
+
 /** A source-package contract that has passed the canonical grammar check. */
 export class ParagraphPropertySourceContract {
   readonly #validated = true;
+  readonly #storyParagraphCounts: ReadonlyMap<string, number>;
 
   private constructor(
     readonly serialized: string,
     readonly fingerprint: string,
+    entries: readonly SerializedParagraphPropertySourceCensusEntry[],
   ) {
+    this.#storyParagraphCounts = censusCounts(entries);
     Object.freeze(this);
   }
 
-  static fromDigest(sourceDigest: string): ParagraphPropertySourceContract {
+  static fromSourceCensus(
+    sourceDigest: string,
+    entries: readonly ParagraphPropertySourceCensusEntry[],
+  ): ParagraphPropertySourceContract {
     if (!SHA256_HEX.test(sourceDigest)) {
       panic("Paragraph-property source digest must be lowercase SHA-256 hex");
     }
-    return new ParagraphPropertySourceContract(
-      `${PARAGRAPH_SOURCE_TOKEN_VERSION}:${sourceDigest}`,
-      sourceDigest,
-    );
+    const census = canonicalSourceCensus(entries);
+    const serialized = `${PARAGRAPH_SOURCE_TOKEN_VERSION}:${sourceDigest}:${JSON.stringify(census)}`;
+    if (serialized.length > PARAGRAPH_PROPERTY_SOURCE_MAX_CONTRACT_CODE_UNITS) {
+      throw new ParagraphPropertySourceValidationError({
+        code: "source_capacity_exceeded",
+        message: "Paragraph-property source contract capacity was exceeded.",
+      });
+    }
+    return new ParagraphPropertySourceContract(serialized, sourceDigest, census);
   }
 
   static read(raw: unknown): ParagraphPropertySourceAttribute<ParagraphPropertySourceContract> {
     if (raw === null || raw === undefined) {
       return { status: "absent" };
     }
-    if (typeof raw !== "string") {
+    if (typeof raw !== "string" || raw.length > PARAGRAPH_PROPERTY_SOURCE_MAX_CONTRACT_CODE_UNITS) {
       return { raw, status: "invalid" };
     }
     const prefix = `${PARAGRAPH_SOURCE_TOKEN_VERSION}:`;
-    const digest = raw.startsWith(prefix) ? raw.slice(prefix.length) : "";
-    if (!SHA256_HEX.test(digest)) {
+    if (!raw.startsWith(prefix)) {
+      return { raw, status: "invalid" };
+    }
+    const digestStart = prefix.length;
+    const digest = raw.slice(digestStart, digestStart + 64);
+    if (!SHA256_HEX.test(digest) || raw.at(digestStart + 64) !== ":") {
+      return { raw, status: "invalid" };
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw.slice(digestStart + 65));
+    } catch {
+      return { raw, status: "invalid" };
+    }
+    if (!Array.isArray(parsed) || parsed.length > PARAGRAPH_PROPERTY_SOURCE_MAX_STORIES) {
+      return { raw, status: "invalid" };
+    }
+    const census: ParagraphPropertySourceCensusEntry[] = [];
+    for (const entry of parsed) {
+      if (
+        !Array.isArray(entry) ||
+        entry.length !== 3 ||
+        typeof entry[0] !== "string" ||
+        typeof entry[1] !== "string" ||
+        typeof entry[2] !== "number"
+      ) {
+        return { raw, status: "invalid" };
+      }
+      const story = readStory(entry[0], entry[1]);
+      if (!story) {
+        return { raw, status: "invalid" };
+      }
+      census.push({ paragraphCount: entry[2], story });
+    }
+    let canonical: readonly SerializedParagraphPropertySourceCensusEntry[];
+    try {
+      canonical = canonicalSourceCensus(census);
+    } catch {
+      return { raw, status: "invalid" };
+    }
+    if (`${prefix}${digest}:${JSON.stringify(canonical)}` !== raw) {
       return { raw, status: "invalid" };
     }
     return {
       status: "valid",
-      value: new ParagraphPropertySourceContract(raw, digest),
+      value: new ParagraphPropertySourceContract(raw, digest, canonical),
     };
   }
 
@@ -166,6 +338,9 @@ export class ParagraphPropertySourceContract {
       return { status: "absent" };
     }
     if (typeof raw !== "string") {
+      return { raw, status: "invalid" };
+    }
+    if (raw.length > PARAGRAPH_PROPERTY_SOURCE_MAX_SERIALIZED_TOKEN_CODE_UNITS) {
       return { raw, status: "invalid" };
     }
     const match = SOURCE_TOKEN.exec(raw);
@@ -178,16 +353,29 @@ export class ParagraphPropertySourceContract {
     if (!storyType || storyIdentifier === undefined || !serializedOrdinal) {
       return { raw, status: "invalid" };
     }
+    if (
+      storyIdentifier.length > PARAGRAPH_PROPERTY_SOURCE_MAX_STORY_IDENTIFIER_CODE_UNITS * 3 ||
+      serializedOrdinal.length > PARAGRAPH_PROPERTY_SOURCE_MAX_SERIALIZED_ORDINAL_CODE_UNITS
+    ) {
+      return { raw, status: "invalid" };
+    }
     const story = readStory(storyType, storyIdentifier);
     const ordinal = Number.parseInt(serializedOrdinal, 36);
-    if (!story || !Number.isSafeInteger(ordinal) || ordinal.toString(36) !== serializedOrdinal) {
+    if (
+      !story ||
+      !Number.isSafeInteger(ordinal) ||
+      ordinal < 0 ||
+      ordinal >= PARAGRAPH_PROPERTY_SOURCE_MAX_PARAGRAPHS ||
+      ordinal.toString(36) !== serializedOrdinal ||
+      ordinal >= (this.#storyParagraphCounts.get(paragraphPropertySourceStoryKey(story)) ?? 0)
+    ) {
       return { raw, status: "invalid" };
     }
     return {
       status: "valid",
       value: new ParagraphPropertySourceToken(
         paragraphPropertySourceTokenIssuer,
-        this.fingerprint,
+        this,
         raw,
         story,
         ordinal,
@@ -195,15 +383,8 @@ export class ParagraphPropertySourceContract {
     };
   }
 
-  bindStoryCensus(
-    story: ParagraphPropertySourceStory,
-    paragraphCount: number,
-  ): ParagraphPropertySourceTokenCensus {
-    return ParagraphPropertySourceTokenCensus.bind(this, story, paragraphCount);
-  }
-
   owns(token: ParagraphPropertySourceToken): boolean {
-    return this.#validated && token.belongsToContract(this.fingerprint);
+    return this.#validated && token.belongsTo(this);
   }
 }
 
@@ -213,11 +394,11 @@ type ParagraphPropertySourceTokenIssuer = typeof paragraphPropertySourceTokenIss
 /** A paragraph token whose syntax has passed the canonical grammar check. */
 export class ParagraphPropertySourceToken {
   readonly #validated = true;
-  readonly #contractFingerprint: string;
+  readonly #contract: ParagraphPropertySourceContract;
 
   constructor(
     issuer: ParagraphPropertySourceTokenIssuer,
-    contractFingerprint: string,
+    contract: ParagraphPropertySourceContract,
     readonly serialized: string,
     readonly story: ParagraphPropertySourceStory,
     readonly ordinal: number,
@@ -225,59 +406,16 @@ export class ParagraphPropertySourceToken {
     if (issuer !== paragraphPropertySourceTokenIssuer) {
       panic("Only a paragraph-property source census may issue tokens");
     }
-    this.#contractFingerprint = contractFingerprint;
+    this.#contract = contract;
     Object.freeze(this);
   }
 
   belongsTo(contract: ParagraphPropertySourceContract): boolean {
-    return this.#validated && contract.owns(this);
+    return this.#validated && this.#contract === contract;
   }
 
   belongsToStory(story: ParagraphPropertySourceStory): boolean {
     return this.#validated && paragraphPropertySourceStoriesEqual(this.story, story);
-  }
-
-  belongsToContract(fingerprint: string): boolean {
-    return this.#validated && this.#contractFingerprint === fingerprint;
-  }
-}
-
-/** The only token issuer: one complete, canonical story census. */
-class ParagraphPropertySourceTokenCensus {
-  readonly #tokens: readonly ParagraphPropertySourceToken[];
-
-  private constructor(tokens: readonly ParagraphPropertySourceToken[]) {
-    this.#tokens = Object.freeze(tokens);
-    Object.freeze(this);
-  }
-
-  static bind(
-    contract: ParagraphPropertySourceContract,
-    story: ParagraphPropertySourceStory,
-    paragraphCount: number,
-  ): ParagraphPropertySourceTokenCensus {
-    if (!Number.isSafeInteger(paragraphCount) || paragraphCount < 0) {
-      panic("A paragraph-property source census requires a non-negative safe paragraph count");
-    }
-    const canonicalStory = canonicalParagraphPropertySourceStory(story);
-    const tokens = Array.from({ length: paragraphCount }, (_, ordinal) =>
-      new ParagraphPropertySourceToken(
-        paragraphPropertySourceTokenIssuer,
-        contract.fingerprint,
-        `${PARAGRAPH_SOURCE_TOKEN_PREFIX}:${canonicalStory.type}:${serializedStoryIdentifier(canonicalStory)}:${ordinal.toString(36)}`,
-        canonicalStory,
-        ordinal,
-      ),
-    );
-    return new ParagraphPropertySourceTokenCensus(tokens);
-  }
-
-  tokenAt(ordinal: number): ParagraphPropertySourceToken {
-    const token = this.#tokens.at(ordinal);
-    if (!token) {
-      return panic("Paragraph-property source census ordinal is outside its bound story");
-    }
-    return token;
   }
 }
 
@@ -287,7 +425,11 @@ type TransientTemplateHandleIssuer = typeof transientTemplateHandleIssuer;
 export class ParagraphPropertyTransientTemplateHandle {
   readonly #owner: object;
 
-  constructor(issuer: TransientTemplateHandleIssuer, owner: object, readonly ordinal: number) {
+  constructor(
+    issuer: TransientTemplateHandleIssuer,
+    owner: object,
+    readonly ordinal: number,
+  ) {
     if (issuer !== transientTemplateHandleIssuer) {
       panic("Only a paragraph-property template store may issue transient handles");
     }
@@ -311,9 +453,12 @@ export const PARAGRAPH_PROPERTY_SOURCE_VALIDATION_CODES = [
   "duplicate_token",
   "invalid_state",
   "invalid_template_handle",
+  "ownership_transition_mismatch",
   "template_capacity_exceeded",
   "transient_state",
   "invalid_token",
+  "source_capacity_exceeded",
+  "state_capacity_exceeded",
   "unconsumed_template_handle",
   "unknown_template_handle",
   "unknown_token",

--- a/packages/core/src/docx/serializer/paragraphSerializer.ts
+++ b/packages/core/src/docx/serializer/paragraphSerializer.ts
@@ -35,10 +35,13 @@ import type {
   ShadingProperties,
   TextFormatting,
 } from "../../types/document";
-import { PARAGRAPH_MARK_CHANGE_KINDS } from "@stll/docx-core/model";
+import {
+  canonicalParagraphPropertySourceFingerprintJson,
+  PARAGRAPH_MARK_CHANGE_KINDS,
+  paragraphPropertySourceFingerprintFromFormatting,
+} from "@stll/docx-core/model";
 import { panic } from "better-result";
 import { isValidHexColor } from "../../utils/colorResolver";
-import { canonicalJson } from "../../utils/canonicalJson";
 import { numPrEqual } from "../numberingParser";
 import { getParagraphPropertySource } from "../paragraphPropertySource";
 import { reconcileRawSdtPr } from "../sdtPropertiesPatch";
@@ -709,7 +712,11 @@ const verifiedParagraphPropertySource = (
   if (replayableSource === null) {
     return null;
   }
-  return canonicalJson(formatting ?? {}) === source.formattingJson ? replayableSource : null;
+  return canonicalParagraphPropertySourceFingerprintJson(
+    paragraphPropertySourceFingerprintFromFormatting(formatting),
+  ) === source.fingerprintJson
+    ? replayableSource
+    : null;
 };
 
 const withTrailingParagraphPropertyChildren = (

--- a/packages/core/src/docx/server/materializeYjsDocx.test.ts
+++ b/packages/core/src/docx/server/materializeYjsDocx.test.ts
@@ -6,7 +6,6 @@ import * as Y from "yjs";
 
 import { toProseDoc } from "../../prosemirror/conversion/toProseDoc";
 import { writeYjsParagraphSourceContract } from "../../prosemirror/yjsParagraphSourceContract";
-import { PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR } from "../paragraphPropertySource";
 import { parseDocx } from "../parser";
 import { createDocx, createEmptyDocx } from "../rezip";
 import { createEmptyDocument } from "../../utils/createDocument";
@@ -110,6 +109,8 @@ describe("materializeYjsDocx", () => {
     expect(outputXml).not.toContain("_docxParagraphSource");
     expect(outputXml).not.toContain("folio-ppr-v1");
     expect(outputXml).not.toContain("p1d:");
+    expect(outputXml).not.toContain("folio-ppr-v3");
+    expect(outputXml).not.toContain("p3s:");
   });
 
   test("rejects a state update without Folio's document fragment", async () => {
@@ -177,10 +178,26 @@ describe("materializeYjsDocx", () => {
     if (!first || !second) {
       throw new Error("Source fixture lost a paragraph");
     }
+    const firstState = first.attrs["_paragraphPropertyState"];
+    const secondState = second.attrs["_paragraphPropertyState"];
+    if (
+      typeof firstState !== "object" ||
+      firstState === null ||
+      !("type" in firstState) ||
+      firstState.type !== "imported" ||
+      !("token" in firstState) ||
+      typeof firstState.token !== "string" ||
+      typeof secondState !== "object" ||
+      secondState === null ||
+      !("type" in secondState) ||
+      secondState.type !== "imported"
+    ) {
+      throw new Error("Source fixture paragraphs must carry imported property state");
+    }
     const duplicated = initialState.apply(
       initialState.tr.setNodeMarkup(secondPos, undefined, {
         ...second.attrs,
-        [PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR]: first.attrs[PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR],
+        _paragraphPropertyState: { ...secondState, token: firstState.token },
       }),
     );
     const yjsUpdate = encodeCollaborativeDocument(duplicated.doc);
@@ -196,15 +213,23 @@ describe("materializeYjsDocx", () => {
     const sourceDocument = await parseDocx(sourceDocx, { preloadFonts: false });
     const initialState = EditorState.create({ doc: toProseDoc(sourceDocument) });
     const first = initialState.doc.child(0);
-    const sourceToken = first.attrs[PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR];
-    if (typeof sourceToken !== "string") {
+    const firstState = first.attrs["_paragraphPropertyState"];
+    if (
+      typeof firstState !== "object" ||
+      firstState === null ||
+      !("type" in firstState) ||
+      firstState.type !== "imported" ||
+      !("token" in firstState) ||
+      typeof firstState.token !== "string"
+    ) {
       throw new Error("Source fixture paragraph must carry a source token");
     }
+    const sourceToken = firstState.token;
     const unknownToken = `${sourceToken.slice(0, sourceToken.lastIndexOf(":"))}:zz`;
     const spoofed = initialState.apply(
       initialState.tr.setNodeMarkup(0, undefined, {
         ...first.attrs,
-        [PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR]: unknownToken,
+        _paragraphPropertyState: { ...firstState, token: unknownToken },
       }),
     );
     const yjsUpdate = encodeCollaborativeDocument(spoofed.doc);

--- a/packages/core/src/docx/server/materializeYjsDocx.ts
+++ b/packages/core/src/docx/server/materializeYjsDocx.ts
@@ -74,13 +74,13 @@ const readProseMirrorDocument = (yjsUpdate: Uint8Array) => {
         });
       }
       const contract = readYjsParagraphSourceContract(ydoc);
-      if (!contract) {
+      if (contract.status !== "valid") {
         throw new FolioYjsDocxMaterializationError({
           code: "source_mismatch",
           message: "Yjs update does not identify its paragraph-property source document.",
         });
       }
-      return withParagraphSourceContract(initProseMirrorDoc(fragment, schema).doc, contract);
+      return withParagraphSourceContract(initProseMirrorDoc(fragment, schema).doc, contract.value);
     },
     catch: (cause) =>
       cause instanceof FolioYjsDocxMaterializationError

--- a/packages/core/src/internal/headlessRevisionResolution.ts
+++ b/packages/core/src/internal/headlessRevisionResolution.ts
@@ -3,7 +3,7 @@ import { Fragment, Slice, type Mark, type MarkType, type Node as PMNode } from "
 import type { Transaction } from "prosemirror-state";
 import { ReplaceStep, StepMap, type Mappable } from "prosemirror-transform";
 
-import { recreateProseNodeWithParagraphPropertySource } from "../docx/paragraphPropertySource";
+import { recreateProseNode } from "../prosemirror/recreateNode";
 import { expectRunPropertyChangeMarkAttrs } from "../prosemirror/attrs";
 import { reconstructRejectedRunFormattingMarks } from "../prosemirror/runPropertyChangeResolution";
 import { RUN_FORMATTING_MARK_NAMES } from "../prosemirror/runFormattingMarkNames";
@@ -109,7 +109,7 @@ const rebuildNode = (
   content: Fragment,
   marks: readonly Mark[] = source.marks,
 ): PMNode =>
-  recreateProseNodeWithParagraphPropertySource(source, {
+  recreateProseNode(source, {
     attrs,
     content,
     marks,

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -38,6 +38,10 @@ import type { ParagraphFormatting } from "../../types/document";
 import { normalizeHorizontalScalePercent } from "../../utils/horizontalScale";
 import { DRAWING_RAW_XML_MODES, isOoxmlSymbolCharacter } from "@stll/docx-core/model";
 import { isParagraphDirection } from "../paragraphDirection";
+import {
+  readAuthoredParagraphProperties,
+  readParagraphPropertyState,
+} from "../paragraphPropertyState";
 import type {
   BlockSdtAttrs,
   CharacterSpacingAttrs,
@@ -437,8 +441,71 @@ export const readParagraphAttrs = (node: PMNode): ReadProseMirrorAttrsResult<Par
     "paragraph.attrs.defaultTextFormatting",
     issues,
   );
+  const paragraphPropertyState = readParagraphPropertyState(attrs["_paragraphPropertyState"]);
+  if (paragraphPropertyState.status !== "valid") {
+    issues.push({
+      path: "paragraph.attrs._paragraphPropertyState",
+      message: "Expected mandatory validated paragraph-property state.",
+    });
+  }
+  const paragraphPropertyInheritance = readAuthoredParagraphProperties(
+    attrs["_paragraphPropertyInheritance"],
+  );
+  if (paragraphPropertyInheritance.status !== "valid") {
+    issues.push({
+      path: "paragraph.attrs._paragraphPropertyInheritance",
+      message: "Expected mandatory inherited paragraph-property object.",
+    });
+  }
+  const paragraphMarkFormatting = attrs["_paragraphMarkFormatting"];
+  if (!isRecord(paragraphMarkFormatting)) {
+    issues.push({
+      path: "paragraph.attrs._paragraphMarkFormatting",
+      message: "Expected mandatory paragraph-mark formatting object.",
+    });
+  } else {
+    const paragraphMarkKeys = new Set(["runProperties", "runInWithNext"]);
+    for (const key of Object.keys(paragraphMarkFormatting)) {
+      if (!paragraphMarkKeys.has(key)) {
+        issues.push({
+          path: `paragraph.attrs._paragraphMarkFormatting.${key}`,
+          message: "Expected a paragraph-mark property.",
+        });
+      }
+    }
+    optionalNestedRecord(
+      paragraphMarkFormatting,
+      "runProperties",
+      "paragraph.attrs._paragraphMarkFormatting.runProperties",
+      issues,
+      validateTextFormatting,
+    );
+    optionalBoolean(
+      paragraphMarkFormatting,
+      "runInWithNext",
+      "paragraph.attrs._paragraphMarkFormatting.runInWithNext",
+      issues,
+    );
+  }
   optionalRecord(attrs, "numPr", "paragraph.attrs.numPr", issues);
   validateNumPr(attrs["numPr"], issues);
+  optionalRecord(attrs, "numPrFromStyle", "paragraph.attrs.numPrFromStyle", issues);
+  validateNumPr(attrs["numPrFromStyle"], issues);
+  const numberingLevelIndent = attrs["_numberingLevelIndent"];
+  if (numberingLevelIndent !== undefined && numberingLevelIndent !== null) {
+    if (!isRecord(numberingLevelIndent)) {
+      issues.push({
+        path: "paragraph.attrs._numberingLevelIndent",
+        message: "Expected an object.",
+      });
+    } else {
+      validateParagraphFormatting(
+        { numPr: attrs["numPr"], numberingLevelIndent },
+        "paragraph.attrs",
+        issues,
+      );
+    }
+  }
   optionalBookmarkArray(attrs["bookmarks"], issues);
   optionalEmptyHyperlinkArray(attrs["_emptyHyperlinks"], issues);
   optionalAutospacingBase(attrs, "paragraph.attrs._autospacingBase", issues);

--- a/packages/core/src/prosemirror/attrs/index.ts
+++ b/packages/core/src/prosemirror/attrs/index.ts
@@ -38,9 +38,10 @@ import type { ParagraphFormatting } from "../../types/document";
 import { normalizeHorizontalScalePercent } from "../../utils/horizontalScale";
 import { DRAWING_RAW_XML_MODES, isOoxmlSymbolCharacter } from "@stll/docx-core/model";
 import { isParagraphDirection } from "../paragraphDirection";
+import type { ParagraphPropertySourceAttribute } from "../../docx/paragraphPropertySourceIdentity";
 import {
-  readAuthoredParagraphProperties,
   readParagraphPropertyState,
+  type ParagraphPropertyState,
 } from "../paragraphPropertyState";
 import type {
   BlockSdtAttrs,
@@ -448,64 +449,10 @@ export const readParagraphAttrs = (node: PMNode): ReadProseMirrorAttrsResult<Par
       message: "Expected mandatory validated paragraph-property state.",
     });
   }
-  const paragraphPropertyInheritance = readAuthoredParagraphProperties(
-    attrs["_paragraphPropertyInheritance"],
-  );
-  if (paragraphPropertyInheritance.status !== "valid") {
-    issues.push({
-      path: "paragraph.attrs._paragraphPropertyInheritance",
-      message: "Expected mandatory inherited paragraph-property object.",
-    });
-  }
-  const paragraphMarkFormatting = attrs["_paragraphMarkFormatting"];
-  if (!isRecord(paragraphMarkFormatting)) {
-    issues.push({
-      path: "paragraph.attrs._paragraphMarkFormatting",
-      message: "Expected mandatory paragraph-mark formatting object.",
-    });
-  } else {
-    const paragraphMarkKeys = new Set(["runProperties", "runInWithNext"]);
-    for (const key of Object.keys(paragraphMarkFormatting)) {
-      if (!paragraphMarkKeys.has(key)) {
-        issues.push({
-          path: `paragraph.attrs._paragraphMarkFormatting.${key}`,
-          message: "Expected a paragraph-mark property.",
-        });
-      }
-    }
-    optionalNestedRecord(
-      paragraphMarkFormatting,
-      "runProperties",
-      "paragraph.attrs._paragraphMarkFormatting.runProperties",
-      issues,
-      validateTextFormatting,
-    );
-    optionalBoolean(
-      paragraphMarkFormatting,
-      "runInWithNext",
-      "paragraph.attrs._paragraphMarkFormatting.runInWithNext",
-      issues,
-    );
-  }
   optionalRecord(attrs, "numPr", "paragraph.attrs.numPr", issues);
   validateNumPr(attrs["numPr"], issues);
   optionalRecord(attrs, "numPrFromStyle", "paragraph.attrs.numPrFromStyle", issues);
-  validateNumPr(attrs["numPrFromStyle"], issues);
-  const numberingLevelIndent = attrs["_numberingLevelIndent"];
-  if (numberingLevelIndent !== undefined && numberingLevelIndent !== null) {
-    if (!isRecord(numberingLevelIndent)) {
-      issues.push({
-        path: "paragraph.attrs._numberingLevelIndent",
-        message: "Expected an object.",
-      });
-    } else {
-      validateParagraphFormatting(
-        { numPr: attrs["numPr"], numberingLevelIndent },
-        "paragraph.attrs",
-        issues,
-      );
-    }
-  }
+  validateNumPr(attrs["numPrFromStyle"], "paragraph.attrs.numPrFromStyle", issues);
   optionalBookmarkArray(attrs["bookmarks"], issues);
   optionalEmptyHyperlinkArray(attrs["_emptyHyperlinks"], issues);
   optionalAutospacingBase(attrs, "paragraph.attrs._autospacingBase", issues);
@@ -524,6 +471,14 @@ export const readParagraphAttrs = (node: PMNode): ReadProseMirrorAttrsResult<Par
 
 export const expectParagraphAttrs = (node: PMNode): ParagraphAttrs =>
   expectCachedNodeAttrs(node, paragraphAttrsCache, readParagraphAttrs, "paragraph attrs");
+
+/** Read the one nominal paragraph-property state through the PM adapter boundary. */
+export const readProseParagraphPropertyState = (
+  node: PMNode,
+): ParagraphPropertySourceAttribute<ParagraphPropertyState> =>
+  node.type.name === "paragraph"
+    ? readParagraphPropertyState(node.attrs["_paragraphPropertyState"])
+    : { raw: node.type.name, status: "invalid" };
 
 export const readHardBreakAttrs = (node: PMNode): ReadProseMirrorAttrsResult<HardBreakAttrs> => {
   const attrs = attrsRecord(node.attrs);

--- a/packages/core/src/prosemirror/commands/comments.ts
+++ b/packages/core/src/prosemirror/commands/comments.ts
@@ -7,8 +7,7 @@
 import type { Mark, MarkType, Node as PMNode } from "prosemirror-model";
 import type { Command, EditorState, Transaction } from "prosemirror-state";
 import { removeRow, TableMap } from "prosemirror-tables";
-
-import { joinProseParagraphsWithRightPropertySource } from "../../docx/paragraphPropertySource";
+import { panic } from "better-result";
 
 import {
   appendHeadlessInlineResolution,
@@ -32,20 +31,29 @@ import {
   finalParagraphsOf,
   paragraphEndsItsContainer,
 } from "../containerFinalParagraph";
-import { resolveParagraphDefaultTextFormatting } from "../conversion/toProseDoc";
 import {
   markChangedParagraphRanges,
   markStructuralChange,
   markTrackedSectionEndpointRemoval,
 } from "../extensions/features/ParagraphChangeTrackerExtension";
 import { getDocumentStyleResolver } from "../plugins/documentStyles";
+import { getDocumentNumbering } from "../plugins/documentNumbering";
+import {
+  applyParagraphPropertyProjection,
+  joinParagraphsWithProperties,
+  patchParagraphPropertyProjection,
+  preserveParagraphProperties,
+  type ParagraphPropertyProjection,
+} from "../paragraphPropertyMutation";
 import { paragraphRunStyleContextAt } from "../runStyleFormatting";
 import { reconstructRejectedRunFormattingMarks } from "../runPropertyChangeResolution";
 import { holdsNoContent } from "../zeroWidthAnchors";
 import { getFolioNodeRevisionCarriers } from "../revisionCarriers";
 import { RUN_FORMATTING_MARK_NAMES } from "../runFormattingMarkNames";
-import { setParagraphAttrsWithRebasedRunFormatting } from "../rebaseParagraphRunFormatting";
+import { setParagraphPropertiesWithRebasedRunFormatting } from "../rebaseParagraphRunFormatting";
 import type { ParagraphPropertyChangeAttrs } from "../schema/nodes";
+import { paragraphPropertiesForStyleTransition } from "../styles/resolvedStyleAttrs";
+import { tableParagraphStyleContextAtPositions } from "../tableConditionalFormatting";
 import { getTableCellMergeChange } from "../tableCellMergeRevision";
 import { reconcileTableGridAfterColumnRemoval } from "../tableGridMutation";
 import {
@@ -55,9 +63,8 @@ import {
 } from "./tableCellMergeResolution";
 import {
   hasSerializableParagraphPropertyChange,
-  paragraphRejectAttrPatch,
-  paragraphRejectOriginalFormatting,
   paragraphPropertiesSnapshot,
+  projectParagraphPropertyRejection,
   removeParagraphPropertyChanges,
   sectionRejectProperties,
   tableCellRejectAttrPatch,
@@ -144,6 +151,10 @@ function resolveChange(
     const insertionType = state.schema.marks["insertion"];
     const deletionType = state.schema.marks["deletion"];
     const styleResolver = getDocumentStyleResolver(state);
+    const numbering = getDocumentNumbering(state);
+    const tableContextByPosition = styleResolver
+      ? tableParagraphStyleContextAtPositions(state.doc, styleResolver)
+      : new Map();
 
     const keepType = mode === "accept" ? insertionType : deletionType;
     const removeType = mode === "accept" ? deletionType : insertionType;
@@ -178,10 +189,12 @@ function resolveChange(
           }
 
           const boundaryCovered = rangeCoversParagraphBoundary(from, to, pos, node);
-          let nextAttrs: Record<string, unknown> | null = null;
+          const attrs = expectParagraphAttrs(node);
+          let projection: ParagraphPropertyProjection | null = null;
+          let restoredParagraphProperties = false;
 
           // Process paragraph property changes (w:pPrChange)
-          const propertyChanges = expectParagraphAttrs(node)._propertyChanges;
+          const propertyChanges = attrs._propertyChanges;
 
           if (Array.isArray(propertyChanges) && propertyChanges.length > 0 && boundaryCovered) {
             const matchesPropertyChange = (change: ParagraphPropertyChangeAttrs) =>
@@ -199,8 +212,7 @@ function resolveChange(
               } else {
                 remaining = rejection.remaining;
               }
-              nextAttrs = {
-                ...node.attrs,
+              const propertyChangePatch = {
                 _propertyChanges: remaining.length > 0 ? remaining : null,
               };
               if (rejection?.type === "restore-previous") {
@@ -211,35 +223,43 @@ function resolveChange(
                 // propertyChangeScope.ts. Earlier removed runs were folded
                 // into the next retained entry, so only a removed trailing
                 // run changes the live properties now.
-                const inheritedAlignment = expectParagraphAttrs(node).alignmentFromStyle;
-                let previousFormattingFromStyle: ParagraphFormatting | undefined;
+                const tableContext = tableContextByPosition.get(pos);
+                let resolvedStyle:
+                  | ReturnType<NonNullable<typeof styleResolver>["resolveParagraphStyleInTable"]>
+                  | undefined;
                 if (styleResolver) {
-                  previousFormattingFromStyle = styleResolver.resolveParagraphStyle(
+                  resolvedStyle = styleResolver.resolveParagraphStyleInTable(
                     rejection.previousFormatting?.styleId,
-                  ).paragraphFormatting;
-                } else if (inheritedAlignment !== undefined) {
-                  previousFormattingFromStyle = { alignment: inheritedAlignment };
+                    tableContext?.pPr,
+                  );
                 }
-                Object.assign(
-                  nextAttrs,
-                  paragraphRejectAttrPatch(
-                    rejection.previousFormatting,
-                    previousFormattingFromStyle,
-                  ),
-                );
-                const restoredFormatting = paragraphRejectOriginalFormatting(
-                  rejection.previousFormatting,
-                  node.attrs["_originalFormatting"],
-                );
-                nextAttrs["_originalFormatting"] = restoredFormatting;
-                if (styleResolver) {
-                  nextAttrs["defaultTextFormatting"] =
-                    resolveParagraphDefaultTextFormatting(
-                      rejection.previousFormatting?.styleId,
-                      restoredFormatting ?? undefined,
-                      styleResolver,
-                    ) ?? null;
+                if (styleResolver && resolvedStyle) {
+                  const styleId = rejection.previousFormatting?.styleId ?? null;
+                  const styleName = styleId ? styleResolver.getStyle(styleId)?.name : undefined;
+                  projection = paragraphPropertiesForStyleTransition({
+                    attrs: { ...attrs, ...propertyChangePatch },
+                    identity: {
+                      styleId,
+                      ...(styleName ? { styleName } : {}),
+                    },
+                    numbering,
+                    resolved: resolvedStyle,
+                    transition: {
+                      type: "restore-authored",
+                      formatting: rejection.previousFormatting,
+                    },
+                    styleResolver,
+                    ...(tableContext?.rPr ? { tableRunFormatting: tableContext.rPr } : {}),
+                  });
+                } else {
+                  projection = projectParagraphPropertyRejection({
+                    attrs: { ...attrs, ...propertyChangePatch },
+                    previousFormatting: rejection.previousFormatting,
+                  });
                 }
+                restoredParagraphProperties = true;
+              } else {
+                projection = preserveParagraphProperties(attrs, propertyChangePatch);
               }
             }
           }
@@ -274,25 +294,33 @@ function resolveChange(
               if (remaining.length > 0) {
                 restored.propertyChanges = remaining;
               }
-              nextAttrs = nextAttrs ?? { ...node.attrs };
-              nextAttrs["_sectionProperties"] = restored;
-              nextAttrs["sectionBreakType"] = sectionBreakTypeFromSectionStart(
-                restored.sectionStart,
-              );
+              const patch = {
+                _sectionProperties: restored,
+                sectionBreakType: sectionBreakTypeFromSectionStart(restored.sectionStart),
+              };
+              projection = projection
+                ? patchParagraphPropertyProjection({ projection, patch })
+                : preserveParagraphProperties(attrs, patch);
             }
           }
 
-          if (nextAttrs) {
-            const styleChanged = nextAttrs["styleId"] !== node.attrs["styleId"];
-            if (styleChanged && styleResolver) {
-              setParagraphAttrsWithRebasedRunFormatting({
-                nextAttrs,
+          if (projection) {
+            if (restoredParagraphProperties && styleResolver) {
+              const tableContext = tableContextByPosition.get(pos);
+              setParagraphPropertiesWithRebasedRunFormatting({
+                projection,
                 paragraphPosition: pos,
                 styleResolver,
+                tableRunFormatting: tableContext?.rPr ?? null,
                 tr,
               });
             } else {
-              tr.setNodeMarkup(pos, undefined, nextAttrs);
+              applyParagraphPropertyProjection({
+                transaction: tr,
+                pos,
+                projection,
+                source: { type: "preserve" },
+              });
             }
           }
 
@@ -487,24 +515,33 @@ function resolveChange(
         // Section properties live on the paragraph mark. Resolving that mark
         // away removes its section endpoint, so the joined paragraph keeps
         // only a section endpoint already owned by the following paragraph.
-        const formattingOwner = emptyFirstParagraph ? nextNode : paragraph;
-        const joinedAttrs = {
-          ...formattingOwner.attrs,
-          pPrMark: nextNode.attrs["pPrMark"],
-          sectionBreakType: nextNode.attrs["sectionBreakType"],
-          _sectionProperties: nextNode.attrs["_sectionProperties"],
-        };
         try {
-          if (emptyFirstParagraph) {
-            joinProseParagraphsWithRightPropertySource({
-              attrs: joinedAttrs,
-              pos: joinPos,
-              transaction: tr,
-            });
-          } else {
-            tr.join(joinPos);
-            tr.setNodeMarkup(mappedPos, undefined, joinedAttrs);
+          joinParagraphsWithProperties({
+            transaction: tr,
+            joinPos,
+            transition: { type: "join-right-paragraph-mark-retains" },
+          });
+          const joined = tr.doc.nodeAt(mappedPos);
+          if (joined?.type.name !== "paragraph") {
+            panic("Resolving a paragraph mark lost the joined paragraph");
           }
+          const joinedAttrs = expectParagraphAttrs(joined);
+          const restored = preserveParagraphProperties(
+            joinedAttrs,
+            emptyFirstParagraph
+              ? nextNode.attrs
+              : {
+                  pPrMark: nextNode.attrs["pPrMark"],
+                  sectionBreakType: nextNode.attrs["sectionBreakType"],
+                  _sectionProperties: nextNode.attrs["_sectionProperties"],
+                },
+          );
+          applyParagraphPropertyProjection({
+            transaction: tr,
+            pos: mappedPos,
+            projection: restored,
+            source: { type: "preserve" },
+          });
           if (ownsSectionEndpoint(paragraph)) {
             removedSectionEndpointCount++;
             removedSectionReferences.push(...sectionReferencesOf(paragraph));

--- a/packages/core/src/prosemirror/commands/propertyChangeScope.ts
+++ b/packages/core/src/prosemirror/commands/propertyChangeScope.ts
@@ -44,7 +44,17 @@ import {
   paragraphSpacingAttrPatch,
   paragraphSpacingFromFormatting,
 } from "../paragraphSpacing";
-import { directionFromBidi } from "../paragraphDirection";
+import { directionFromBidi, directionToBidi } from "../paragraphDirection";
+import {
+  isParagraphFormattingPropertyKey,
+  isPprIndentAttr,
+  isPprSpacingAttr,
+  PPR_CHANGE_BOOLEAN_ATTR_KEYS,
+  PPR_CHANGE_SCOPED_ATTR_KEYS,
+  PPR_CHANGE_SCOPED_FORMATTING_KEYS,
+  PPR_OPAQUE_FORMATTING_KEYS,
+  PPR_PARAGRAPH_MARK_FORMATTING_KEYS,
+} from "../paragraphPropertyProjection";
 import type { ParagraphAttrs, ParagraphPropertyChangeAttrs } from "../schema/nodes";
 
 /** Editor-only suggestions are rebased away before save; every other entry emits `w:pPrChange`. */
@@ -182,7 +192,7 @@ export const paragraphPropertiesSnapshot = (node: PMNode): ParagraphPropertySnap
   const attrs = expectParagraphAttrs(node);
   const snapshot: Record<string, unknown> = {};
   for (const key of PPR_CHANGE_SCOPED_ATTR_KEYS) {
-    if (key === "alignment" || PPR_SPACING_ATTR_KEYS.has(key)) {
+    if (key === "alignment" || isPprSpacingAttr(key) || isPprIndentAttr(key)) {
       continue;
     }
     const value: unknown = attrs[key];
@@ -293,7 +303,10 @@ export function paragraphRejectAttrPatch(
     patch["direction"] = directionFromBidi(prev.bidi);
   }
   for (const [key, value] of Object.entries(prev)) {
-    if (PPR_CHANGE_SCOPED_ATTR_KEY_SET.has(key) || PPR_PARSER_ONLY_KEYS.has(key)) {
+    if (
+      PPR_CHANGE_SCOPED_ATTR_KEY_SET.has(key) ||
+      isParagraphFormattingPropertyKey(key)
+    ) {
       continue;
     }
     patch[key] = value ?? null;

--- a/packages/core/src/prosemirror/commands/propertyChangeScope.ts
+++ b/packages/core/src/prosemirror/commands/propertyChangeScope.ts
@@ -11,26 +11,16 @@
  * sectPr on a paragraph, header/footer references inside a sectPr, the
  * paragraph-mark rPr) are separately modeled and must survive a reject.
  *
- * This module is the single place that maps stored "previous" records onto
- * ProseMirror node attrs. Records come in two shapes:
- *
- * - parser-shaped: `parseParagraphPropertyChanges` (docx/paragraphParser.ts)
- *   stores a `ParagraphFormatting`, whose keys mostly match paragraph attr
- *   names except `bidi` (attr `direction`) and the autospacing flags (attr
- *   `_autospacingBase`); table records store `TableFormatting` /
- *   `TableRowFormatting` / `TableCellFormatting`.
- * - attr-shaped: editor-created suggestions (ListExtension) snapshot the
- *   paragraph attrs directly (including list-rendering bookkeeping attrs).
- *
- * Both shapes normalize here; per key, an attr-shaped value wins when present.
+ * Paragraph records use the canonical authored-property state. Table records
+ * retain their table-specific formatting models below.
  */
 
 import type { Node as PMNode } from "prosemirror-model";
+import { isParagraphFormattingPropertyKey } from "@stll/docx-core/model";
 
 import type {
   BorderSpec,
   CellMargins,
-  ParagraphFormatting,
   SectionProperties,
   TableCellFormatting,
   TableFormatting,
@@ -38,23 +28,16 @@ import type {
 } from "../../types/document";
 
 import { expectParagraphAttrs } from "../attrs";
-import { directParagraphAlignment } from "../paragraphAlignment";
 import {
-  directParagraphSpacing,
-  paragraphSpacingAttrPatch,
-  paragraphSpacingFromFormatting,
-} from "../paragraphSpacing";
-import { directionFromBidi, directionToBidi } from "../paragraphDirection";
+  isGovernedParagraphAttr,
+  transitionParagraphProperties,
+  type ParagraphPropertyProjection,
+} from "../paragraphPropertyMutation";
 import {
-  isParagraphFormattingPropertyKey,
-  isPprIndentAttr,
-  isPprSpacingAttr,
-  PPR_CHANGE_BOOLEAN_ATTR_KEYS,
-  PPR_CHANGE_SCOPED_ATTR_KEYS,
-  PPR_CHANGE_SCOPED_FORMATTING_KEYS,
-  PPR_OPAQUE_FORMATTING_KEYS,
-  PPR_PARAGRAPH_MARK_FORMATTING_KEYS,
-} from "../paragraphPropertyProjection";
+  authoredParagraphPropertiesFromFormatting,
+  expectParagraphPropertyState,
+  type ParagraphPropertyProjectionContext,
+} from "../paragraphPropertyState";
 import type { ParagraphAttrs, ParagraphPropertyChangeAttrs } from "../schema/nodes";
 
 /** Editor-only suggestions are rebased away before save; every other entry emits `w:pPrChange`. */
@@ -127,227 +110,46 @@ export const removeParagraphPropertyChanges = (
   return { type: "restore-previous", remaining, previousFormatting: removedPrevious };
 };
 
-/**
- * Paragraph attrs governed by a `w:pPrChange` — the attrs
- * `paragraphFormattingToAttrs` (conversion/toProseDoc.ts) can produce from a
- * parsed `CT_PPrBase` (ECMA-376 §17.13.5.29). Rejecting a pPrChange restores
- * the stored old pPr wholesale for exactly these keys: a key absent from the
- * stored record resets to the schema default (`null`).
- *
- * Deliberately OUT of scope (preserved across a reject):
- * - identity/structure: `paraId`, `textId`, `sectionBreakType`,
- *   `_sectionProperties`, `_propertyChanges`, `pPrMark`, `bookmarks`,
- *   `_emptyHyperlinks`, `renderedPageBreakBefore`
- * - paragraph-mark run properties — `pPr/rPr` is CT_PPr-only, not part of the
- *   CT_PPrBase payload a pPrChange stores: `defaultTextFormatting`,
- *   `runInWithNext` (`w:specVanish` lives in that rPr)
- * - load-time style/numbering bookkeeping the command layer cannot recompute
- *   without a style resolver: `numPrFromStyle`, the `list*` rendering attrs,
- *   `alignmentFromStyle`, `spacingFromDocDefaults`, and resolved style-spacing
- *   provenance in `spacingFromImplicitDefaultStyle`
- */
-export const PPR_CHANGE_SCOPED_ATTR_KEYS = [
-  "styleId",
-  "numPr",
-  "alignment",
-  "spaceBefore",
-  "spaceAfter",
-  "lineSpacing",
-  "lineSpacingRule",
-  "lineSpacingExplicit",
-  "snapToGrid",
-  "spacingExplicit",
-  "indentLeft",
-  "indentRight",
-  "indentFirstLine",
-  "hangingIndent",
-  "borders",
-  "shading",
-  "tabs",
-  "pageBreakBefore",
-  "keepNext",
-  "keepLines",
-  "widowControl",
-  "contextualSpacing",
-  "outlineLevel",
-  "direction",
-  "_autospacingBase",
-] as const satisfies readonly (keyof ParagraphAttrs)[];
-
-const PPR_CHANGE_SCOPED_ATTR_KEY_SET: ReadonlySet<string> = new Set(PPR_CHANGE_SCOPED_ATTR_KEYS);
-
-/** Effective/bookkeeping attrs whose tracked snapshot must use direct provenance instead. */
-const PPR_SPACING_ATTR_KEYS: ReadonlySet<keyof ParagraphAttrs> = new Set([
-  "spaceBefore",
-  "spaceAfter",
-  "lineSpacing",
-  "lineSpacingRule",
-  "lineSpacingExplicit",
-  "spacingExplicit",
-  "_autospacingBase",
-]);
-
 /** The in-scope paragraph properties as they stand, for a `w:pPrChange` record. */
 export const paragraphPropertiesSnapshot = (node: PMNode): ParagraphPropertySnapshot => {
   const attrs = expectParagraphAttrs(node);
-  const snapshot: Record<string, unknown> = {};
-  for (const key of PPR_CHANGE_SCOPED_ATTR_KEYS) {
-    if (key === "alignment" || isPprSpacingAttr(key) || isPprIndentAttr(key)) {
-      continue;
-    }
-    const value: unknown = attrs[key];
-    if (
-      key === "hangingIndent" &&
-      value === false &&
-      attrs._originalFormatting?.hangingIndent === undefined
-    ) {
-      continue;
-    }
-    if (value !== null && value !== undefined) {
-      snapshot[key] = value;
-    }
-  }
-  const directAlignment = directParagraphAlignment(attrs);
-  if (directAlignment !== undefined) {
-    snapshot["alignment"] = directAlignment;
-  }
-  Object.assign(snapshot, directParagraphSpacing(attrs));
-  return snapshot;
+  return structuredClone(
+    expectParagraphPropertyState(attrs._paragraphPropertyState).authoredPPr,
+  );
 };
 
-/**
- * Parser-shaped `ParagraphFormatting` keys that must NOT merge through to
- * attrs verbatim: they either normalize to a differently named attr
- * (`bidi` → `direction`, autospacing flags → `_autospacingBase`), have no
- * attr representation and round-trip via `_originalFormatting` only
- * (`frame`, `suppressLineNumbers`, `suppressAutoHyphens`), or sit outside
- * the CT_PPrBase scope entirely (`runProperties`, `runInWithNext` — the
- * paragraph-mark rPr) and so must never overwrite the live value on reject.
- */
-const PPR_PARSER_ONLY_KEYS: ReadonlySet<string> = new Set([
-  "bidi",
-  "beforeAutospacing",
-  "afterAutospacing",
-  "runProperties",
-  "runInWithNext",
-  "frame",
-  "suppressLineNumbers",
-  "suppressAutoHyphens",
-  "numPrFromStyle",
-]);
+type ParagraphPropertyRejectionProjectionOptions = {
+  attrs: ParagraphAttrs;
+  previousFormatting: ParagraphPropertySnapshot | null | undefined;
+  context?: ParagraphPropertyProjectionContext;
+};
 
-/**
- * `ParagraphFormatting` keys inside the CT_PPrBase scope, used to rebuild
- * `_originalFormatting` after a reject (old pPr wholesale within scope,
- * paragraph-mark rPr fields preserved from the live original).
- */
-const PPR_CHANGE_SCOPED_FORMATTING_KEYS = [
-  "styleId",
-  "numPr",
-  "alignment",
-  "bidi",
-  "spaceBefore",
-  "spaceAfter",
-  "lineSpacing",
-  "lineSpacingRule",
-  "beforeAutospacing",
-  "afterAutospacing",
-  "spacingExplicit",
-  "indentLeft",
-  "indentRight",
-  "indentFirstLine",
-  "hangingIndent",
-  "borders",
-  "shading",
-  "tabs",
-  "pageBreakBefore",
-  "keepNext",
-  "keepLines",
-  "widowControl",
-  "contextualSpacing",
-  "outlineLevel",
-  "frame",
-  "suppressLineNumbers",
-  "suppressAutoHyphens",
-] as const satisfies readonly (keyof ParagraphFormatting)[];
-
-/**
- * Build the attr patch that rejecting one pPrChange applies to a paragraph:
- * every in-scope key set to the stored previous value, or reset to `null`
- * when the stored old pPr does not carry it. Keys the record captured beyond
- * the scoped set (editor-created list suggestions snapshot list-rendering
- * bookkeeping attrs) merge through 1:1 so their pre-change values restore too.
- */
-export function paragraphRejectAttrPatch(
-  previousFormatting: ParagraphPropertySnapshot | null | undefined,
-  inheritedFormatting?: ParagraphFormatting,
-): AttrPatch {
-  const prev: ParagraphPropertySnapshot = previousFormatting ?? {};
-  const patch: AttrPatch = {};
-  for (const key of PPR_CHANGE_SCOPED_ATTR_KEYS) {
-    patch[key] = Object.hasOwn(prev, key) ? (prev[key] ?? null) : null;
-  }
-  if (!Object.hasOwn(prev, "alignment")) {
-    patch["alignment"] = inheritedFormatting?.alignment ?? null;
-  }
-  patch["alignmentFromStyle"] = inheritedFormatting?.alignment;
-  const directSpacing = paragraphSpacingFromFormatting(prev);
-  const inheritedSpacing = paragraphSpacingFromFormatting(inheritedFormatting);
-  Object.assign(
-    patch,
-    paragraphSpacingAttrPatch({ direct: directSpacing, inherited: inheritedSpacing }),
-  );
-  // Parser-shaped fallbacks for the two renamed attrs (attr-shaped records
-  // carrying `direction` / `_autospacingBase` already won above).
-  if (!Object.hasOwn(prev, "direction")) {
-    patch["direction"] = directionFromBidi(prev.bidi);
-  }
-  for (const [key, value] of Object.entries(prev)) {
-    if (
-      PPR_CHANGE_SCOPED_ATTR_KEY_SET.has(key) ||
-      isParagraphFormattingPropertyKey(key)
-    ) {
+/** Canonical accepted/rejected-view projection for a removed `w:pPrChange`. */
+export const projectParagraphPropertyRejection = ({
+  attrs,
+  previousFormatting,
+  context,
+}: ParagraphPropertyRejectionProjectionOptions): ParagraphPropertyProjection => {
+  const previous = previousFormatting ?? {};
+  const nextAttrs = { ...attrs };
+  for (const [key, value] of Object.entries(previous)) {
+    if (isParagraphFormattingPropertyKey(key) || isGovernedParagraphAttr(key)) {
       continue;
     }
-    patch[key] = value ?? null;
+    Reflect.set(nextAttrs, key, value ?? null);
   }
-  return patch;
-}
-
-/**
- * Rebuild the paragraph's `_originalFormatting` (the serializer's pPr source)
- * after a reject: the stored old pPr wholesale within CT_PPrBase scope, with
- * the paragraph-mark rPr fields (`runProperties`, `runInWithNext`) preserved
- * from the live original — a pPrChange cannot store them, so a reject must
- * not drop them.
- */
-export function paragraphRejectOriginalFormatting(
-  previousFormatting: ParagraphPropertySnapshot | null | undefined,
-  liveOriginal: unknown,
-): ParagraphFormatting | null {
-  const prev: ParagraphPropertySnapshot = previousFormatting ?? {};
-  const result: Partial<ParagraphFormatting> = {};
-  for (const key of PPR_CHANGE_SCOPED_FORMATTING_KEYS) {
-    const value = Object.hasOwn(prev, key) ? prev[key] : undefined;
-    if (value != null) {
-      Object.assign(result, { [key]: value });
-    }
-  }
-  const live = isRecord(liveOriginal) ? liveOriginal : {};
-  if (live["runProperties"] != null) {
-    Object.assign(result, { runProperties: live["runProperties"] });
-  }
-  if (live["runInWithNext"] != null) {
-    Object.assign(result, { runInWithNext: live["runInWithNext"] });
-  }
-  if (Object.keys(result).length === 0) {
-    return null;
-  }
-  // SAFETY: every key written above is a ParagraphFormatting key; values come
-  // from a stored ParagraphFormatting (or an attr-shaped snapshot whose
-  // overlapping keys share the same value shapes).
-  return result;
-}
+  return transitionParagraphProperties({
+    attrs: nextAttrs,
+    state: {
+      type: "update",
+      authored: {
+        type: "replace",
+        authoredPPr: authoredParagraphPropertiesFromFormatting(previous),
+      },
+      context: context === undefined ? { type: "preserve" } : { type: "replace", context },
+    },
+  });
+};
 
 /**
  * Rejected section properties: the stored old sectPr wholesale, preserving
@@ -481,8 +283,4 @@ function cellBordersToAttr(borders: NonNullable<TableCellFormatting["borders"]>)
     result.right = borders.right;
   }
   return result;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/packages/core/src/prosemirror/commands/sectionBreak.ts
+++ b/packages/core/src/prosemirror/commands/sectionBreak.ts
@@ -7,6 +7,15 @@
 import type { Command } from "prosemirror-state";
 import { TextSelection } from "prosemirror-state";
 
+import { expectParagraphAttrs } from "../attrs";
+import {
+  applyParagraphPropertyProjection,
+  createEditorParagraphProperties,
+  createParagraphNodeFromProjection,
+  preserveParagraphProperties,
+  splitParagraphWithProperties,
+} from "../paragraphPropertyMutation";
+
 type InsertableSectionBreak = "nextPage" | "continuous";
 
 /**
@@ -42,12 +51,20 @@ function insertSectionBreakAtCursor(breakType: InsertableSectionBreak): Command 
         // Position of the paragraph node the cursor sits in. Unaffected by the
         // split below, since the split happens at a later position.
         const paraPos = $from.before();
-        tr.split($from.pos);
+        splitParagraphWithProperties({
+          transaction: tr,
+          pos: $from.pos,
+          transition: { type: "split-left-created-right-retains" },
+        });
         const firstPara = tr.doc.nodeAt(paraPos);
-        if (firstPara) {
-          tr.setNodeMarkup(paraPos, undefined, {
-            ...firstPara.attrs,
-            sectionBreakType: breakType,
+        if (firstPara?.type.name === "paragraph") {
+          applyParagraphPropertyProjection({
+            transaction: tr,
+            pos: paraPos,
+            projection: preserveParagraphProperties(expectParagraphAttrs(firstPara), {
+              sectionBreakType: breakType,
+            }),
+            source: { type: "preserve" },
           });
         }
         // The split position maps to the start of the second paragraph's
@@ -59,7 +76,16 @@ function insertSectionBreakAtCursor(breakType: InsertableSectionBreak): Command 
         // `$from.pos` would land on a block boundary, which is not a valid
         // `TextSelection` position and would throw.
         const pos = $from.pos;
-        tr.insert(pos, paragraphType.create({ sectionBreakType: breakType }));
+        tr.insert(
+          pos,
+          createParagraphNodeFromProjection({
+            type: paragraphType,
+            projection: createEditorParagraphProperties({
+              attrs: { sectionBreakType: breakType },
+              authoredPPr: {},
+            }),
+          }),
+        );
         cursorPos = pos + 1;
       }
 

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -11,7 +11,11 @@
  */
 
 import { panic } from "better-result";
-import { DRAWING_RAW_XML_MODES } from "@stll/docx-core/model";
+import {
+  DRAWING_RAW_XML_MODES,
+  paragraphFormattingWithPropertySourceFingerprint,
+  paragraphPropertySourceFingerprintFromParts,
+} from "@stll/docx-core/model";
 import type { Node as PMNode, Mark } from "prosemirror-model";
 import { Fragment } from "prosemirror-model";
 
@@ -22,6 +26,7 @@ import {
   ParagraphPropertySourceValidationError,
   type ParagraphPropertySourceValidationCode,
   ParagraphPropertyStorySource,
+  type ParagraphPropertySourceToken,
   type ParagraphPropertyTemplateResolutionRegistry,
   type ParagraphPropertyTemplateStore,
   assignEditorCreatedParagraphPropertySource,
@@ -29,7 +34,6 @@ import {
   copyParagraphPropertySource,
   getDocumentParagraphPropertySourceContract,
   readProseDocumentParagraphPropertySourceContract,
-  recreateProseNodeWithParagraphPropertySource,
 } from "../../docx/paragraphPropertySource";
 import { normalizeHorizontalScalePercent } from "../../utils/horizontalScale";
 import { parseShapeGeometryAdjustments } from "../shapeGeometryAdjustments";
@@ -123,13 +127,8 @@ import {
   expectTrackedChangeMarkAttrs,
   expectUnderlineMarkAttrs,
 } from "../attrs";
-import { autospacingMatchesBase, hasAutospacingBaseSide } from "../autospacingBase";
-import { directionToBidi } from "../paragraphDirection";
-import { directParagraphAlignment } from "../paragraphAlignment";
-import { directParagraphSpacing } from "../paragraphSpacing";
 import {
-  paragraphRejectAttrPatch,
-  paragraphRejectOriginalFormatting,
+  projectParagraphPropertyRejection,
   removeParagraphPropertyChanges,
 } from "../commands/propertyChangeScope";
 import { RUN_FORMATTING_MARK_NAMES } from "../runFormattingMarkNames";
@@ -159,8 +158,16 @@ import type {
   TextBoxAttrs,
 } from "../schema/nodes";
 import { assertValidProseMirrorDocument } from "../validation";
+import { recreateProseNode } from "../recreateNode";
 import { resolveNumberedRefFields } from "../numberedRefFields";
-import { readParagraphPropertyState } from "../paragraphPropertyState";
+import {
+  expectParagraphPropertyState,
+  readParagraphPropertyState,
+} from "../paragraphPropertyState";
+import {
+  createParagraphNodeFromProjection,
+  type ParagraphPropertyProjection,
+} from "../paragraphPropertyMutation";
 import { expectTextBoxAnchorAttrs } from "../textBoxAnchorAttrs";
 import { runShadingAttrsToShading, shadingToRunShadingAttrs } from "./runShadingMark";
 import { mergeTextFormatting } from "../../utils/textFormattingMerge";
@@ -286,6 +293,7 @@ const sourceValidationError = (
 type ValidatedParagraphPropertySources = {
   source?: ParagraphPropertyStorySource;
   templateRegistry?: ParagraphPropertyTemplateResolutionRegistry;
+  tokens: ReadonlyMap<PMNode, ParagraphPropertySourceToken>;
 };
 
 const validateParagraphPropertySourceStates = (
@@ -294,6 +302,7 @@ const validateParagraphPropertySourceStates = (
   templateStore?: ParagraphPropertyTemplateStore,
 ): ValidatedParagraphPropertySources => {
   const seen = new Set<string>();
+  const tokens = new Map<PMNode, ParagraphPropertySourceToken>();
   const templateHandles = [];
   pmDoc.descendants((node) => {
     if (node.type.name !== "paragraph") {
@@ -320,33 +329,32 @@ const validateParagraphPropertySourceStates = (
       templateHandles.push(state.value.handle);
       return false;
     }
-    const token = state.value.token;
+    const rawToken = state.value.token;
     if (!source) {
       throw sourceValidationError(
         "contract_mismatch",
         "An imported paragraph-property state requires its explicit source story.",
-        token.serialized,
+        rawToken,
       );
     }
-    if (!source.owns(token)) {
-      throw sourceValidationError(
-        "unknown_token",
-        "A paragraph-property token belongs to a different source document.",
-        token.serialized,
-      );
-    }
-    if (seen.has(token.serialized)) {
+    const token = source.readToken(rawToken);
+    if (seen.has(rawToken)) {
       throw sourceValidationError(
         "duplicate_token",
         "A paragraph-property token is attached to more than one paragraph.",
-        token.serialized,
+        rawToken,
       );
     }
-    seen.add(token.serialized);
+    seen.add(rawToken);
+    tokens.set(node, token);
     return false;
   });
   const templateRegistry = templateStore?.beginResolution(templateHandles);
-  return { ...(source ? { source } : {}), ...(templateRegistry ? { templateRegistry } : {}) };
+  return {
+    tokens,
+    ...(source ? { source } : {}),
+    ...(templateRegistry ? { templateRegistry } : {}),
+  };
 };
 
 const paragraphPropertySourceResolver = (
@@ -365,7 +373,11 @@ const paragraphPropertySourceResolver = (
         if (!sources.source) {
           panic("Validated paragraph-property token lost its source owner");
         }
-        sources.source.bindImportedParagraph(paragraph, state.value.token);
+        const token = sources.tokens.get(source);
+        if (!token) {
+          panic("Validated paragraph-property token lost its source-bound identity");
+        }
+        sources.source.bindImportedParagraph(paragraph, token);
         return;
       }
       case "transient-template":
@@ -567,7 +579,11 @@ function stripSuggestedInlineMarks(
  *
  * Reads go through the typed attr readers (adapter-boundary convention).
  */
-function stripSuggestedNodeAttrs(node: PMNode): Record<string, unknown> | null {
+type SuggestedNodePropertyProjection =
+  | { type: "attrs"; attrs: Record<string, unknown> }
+  | { type: "paragraph-properties"; projection: ParagraphPropertyProjection };
+
+function stripSuggestedNodeAttrs(node: PMNode): SuggestedNodePropertyProjection | null {
   const name = node.type.name;
   if (name === "paragraph") {
     const attrs = expectParagraphAttrs(node);
@@ -585,7 +601,7 @@ function stripSuggestedNodeAttrs(node: PMNode): Record<string, unknown> | null {
     if (removal.type === "unchanged") {
       return null;
     }
-    const nextAttrs: Record<string, unknown> = {
+    const nextAttrs = {
       ...node.attrs,
       _propertyChanges: removal.remaining.length > 0 ? removal.remaining : null,
     };
@@ -594,18 +610,20 @@ function stripSuggestedNodeAttrs(node: PMNode): Record<string, unknown> | null {
     // previous snapshot above, so removing the proposal cannot overwrite the
     // later authored state.
     if (removal.type === "restore-previous") {
-      Object.assign(nextAttrs, paragraphRejectAttrPatch(removal.previousFormatting));
-      nextAttrs["_originalFormatting"] = paragraphRejectOriginalFormatting(
-        removal.previousFormatting,
-        nextAttrs["_originalFormatting"],
-      );
+      return {
+        type: "paragraph-properties",
+        projection: projectParagraphPropertyRejection({
+          attrs: expectParagraphAttrs(node),
+          previousFormatting: removal.previousFormatting,
+        }),
+      };
     }
-    return nextAttrs;
+    return { type: "attrs", attrs: nextAttrs };
   }
   if (name === "tableRow") {
     const rowAttrs = expectTableRowAttrs(node);
     if (rowAttrs.trDel?.provenance === "suggested") {
-      return { ...rowAttrs, trDel: null };
+      return { type: "attrs", attrs: { ...rowAttrs, trDel: null } };
     }
     return null;
   }
@@ -613,7 +631,7 @@ function stripSuggestedNodeAttrs(node: PMNode): Record<string, unknown> | null {
     const cellAttrs = expectTableCellAttrs(node);
     const marker = cellAttrs.cellMarker;
     if (marker && marker.kind !== "merge" && marker.info.provenance === "suggested") {
-      return { ...cellAttrs, cellMarker: null };
+      return { type: "attrs", attrs: { ...cellAttrs, cellMarker: null } };
     }
   }
   return null;
@@ -702,8 +720,16 @@ function mapSuggestionStrippedNode(
     return node;
   }
   const content = Fragment.fromArray(children);
-  return recreateProseNodeWithParagraphPropertySource(node, {
-    ...(nextAttrs === null ? {} : { attrs: nextAttrs }),
+  if (nextAttrs?.type === "paragraph-properties") {
+    return createParagraphNodeFromProjection({
+      type: node.type,
+      projection: nextAttrs.projection,
+      content,
+      marks: node.marks,
+    });
+  }
+  return recreateProseNode(node, {
+    ...(nextAttrs === null ? {} : { attrs: nextAttrs.attrs }),
     content,
   });
 }
@@ -741,7 +767,7 @@ function materializeNumberedRefValues(doc: PMNode): PMNode {
     if (node.type.name === "field" || node.type.name === "structuredField") {
       const displayText = results.get(node);
       if (displayText !== undefined) {
-        return recreateProseNodeWithParagraphPropertySource(node, {
+        return recreateProseNode(node, {
           attrs: { ...node.attrs, displayText },
         });
       }
@@ -759,7 +785,7 @@ function materializeNumberedRefValues(doc: PMNode): PMNode {
       changed ||= mappedChild !== child;
     });
     return changed
-      ? recreateProseNodeWithParagraphPropertySource(node, {
+      ? recreateProseNode(node, {
           content: Fragment.fromArray(children),
         })
       : node;
@@ -1438,331 +1464,22 @@ const propertyChangeFromAttrs = (change: ParagraphPropertyChangeAttrs): Paragrap
   };
 };
 
-/**
- * Whether the paragraph's numbering still comes verbatim from its style —
- * serialize no direct `<w:numPr>` then. The moment a list command changes
- * `numPr` the values diverge and the numbering serializes as direct
- * formatting, so a stale provenance value can never swallow a user edit.
- */
-function isStyleSourcedNumPr(attrs: ParagraphAttrs): boolean {
-  return (
-    attrs.numPrFromStyle != null &&
-    attrs.numPr != null &&
-    numPrEqual(attrs.numPr, attrs.numPrFromStyle)
-  );
-}
-
-// OOXML boolean paragraph toggles are tri-state: `true` (on), `false` (explicit
-// off, serialized as `w:val="0"`), and `null`/`undefined` (inherit). A
-// truthiness check (`if (attrs.key)`) silently collapses explicit `false` into
-// "inherit", dropping the user's decision on save. Branch on `== null` so every
-// toggle routed through here preserves `false`. (Direction is handled
-// separately via the `direction` discriminated union, not this helper.)
-type BooleanToggleKey =
-  | "pageBreakBefore"
-  | "widowControl"
-  | "snapToGrid"
-  | "kinsoku"
-  | "overflowPunctuation"
-  | "suppressAutoHyphens";
-
-function assignBooleanToggle(
-  result: ParagraphFormatting,
-  attrs: ParagraphAttrs,
-  orig: ParagraphFormatting,
-  key: BooleanToggleKey,
-): void {
-  // Tri-state: `true`/`false` are explicit decisions to keep; `null`/`undefined`
-  // is "undecided" and clears the toggle. `exactOptionalPropertyTypes` forbids
-  // assigning `undefined`, and `no-dynamic-delete` forbids `delete result[key]`,
-  // so the undecided branch clears via `Reflect.deleteProperty`. This preserves
-  // an explicit `false` that a truthiness check would have dropped.
-  const value = attrs[key] ?? undefined;
-  if (value === (orig[key] ?? undefined)) {
-    return;
-  }
-  if (value === undefined) {
-    Reflect.deleteProperty(result, key);
-  } else {
-    result[key] = value;
-  }
-}
-
 function paragraphAttrsToFormatting(attrs: ParagraphAttrs): ParagraphFormatting | undefined {
-  const directAlignment = directParagraphAlignment(attrs);
-  const directSpacing = directParagraphSpacing(attrs);
-  // If we have the original inline formatting from the DOCX, use it as a base
-  // for lossless round-trip. This preserves properties like contextualSpacing,
-  // widowControl, beforeAutospacing, runProperties, etc. that aren't tracked
-  // as individual PM attrs. It also avoids "inlining" style-inherited values
-  // (spacing, indentation, numPr) which would override style definitions
-  // and break rendering in Word/Pages/Google Docs.
-  //
-  // We then apply overrides for any properties the user may have changed
-  // via editor commands (alignment, list toggle, etc.).
-  const spaceBefore = Reflect.get(attrs, "spaceBefore");
-  const spaceAfter = Reflect.get(attrs, "spaceAfter");
-  const beforeHasAutospacingBase = hasAutospacingBaseSide(attrs._autospacingBase, "before");
-  const afterHasAutospacingBase = hasAutospacingBaseSide(attrs._autospacingBase, "after");
-  const beforeOriginalAutospacing = attrs._originalFormatting?.beforeAutospacing === true;
-  const afterOriginalAutospacing = attrs._originalFormatting?.afterAutospacing === true;
-  const beforeAutospacingEdited = beforeHasAutospacingBase
-    ? !autospacingMatchesBase(attrs._autospacingBase, "before", spaceBefore)
-    : beforeOriginalAutospacing && attrs._autospacingBase == null;
-  const afterAutospacingEdited = afterHasAutospacingBase
-    ? !autospacingMatchesBase(attrs._autospacingBase, "after", spaceAfter)
-    : afterOriginalAutospacing && attrs._autospacingBase == null;
-  const beforeIsInherited =
-    attrs.spacingFromDocDefaults?.before === true ||
-    attrs.spacingFromImplicitDefaultStyle?.before === true;
-  const afterIsInherited =
-    attrs.spacingFromDocDefaults?.after === true ||
-    attrs.spacingFromImplicitDefaultStyle?.after === true;
-  const shouldSerializeSpaceBefore =
-    typeof spaceBefore === "number" &&
-    (attrs.spacingExplicit?.before === true ||
-      beforeAutospacingEdited ||
-      (!beforeIsInherited && !beforeHasAutospacingBase));
-  const shouldSerializeSpaceAfter =
-    typeof spaceAfter === "number" &&
-    (attrs.spacingExplicit?.after === true ||
-      afterAutospacingEdited ||
-      (!afterIsInherited && !afterHasAutospacingBase));
-  const hasDirectLineSpacing = directSpacing?.lineSpacing !== undefined;
-  const hasDirectLineSpacingRule = directSpacing?.lineSpacingRule !== undefined;
-
-  if (attrs._originalFormatting) {
-    const orig = attrs._originalFormatting;
-    const result = { ...orig };
-
-    if (beforeAutospacingEdited) {
-      result.beforeAutospacing = false;
-      if (typeof spaceBefore === "number") {
-        result.spaceBefore = spaceBefore;
-      } else {
-        delete result.spaceBefore;
-      }
-    }
-    if (afterAutospacingEdited) {
-      result.afterAutospacing = false;
-      if (typeof spaceAfter === "number") {
-        result.spaceAfter = spaceAfter;
-      } else {
-        delete result.spaceAfter;
-      }
-    }
-
-    // A spacing command is a direct override even when the imported value was
-    // inherited from a style. Keep the explicit zero instead of dropping the
-    // side and letting the style value reappear on the next load.
-    if (orig.spaceBefore !== undefined || attrs.spacingExplicit?.before) {
-      if (typeof spaceBefore === "number") {
-        result.spaceBefore = spaceBefore;
-      } else {
-        Reflect.deleteProperty(result, "spaceBefore");
-      }
-    }
-    if (orig.spaceAfter !== undefined || attrs.spacingExplicit?.after) {
-      if (typeof spaceAfter === "number") {
-        result.spaceAfter = spaceAfter;
-      } else {
-        Reflect.deleteProperty(result, "spaceAfter");
-      }
-    }
-
-    const originalHasDirectLineSpacing = orig.lineSpacing !== undefined;
-    if (hasDirectLineSpacing || originalHasDirectLineSpacing) {
-      if (typeof attrs.lineSpacing === "number") {
-        result.lineSpacing = attrs.lineSpacing;
-      } else {
-        Reflect.deleteProperty(result, "lineSpacing");
-      }
-    }
-    const originalHasDirectLineSpacingRule = orig.lineSpacingRule !== undefined;
-    if (hasDirectLineSpacingRule || originalHasDirectLineSpacingRule) {
-      if (attrs.lineSpacingRule) {
-        result.lineSpacingRule = attrs.lineSpacingRule;
-      } else {
-        Reflect.deleteProperty(result, "lineSpacingRule");
-      }
-    }
-
-    // The effective value stays available for layout, but only the separately
-    // tracked direct value belongs in `w:pPr/w:jc`.
-    if (directAlignment === undefined) {
-      Reflect.deleteProperty(result, "alignment");
-    } else {
-      result.alignment = directAlignment;
-    }
-    if (isStyleSourcedNumPr(attrs)) {
-      // The numbering still comes verbatim from the paragraph style — don't
-      // materialize it as direct formatting (see ParagraphAttrs.numPrFromStyle).
-      delete result.numPr;
-      delete result.numPrFromStyle;
-    } else if (attrs.numPr !== orig.numPr && !numPrEqual(attrs.numPr, orig.numPr)) {
-      if (attrs.numPr) {
-        result.numPr = attrs.numPr;
-      } else {
-        delete result.numPr;
-      }
-      delete result.numPrFromStyle;
-    }
-    if (attrs.styleId !== (orig.styleId ?? undefined)) {
-      if (attrs.styleId) {
-        result.styleId = attrs.styleId;
-      } else {
-        delete result.styleId;
-      }
-    }
-    assignBooleanToggle(result, attrs, orig, "pageBreakBefore");
-    assignBooleanToggle(result, attrs, orig, "widowControl");
-    assignBooleanToggle(result, attrs, orig, "snapToGrid");
-    assignBooleanToggle(result, attrs, orig, "kinsoku");
-    assignBooleanToggle(result, attrs, orig, "overflowPunctuation");
-    assignBooleanToggle(result, attrs, orig, "suppressAutoHyphens");
-    if (attrs.spacingExplicit !== orig.spacingExplicit) {
-      if (attrs.spacingExplicit) {
-        result.spacingExplicit = attrs.spacingExplicit;
-      } else {
-        delete result.spacingExplicit;
-      }
-    }
-    // Resolve the paragraph direction to the OOXML `w:bidi` tri-state. An
-    // explicit `false` (forced LTR) is preserved so it serializes as
-    // `<w:bidi w:val="0"/>` and survives save/reload; `undefined` (undecided)
-    // clears it.
-    const bidi = directionToBidi(attrs.direction);
-    if (bidi !== (orig.bidi ?? undefined)) {
-      if (bidi === undefined) {
-        delete result.bidi;
-      } else {
-        result.bidi = bidi;
-      }
-    }
-
-    return result;
-  }
-
-  // Fallback: reconstruct formatting from individual attrs (e.g. for
-  // newly created paragraphs that don't have _originalFormatting)
-  const outlineLevel = Reflect.get(attrs, "outlineLevel");
-  const bidi = directionToBidi(attrs.direction);
-  const hasDirectAlignment = directAlignment !== undefined;
-  const hasFormatting =
-    hasDirectAlignment ||
-    shouldSerializeSpaceBefore ||
-    shouldSerializeSpaceAfter ||
-    beforeAutospacingEdited ||
-    afterAutospacingEdited ||
-    hasDirectLineSpacing ||
-    hasDirectLineSpacingRule ||
-    attrs.snapToGrid != null ||
-    attrs.indentLeft ||
-    attrs.indentRight ||
-    attrs.indentFirstLine ||
-    attrs.numPr ||
-    attrs.styleId ||
-    attrs.borders ||
-    attrs.shading ||
-    attrs.tabs ||
-    typeof outlineLevel === "number" ||
-    attrs.contextualSpacing ||
-    attrs.spacingExplicit ||
-    // Tri-state toggles: an explicit `false` is meaningful formatting and must
-    // keep the paragraph from short-circuiting to "no formatting".
-    bidi != null ||
-    attrs.pageBreakBefore != null ||
-    attrs.widowControl != null ||
-    attrs.kinsoku != null ||
-    attrs.overflowPunctuation != null ||
-    attrs.suppressAutoHyphens != null;
-
-  if (!hasFormatting) {
-    return undefined;
-  }
-
-  const f: ParagraphFormatting = {};
-  if (directAlignment !== undefined) {
-    f.alignment = directAlignment;
-  }
-  if (shouldSerializeSpaceBefore) {
-    f.spaceBefore = spaceBefore;
-  }
-  if (beforeAutospacingEdited) {
-    f.beforeAutospacing = false;
-  }
-  if (shouldSerializeSpaceAfter) {
-    f.spaceAfter = spaceAfter;
-  }
-  if (afterAutospacingEdited) {
-    f.afterAutospacing = false;
-  }
-  if (hasDirectLineSpacing && typeof attrs.lineSpacing === "number") {
-    f.lineSpacing = attrs.lineSpacing;
-  }
-  if (hasDirectLineSpacingRule && attrs.lineSpacingRule) {
-    f.lineSpacingRule = attrs.lineSpacingRule;
-  }
-  if (attrs.snapToGrid != null) {
-    f.snapToGrid = attrs.snapToGrid;
-  }
-  if (attrs.spacingExplicit) {
-    f.spacingExplicit = attrs.spacingExplicit;
-  }
-  if (attrs.indentLeft) {
-    f.indentLeft = attrs.indentLeft;
-  }
-  if (attrs.indentRight) {
-    f.indentRight = attrs.indentRight;
-  }
-  if (attrs.indentFirstLine) {
-    f.indentFirstLine = attrs.indentFirstLine;
-  }
-  if (attrs.hangingIndent) {
-    f.hangingIndent = attrs.hangingIndent;
-  }
-  if (attrs.numPr && !isStyleSourcedNumPr(attrs)) {
-    f.numPr = attrs.numPr;
-  }
-  if (attrs.styleId) {
-    f.styleId = attrs.styleId;
-  }
-  if (attrs.borders) {
-    f.borders = attrs.borders;
-  }
-  if (attrs.shading) {
-    f.shading = attrs.shading;
-  }
-  if (attrs.tabs) {
-    f.tabs = attrs.tabs;
-  }
-  if (typeof outlineLevel === "number") {
-    f.outlineLevel = outlineLevel;
-  }
-  if (attrs.contextualSpacing) {
-    f.contextualSpacing = attrs.contextualSpacing;
-  }
-  // Preserve explicit tri-state decisions, including `false` (which serializes
-  // as `w:val="0"`); only undecided `null` is omitted.
-  if (bidi != null) {
-    f.bidi = bidi;
-  }
-  if (attrs.pageBreakBefore != null) {
-    f.pageBreakBefore = attrs.pageBreakBefore;
-  }
-  if (attrs.widowControl != null) {
-    f.widowControl = attrs.widowControl;
-  }
-  if (attrs.kinsoku != null) {
-    f.kinsoku = attrs.kinsoku;
-  }
-  if (attrs.overflowPunctuation != null) {
-    f.overflowPunctuation = attrs.overflowPunctuation;
-  }
-  if (attrs.suppressAutoHyphens != null) {
-    f.suppressAutoHyphens = attrs.suppressAutoHyphens;
-  }
-  return f;
+  const state = expectParagraphPropertyState(attrs._paragraphPropertyState);
+  return paragraphFormattingWithPropertySourceFingerprint(
+    {
+      ...(state.context.numberingLevelIndent === null
+        ? {}
+        : { numberingLevelIndent: state.context.numberingLevelIndent }),
+      ...(state.context.numPrFromStyle === null
+        ? {}
+        : { numPrFromStyle: state.context.numPrFromStyle }),
+    },
+    paragraphPropertySourceFingerprintFromParts(
+      state.authoredPPr,
+      state.context.paragraphMark.authored,
+    ),
+  );
 }
 
 /**

--- a/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -15,31 +15,22 @@ import { DRAWING_RAW_XML_MODES } from "@stll/docx-core/model";
 import type { Node as PMNode, Mark } from "prosemirror-model";
 import { Fragment } from "prosemirror-model";
 
-import { numPrEqual } from "../../docx/numberingParser";
-import { visitDocxParagraphs } from "../../docx/paragraphTraversal";
 import { DATE_UTC_ATTRIBUTE } from "../../docx/trackedChangeInfo";
 import { createStyleEngine, type StyleEngine } from "../../style-engine";
 import {
   PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR,
   ParagraphPropertySourceValidationError,
   type ParagraphPropertySourceValidationCode,
+  ParagraphPropertyStorySource,
+  type ParagraphPropertyTemplateResolutionRegistry,
+  type ParagraphPropertyTemplateStore,
+  assignEditorCreatedParagraphPropertySource,
   copyDocumentParagraphPropertySourceContract,
-  copyParagraphPropertyCapture,
   copyParagraphPropertySource,
   getDocumentParagraphPropertySourceContract,
-  getParagraphPropertySource,
-  getParagraphPropertySourceCandidate,
-  getParagraphPropertySourceToken,
-  getParagraphPropertySourceTransferId,
-  getProseDocumentParagraphPropertySourceContract,
-  getProseParagraphPropertySourceToken,
-  isParagraphPropertySourceToken,
-  linkParagraphPropertySourceCandidate,
-  paragraphPropertySourceTokenMatchesContract,
+  readProseDocumentParagraphPropertySourceContract,
   recreateProseNodeWithParagraphPropertySource,
-  visitDocumentStoryParagraphs,
 } from "../../docx/paragraphPropertySource";
-import { canonicalJson } from "../../utils/canonicalJson";
 import { normalizeHorizontalScalePercent } from "../../utils/horizontalScale";
 import { parseShapeGeometryAdjustments } from "../shapeGeometryAdjustments";
 import { narrowEnum, ShapeOutlineStyleSchema } from "../../docx/parserEnums";
@@ -169,6 +160,7 @@ import type {
 } from "../schema/nodes";
 import { assertValidProseMirrorDocument } from "../validation";
 import { resolveNumberedRefFields } from "../numberedRefFields";
+import { readParagraphPropertyState } from "../paragraphPropertyState";
 import { expectTextBoxAnchorAttrs } from "../textBoxAnchorAttrs";
 import { runShadingAttrsToShading, shadingToRunShadingAttrs } from "./runShadingMark";
 import { mergeTextFormatting } from "../../utils/textFormattingMerge";
@@ -280,79 +272,6 @@ function textBoxWrapFromAttrs(attrs: TextBoxAttrs): ImageWrap | undefined {
   return wrap;
 }
 
-const assignUniqueParagraph = (
-  paragraphs: Map<string, Paragraph | null>,
-  paraId: string,
-  paragraph: Paragraph,
-): void => {
-  const existing = paragraphs.get(paraId);
-  if (!paragraphs.has(paraId) || existing === paragraph) {
-    paragraphs.set(paraId, paragraph);
-    return;
-  }
-  paragraphs.set(paraId, null);
-};
-
-const uniqueParagraphsById = (
-  content: BlockContent[],
-  includeTransferIds = false,
-): Map<string, Paragraph | null> => {
-  const paragraphs = new Map<string, Paragraph | null>();
-  visitDocxParagraphs({ documentBody: { content } }, (paragraph) => {
-    const { paraId } = paragraph;
-    if (paraId) {
-      assignUniqueParagraph(paragraphs, paraId, paragraph);
-    }
-    const transferId = includeTransferIds
-      ? getParagraphPropertySourceTransferId(paragraph)
-      : undefined;
-    if (transferId) {
-      assignUniqueParagraph(paragraphs, transferId, paragraph);
-    }
-  });
-  return paragraphs;
-};
-
-const restoreParagraphPropertySource = (paragraph: Paragraph, baseParagraph: Paragraph): void => {
-  copyParagraphPropertySource(paragraph, baseParagraph);
-
-  const baseFormatting = baseParagraph.formatting;
-  if (
-    !baseFormatting?.numPr ||
-    !baseFormatting.numPrFromStyle ||
-    !numPrEqual(baseFormatting.numPr, baseFormatting.numPrFromStyle)
-  ) {
-    return;
-  }
-  const { numPr, numPrFromStyle, ...authoredFormatting } = baseFormatting;
-  if (canonicalJson(paragraph.formatting ?? {}) !== canonicalJson(authoredFormatting)) {
-    return;
-  }
-  paragraph.formatting = { ...paragraph.formatting, numPr, numPrFromStyle };
-};
-
-const restoreParagraphPropertySources = (
-  content: BlockContent[],
-  baseContent: BlockContent[],
-  linkedTargets: ReadonlySet<Paragraph>,
-  linkedSources: ReadonlySet<Paragraph>,
-): void => {
-  const baseParagraphs = uniqueParagraphsById(baseContent, true);
-  for (const [paraId, paragraph] of uniqueParagraphsById(content)) {
-    const baseParagraph = baseParagraphs.get(paraId);
-    if (
-      !paragraph ||
-      !baseParagraph ||
-      linkedTargets.has(paragraph) ||
-      linkedSources.has(baseParagraph) ||
-      !getParagraphPropertySource(baseParagraph)
-    ) {
-      continue;
-    }
-    restoreParagraphPropertySource(paragraph, baseParagraph);
-  }
-};
-
 const sourceValidationError = (
   code: ParagraphPropertySourceValidationCode,
   message: string,
@@ -364,127 +283,114 @@ const sourceValidationError = (
     ...(token !== undefined ? { token } : {}),
   });
 
-const validateParagraphPropertySourceTokens = (
-  pmDoc: PMNode,
-  baseContent: BlockContent[],
-  contract: string,
-): Map<string, Paragraph> => {
-  const baseParagraphs = new Map<string, Paragraph>();
-  visitDocumentStoryParagraphs(baseContent, (paragraph) => {
-    const token = getParagraphPropertySourceToken(paragraph);
-    if (!token || !paragraphPropertySourceTokenMatchesContract(token, contract)) {
-      throw sourceValidationError(
-        "invalid_token",
-        "The source document contains an invalid paragraph-property token.",
-        token,
-      );
-    }
-    if (baseParagraphs.has(token)) {
-      throw sourceValidationError(
-        "duplicate_token",
-        "The source document contains a duplicate paragraph-property token.",
-        token,
-      );
-    }
-    baseParagraphs.set(token, paragraph);
-  });
+type ValidatedParagraphPropertySources = {
+  source?: ParagraphPropertyStorySource;
+  templateRegistry?: ParagraphPropertyTemplateResolutionRegistry;
+};
 
+const validateParagraphPropertySourceStates = (
+  pmDoc: PMNode,
+  source?: ParagraphPropertyStorySource,
+  templateStore?: ParagraphPropertyTemplateStore,
+): ValidatedParagraphPropertySources => {
   const seen = new Set<string>();
+  const templateHandles = [];
   pmDoc.descendants((node) => {
     if (node.type.name !== "paragraph") {
       return true;
     }
-    const token = getProseParagraphPropertySourceToken(node);
-    if (token === null || token === undefined) {
-      return false;
-    }
-    if (!isParagraphPropertySourceToken(token)) {
+    const state = readParagraphPropertyState(node.attrs["_paragraphPropertyState"]);
+    if (state.status !== "valid") {
       throw sourceValidationError(
-        "invalid_token",
-        "A paragraph contains a malformed paragraph-property token.",
-        token,
+        "invalid_state",
+        "A paragraph contains invalid paragraph-property state.",
+        state.status === "invalid" ? state.raw : undefined,
       );
     }
-    if (!paragraphPropertySourceTokenMatchesContract(token, contract)) {
+    if (state.value.type === "editor-created") {
+      return false;
+    }
+    if (state.value.type === "transient-template") {
+      if (!templateStore) {
+        throw sourceValidationError(
+          "transient_state",
+          "A transient paragraph-property template requires its conversion registry.",
+        );
+      }
+      templateHandles.push(state.value.handle);
+      return false;
+    }
+    const token = state.value.token;
+    if (!source) {
+      throw sourceValidationError(
+        "contract_mismatch",
+        "An imported paragraph-property state requires its explicit source story.",
+        token.serialized,
+      );
+    }
+    if (!source.owns(token)) {
       throw sourceValidationError(
         "unknown_token",
         "A paragraph-property token belongs to a different source document.",
-        token,
+        token.serialized,
       );
     }
-    if (seen.has(token)) {
+    if (seen.has(token.serialized)) {
       throw sourceValidationError(
         "duplicate_token",
         "A paragraph-property token is attached to more than one paragraph.",
-        token,
+        token.serialized,
       );
     }
-    if (!baseParagraphs.has(token)) {
-      throw sourceValidationError(
-        "unknown_token",
-        "A paragraph-property token is not present in the source document.",
-        token,
-      );
-    }
-    seen.add(token);
+    seen.add(token.serialized);
     return false;
   });
-  return baseParagraphs;
+  const templateRegistry = templateStore?.beginResolution(templateHandles);
+  return { ...(source ? { source } : {}), ...(templateRegistry ? { templateRegistry } : {}) };
 };
 
-const restoreParagraphPropertySourcesByToken = (
-  content: BlockContent[],
-  baseParagraphs: ReadonlyMap<string, Paragraph>,
-): void => {
-  visitDocumentStoryParagraphs(content, (paragraph) => {
-    const token = getParagraphPropertySourceToken(paragraph);
-    if (!token) {
-      return;
+const paragraphPropertySourceResolver = (
+  sources: ValidatedParagraphPropertySources,
+): ParagraphPropertySourceResolver =>
+  (paragraph, source) => {
+    const state = readParagraphPropertyState(source.attrs["_paragraphPropertyState"]);
+    if (state.status !== "valid") {
+      panic("Validated paragraph-property state became malformed during conversion");
     }
-    const baseParagraph = baseParagraphs.get(token);
-    if (!baseParagraph) {
-      panic("Validated paragraph-property token lost its source owner");
-    }
-    restoreParagraphPropertySource(paragraph, baseParagraph);
-  });
-};
-
-type LinkedParagraphPropertySources = {
-  targets: ReadonlySet<Paragraph>;
-  sources: ReadonlySet<Paragraph>;
-};
-
-const restoreLinkedParagraphPropertySources = (
-  content: BlockContent[],
-): LinkedParagraphPropertySources => {
-  const targetsBySource = new Map<Paragraph, Paragraph[]>();
-  const linkedTargets = new Set<Paragraph>();
-  visitDocxParagraphs({ documentBody: { content } }, (paragraph) => {
-    const source = getParagraphPropertySourceCandidate(paragraph);
-    if (!source) {
-      return;
-    }
-    linkedTargets.add(paragraph);
-    const targets = targetsBySource.get(source);
-    if (targets) {
-      targets.push(paragraph);
-    } else {
-      targetsBySource.set(source, [paragraph]);
-    }
-  });
-  for (const [source, targets] of targetsBySource) {
-    if (targets.length === 1) {
-      const target = targets.at(0);
-      if (target) {
-        copyParagraphPropertyCapture(target, source);
+    switch (state.value.type) {
+      case "editor-created":
+        assignEditorCreatedParagraphPropertySource(paragraph);
+        return;
+      case "imported": {
+        if (!sources.source) {
+          panic("Validated paragraph-property token lost its source owner");
+        }
+        sources.source.bindImportedParagraph(paragraph, state.value.token);
+        return;
+      }
+      case "transient-template":
+        if (!sources.templateRegistry) {
+          panic("Validated transient paragraph-property state lost its registry");
+        }
+        sources.templateRegistry.consume(state.value.handle, paragraph);
+        return;
+      default: {
+        const exhaustive: never = state.value;
+        return exhaustive;
       }
     }
-  }
-  return { targets: linkedTargets, sources: new Set(targetsBySource.keys()) };
-};
+  };
 
 /** Convert a ProseMirror document to the document model. */
-export function fromProseDoc(pmDoc: PMNode, baseDocument?: Document): Document {
+type FromProseDocOptions = {
+  paragraphPropertyTemplates?: ParagraphPropertyTemplateStore;
+};
+
+export function fromProseDoc(
+  pmDoc: PMNode,
+  baseDocument?: Document,
+  options: FromProseDocOptions = {},
+): Document {
   assertValidProseMirrorDocument(
     pmDoc,
     "Cannot convert invalid ProseMirror document to DOCX model",
@@ -493,43 +399,35 @@ export function fromProseDoc(pmDoc: PMNode, baseDocument?: Document): Document {
   const baseContract = baseDocument
     ? getDocumentParagraphPropertySourceContract(baseDocument)
     : undefined;
-  const proseContractAttribute = pmDoc.attrs[PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR];
-  const proseContract = getProseDocumentParagraphPropertySourceContract(pmDoc);
-  const proseCarriesInvalidContract =
-    proseContractAttribute !== null &&
-    proseContractAttribute !== undefined &&
-    proseContract === null;
-  if (proseCarriesInvalidContract || (baseContract ?? null) !== proseContract) {
+  const proseContract = readProseDocumentParagraphPropertySourceContract(pmDoc);
+  if (
+    proseContract.status === "invalid" ||
+    (baseContract === undefined) !== (proseContract.status === "absent") ||
+    (baseContract !== undefined &&
+      proseContract.status === "valid" &&
+      baseContract.serialized !== proseContract.value.serialized)
+  ) {
     throw sourceValidationError(
       "contract_mismatch",
       "The ProseMirror document does not match its paragraph-property source document.",
     );
   }
-  const tokenSources =
-    baseContract && proseContract && baseDocument
-      ? validateParagraphPropertySourceTokens(
+  const paragraphPropertySources =
+    baseContract && proseContract.status === "valid" && baseDocument
+      ? validateParagraphPropertySourceStates(
           pmDoc,
-          baseDocument.package.document.content,
-          baseContract,
+          ParagraphPropertyStorySource.fromDocument(baseDocument, { type: "document" }),
+          options.paragraphPropertyTemplates,
         )
-      : null;
+      : validateParagraphPropertySourceStates(pmDoc, undefined, options.paragraphPropertyTemplates);
 
   const blocks = extractBlocks(
     pmDoc,
     "resolve",
     baseDocument?.package.styles ? createStyleEngine(baseDocument.package.styles) : null,
+    paragraphPropertySourceResolver(paragraphPropertySources),
   );
-  const linkedSources = restoreLinkedParagraphPropertySources(blocks);
-  if (tokenSources) {
-    restoreParagraphPropertySourcesByToken(blocks, tokenSources);
-  } else if (baseDocument) {
-    restoreParagraphPropertySources(
-      blocks,
-      baseDocument.package.document.content,
-      linkedSources.targets,
-      linkedSources.sources,
-    );
-  }
+  paragraphPropertySources.templateRegistry?.assertFullyConsumed();
 
   // Preserve section properties (margins, headers, footers) from base document
   const documentBody: DocumentBody = { content: blocks };
@@ -832,6 +730,7 @@ function stripSuggestedProvenance(doc: PMNode, styleResolver: StyleEngine | null
  * document.
  */
 type RefResolutionMode = "resolve" | "inherit";
+type ParagraphPropertySourceResolver = (paragraph: Paragraph, source: PMNode) => void;
 
 function materializeNumberedRefValues(doc: PMNode): PMNode {
   const results = resolveNumberedRefFields(doc);
@@ -872,6 +771,7 @@ function extractBlocks(
   inputDoc: PMNode,
   refResolution: RefResolutionMode = "resolve",
   styleResolver: StyleEngine | null = null,
+  resolveParagraphPropertySource?: ParagraphPropertySourceResolver,
 ): BlockContent[] {
   // CLASS GUARD: every serialization path (export, copy, header/footer
   // conversion, previews) funnels through `extractBlocks`. Stripping suggested
@@ -916,6 +816,7 @@ function extractBlocks(
         documentCounts,
         textBoxAnchorMarkers,
         styleResolver,
+        resolveParagraphPropertySource,
       );
       prependPageBreaks(paragraph, pendingPageBreaks);
       pendingPageBreaks = 0;
@@ -925,7 +826,9 @@ function extractBlocks(
       if (pendingPageBreaks > 0 && !appendPendingPageBreaksToPreviousParagraph()) {
         flushPendingPageBreaks();
       }
-      blocks.push(convertPMTable(node, documentCounts, styleResolver));
+      blocks.push(
+        convertPMTable(node, documentCounts, styleResolver, resolveParagraphPropertySource),
+      );
       previousStandaloneTextBox = null;
     } else if (node.type.name === "textBox") {
       previousStandaloneTextBox = appendTextBoxBlock(blocks, node, {
@@ -933,13 +836,14 @@ function extractBlocks(
         previousStandaloneTextBox,
         textBoxAnchorMarkers,
         styleResolver,
+        resolveParagraphPropertySource,
       });
       pendingPageBreaks = 0;
     } else if (node.type.name === "blockSdt") {
       if (pendingPageBreaks > 0 && !appendPendingPageBreaksToPreviousParagraph()) {
         flushPendingPageBreaks();
       }
-      blocks.push(convertPMBlockSdt(node, styleResolver));
+      blocks.push(convertPMBlockSdt(node, styleResolver, resolveParagraphPropertySource));
       previousStandaloneTextBox = null;
     }
   });
@@ -958,6 +862,7 @@ type AppendTextBoxBlockOptions = {
   previousStandaloneTextBox: PreviousStandaloneTextBox | null;
   textBoxAnchorMarkers: Map<string, Run>;
   styleResolver: StyleEngine | null;
+  resolveParagraphPropertySource?: ParagraphPropertySourceResolver;
 };
 
 type PreviousStandaloneTextBox = {
@@ -965,7 +870,11 @@ type PreviousStandaloneTextBox = {
   groupId: string;
 };
 
-function convertPMBlockSdt(node: PMNode, styleResolver: StyleEngine | null): BlockSdt {
+function convertPMBlockSdt(
+  node: PMNode,
+  styleResolver: StyleEngine | null,
+  resolveParagraphPropertySource?: ParagraphPropertySourceResolver,
+): BlockSdt {
   const attrs = expectBlockSdtAttrs(node);
   const properties: SdtProperties = { sdtType: attrs.sdtType };
   if (attrs.alias) {
@@ -1024,7 +933,12 @@ function convertPMBlockSdt(node: PMNode, styleResolver: StyleEngine | null): Blo
   // Recursively materialize children. PM `blockSdt` content is `block+`, so a
   // mini-doc node is a convenient way to reuse extractBlocks.
   const innerDoc = node.type.schema.node("doc", null, node.content);
-  const extracted = extractBlocks(innerDoc, "inherit", styleResolver);
+  const extracted = extractBlocks(
+    innerDoc,
+    "inherit",
+    styleResolver,
+    resolveParagraphPropertySource,
+  );
 
   // `toProseDoc` inserts a synthetic filler paragraph into any blockSdt
   // whose source had an empty `<w:sdtContent/>` and stamps the
@@ -1074,7 +988,11 @@ function appendTextBoxBlock(
   options: AppendTextBoxBlockOptions,
 ): PreviousStandaloneTextBox | null {
   const attrs = expectTextBoxAttrs(node);
-  const paragraph = convertPMTextBox(node, options.styleResolver);
+  const paragraph = convertPMTextBox(
+    node,
+    options.styleResolver,
+    options.resolveParagraphPropertySource,
+  );
   const previousBlock = blocks.at(-1);
   if (attrs._docxPlacement === "inlineWithPrevious" && previousBlock?.type === "paragraph") {
     appendPageBreaks(previousBlock, options.pendingPageBreaks);
@@ -1415,6 +1333,7 @@ function convertPMParagraph(
   documentCounts?: TrackedChangeCounts,
   textBoxAnchorMarkers?: Map<string, Run>,
   styleResolver: StyleEngine | null = null,
+  resolveParagraphPropertySource?: ParagraphPropertySourceResolver,
 ): Paragraph {
   const attrs = expectParagraphAttrs(node);
   const paragraphStyleContext = paragraphRunStyleContext(node, styleResolver);
@@ -1492,7 +1411,7 @@ function convertPMParagraph(
     paragraph.pPrMark = attrs.pPrMark;
   }
 
-  linkParagraphPropertySourceCandidate(paragraph, node);
+  resolveParagraphPropertySource?.(paragraph, node);
   return paragraph;
 }
 
@@ -4499,9 +4418,15 @@ function convertPMTable(
   node: PMNode,
   documentCounts?: TrackedChangeCounts,
   styleResolver: StyleEngine | null = null,
+  resolveParagraphPropertySource?: ParagraphPropertySourceResolver,
 ): Table {
   const attrs = expectTableAttrs(node);
-  const rows = convertPMTableRows(node, documentCounts, styleResolver);
+  const rows = convertPMTableRows(
+    node,
+    documentCounts,
+    styleResolver,
+    resolveParagraphPropertySource,
+  );
 
   const formatting = tableAttrsToFormatting(attrs) || undefined;
   if (!formatting?.borders) {
@@ -4558,6 +4483,7 @@ function convertPMTableRows(
   node: PMNode,
   documentCounts?: TrackedChangeCounts,
   styleResolver: StyleEngine | null = null,
+  resolveParagraphPropertySource?: ParagraphPropertySourceResolver,
 ): TableRow[] {
   const rows: TableRow[] = [];
   const activeVerticalMerges = new Map<number, ActiveVerticalMerge>();
@@ -4565,7 +4491,15 @@ function convertPMTableRows(
   // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
   node.forEach((rowNode) => {
     if (rowNode.type.name === "tableRow") {
-      rows.push(convertPMTableRow(rowNode, documentCounts, activeVerticalMerges, styleResolver));
+      rows.push(
+        convertPMTableRow(
+          rowNode,
+          documentCounts,
+          activeVerticalMerges,
+          styleResolver,
+          resolveParagraphPropertySource,
+        ),
+      );
     }
   });
 
@@ -4746,6 +4680,7 @@ function convertPMTableRow(
   documentCounts?: TrackedChangeCounts,
   activeVerticalMerges?: Map<number, ActiveVerticalMerge>,
   styleResolver: StyleEngine | null = null,
+  resolveParagraphPropertySource?: ParagraphPropertySourceResolver,
 ): TableRow {
   const attrs = expectTableRowAttrs(node);
   const cells: TableCell[] = [];
@@ -4775,7 +4710,14 @@ function convertPMTableRow(
     if (cellNode.type.name === "tableCell" || cellNode.type.name === "tableHeader") {
       const cellAttrs = expectTableCellAttrs(cellNode);
       const colspan = Math.max(cellAttrs.colspan, 1);
-      cells.push(convertPMTableCell(cellNode, documentCounts, styleResolver));
+      cells.push(
+        convertPMTableCell(
+          cellNode,
+          documentCounts,
+          styleResolver,
+          resolveParagraphPropertySource,
+        ),
+      );
       if (cellAttrs.rowspan > 1) {
         const continuationCells = cellAttrs._docxVMergeContinuationCells;
         activeVerticalMerges?.set(gridColumn, {
@@ -4915,6 +4857,7 @@ function convertPMTableCell(
   node: PMNode,
   documentCounts?: TrackedChangeCounts,
   styleResolver: StyleEngine | null = null,
+  resolveParagraphPropertySource?: ParagraphPropertySourceResolver,
 ): TableCell {
   const attrs = expectTableCellAttrs(node);
   const content: (Paragraph | Table)[] = [];
@@ -4926,11 +4869,24 @@ function convertPMTableCell(
   node.forEach((contentNode) => {
     if (contentNode.type.name === "paragraph") {
       content.push(
-        convertPMParagraph(contentNode, documentCounts, textBoxAnchorMarkers, styleResolver),
+        convertPMParagraph(
+          contentNode,
+          documentCounts,
+          textBoxAnchorMarkers,
+          styleResolver,
+          resolveParagraphPropertySource,
+        ),
       );
       previousStandaloneTextBox = null;
     } else if (contentNode.type.name === "table") {
-      content.push(convertPMTable(contentNode, documentCounts, styleResolver));
+      content.push(
+        convertPMTable(
+          contentNode,
+          documentCounts,
+          styleResolver,
+          resolveParagraphPropertySource,
+        ),
+      );
       previousStandaloneTextBox = null;
     } else if (contentNode.type.name === "textBox") {
       previousStandaloneTextBox = appendTextBoxBlock(content, contentNode, {
@@ -4938,6 +4894,7 @@ function convertPMTableCell(
         previousStandaloneTextBox,
         textBoxAnchorMarkers,
         styleResolver,
+        resolveParagraphPropertySource,
       });
     }
   });
@@ -5114,7 +5071,11 @@ export function tableCellAttrsToFormatting(attrs: TableCellAttrs): TableCellForm
  * Convert a ProseMirror textBox node back to a Paragraph wrapping a ShapeContent run.
  * The text box content becomes a Shape with textBody.
  */
-function convertPMTextBox(node: PMNode, styleResolver: StyleEngine | null = null): Paragraph {
+function convertPMTextBox(
+  node: PMNode,
+  styleResolver: StyleEngine | null = null,
+  resolveParagraphPropertySource?: ParagraphPropertySourceResolver,
+): Paragraph {
   const attrs = expectTextBoxAttrs(node);
   const verticalAlign = normalizeShapeTextAnchor(attrs.verticalAlign);
 
@@ -5123,9 +5084,19 @@ function convertPMTextBox(node: PMNode, styleResolver: StyleEngine | null = null
   // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
   node.forEach((child) => {
     if (child.type.name === "paragraph") {
-      childBlocks.push(convertPMParagraph(child, undefined, undefined, styleResolver));
+      childBlocks.push(
+        convertPMParagraph(
+          child,
+          undefined,
+          undefined,
+          styleResolver,
+          resolveParagraphPropertySource,
+        ),
+      );
     } else if (child.type.name === "table") {
-      childBlocks.push(convertPMTable(child, undefined, styleResolver));
+      childBlocks.push(
+        convertPMTable(child, undefined, styleResolver, resolveParagraphPropertySource),
+      );
     }
   });
 
@@ -5254,20 +5225,27 @@ export function updateDocumentContent(originalDocument: Document, pmDoc: PMNode)
  * Used for converting edited header/footer PM content back to the document
  * model.
  */
+type ProseDocToBlocksOptions = {
+  paragraphPropertyTemplates?: ParagraphPropertyTemplateStore;
+  source: ParagraphPropertyStorySource;
+  styles?: NonNullable<Document["package"]>["styles"];
+};
+
 export function proseDocToBlocks(
   pmDoc: PMNode,
-  baseContent?: BlockContent[],
-  styles?: NonNullable<Document["package"]>["styles"],
+  options?: ProseDocToBlocksOptions,
 ): BlockContent[] {
-  const blocks = extractBlocks(pmDoc, "resolve", styles ? createStyleEngine(styles) : null);
-  const linkedSources = restoreLinkedParagraphPropertySources(blocks);
-  if (baseContent) {
-    restoreParagraphPropertySources(
-      blocks,
-      baseContent,
-      linkedSources.targets,
-      linkedSources.sources,
-    );
-  }
+  const paragraphPropertySources = validateParagraphPropertySourceStates(
+    pmDoc,
+    options?.source,
+    options?.paragraphPropertyTemplates,
+  );
+  const blocks = extractBlocks(
+    pmDoc,
+    "resolve",
+    options?.styles ? createStyleEngine(options.styles) : null,
+    paragraphPropertySourceResolver(paragraphPropertySources),
+  );
+  paragraphPropertySources.templateRegistry?.assertFullyConsumed();
   return blocks;
 }

--- a/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import { toFlowBlocks } from "../../layout-bridge/convert/toFlowBlocks";
 import { parseSettings } from "../../docx/settingsParser";
 import type { Document, ShadingProperties, TableCell, Theme } from "../../types/document";
+import { expectParagraphPropertyState } from "../paragraphPropertyState";
 import { fromProseDoc } from "./fromProseDoc";
 import { toProseDoc } from "./toProseDoc";
 
@@ -104,8 +105,11 @@ describe("toProseDoc", () => {
     };
 
     const attrs = toProseDoc(document).firstChild?.attrs;
-    expect(attrs?.numPr).toEqual({ numId: 7 });
+    expect(attrs?.numPr).toEqual({ numId: 7, ilvl: 0 });
     expect(attrs?.numPrFromStyle).toBeNull();
+    expect(expectParagraphPropertyState(attrs?._paragraphPropertyState).authoredPPr.numPr).toEqual({
+      numId: 7,
+    });
   });
 
   test("keeps the final section start on the internal document node", () => {
@@ -1031,7 +1035,10 @@ describe("toProseDoc", () => {
       (mark) => mark.type.name === "runFormattingOverride",
     );
 
-    expect(paragraph?.attrs._originalFormatting.runProperties).toMatchObject({
+    expect(
+      expectParagraphPropertyState(paragraph?.attrs._paragraphPropertyState).context.paragraphMark
+        .authored.runProperties,
+    ).toMatchObject({
       bold: true,
       italic: true,
     });

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -58,10 +58,15 @@ import {
 import { resolveColorValueToHex } from "../../docx/drawingUtils";
 import {
   PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR,
-  createProseParagraphWithPropertySource,
   getDocumentParagraphPropertySourceContract,
-  recreateProseNodeWithParagraphPropertySource,
+  getParagraphPropertySourceFingerprint,
+  getParagraphPropertySourceToken,
 } from "../../docx/paragraphPropertySource";
+import {
+  selectAuthoredParagraphProperties,
+  selectParagraphMarkProperties,
+  type AuthoredParagraphProperties,
+} from "@stll/docx-core/model";
 import {
   buildPageBreakRunSourceDescendantIndex,
   type PageBreakRunSourceDescendantIndex,
@@ -78,6 +83,20 @@ import {
   type PageBreakRunParagraphProjectionReason,
 } from "../pageBreakRunProjection";
 import { lineSpacingProvenanceFromSpacing } from "../paragraphSpacing";
+import { recreateProseNode } from "../recreateNode";
+import {
+  createParagraphNodeFromProjection,
+  createParagraphProperties,
+  GOVERNED_PARAGRAPH_ATTR_KEY_LIST,
+} from "../paragraphPropertyMutation";
+import {
+  createEditorParagraphPropertyState,
+  createImportedParagraphPropertyState,
+} from "../paragraphPropertyState";
+import type {
+  ParagraphSpacingInheritance,
+  SerializedParagraphPropertyProjectionContext,
+} from "../paragraphPropertyContext";
 import {
   getParagraphMarkSuppressionOverrides,
   hasDirectRunFormatting,
@@ -442,7 +461,7 @@ function convertParagraph(
   const { nextHyperlinkInstanceIndex, pairedBookmarkIds, pageBreakRunSourceDescendants } = context;
   let pageBreakRunOwnerId = 0;
   const nextPageBreakRunOwnerId = (): number => pageBreakRunOwnerId++;
-  const { attrs, effectiveFrame } = paragraphFormattingToAttrs(
+  const { attrs, effectiveFrame, inheritedPPr, spacingInheritance } = paragraphFormattingToAttrs(
     paragraph,
     styleResolver,
     tableParagraphOverlay,
@@ -736,8 +755,44 @@ function convertParagraph(
     attrs._emptyHyperlinks = emptyHyperlinks;
   }
 
-  return createProseParagraphWithPropertySource(schema.nodes["paragraph"], paragraph, {
-    attrs,
+  const fingerprint = getParagraphPropertySourceFingerprint(paragraph);
+  const authoredPPr = fingerprint?.pPrBase ?? selectAuthoredParagraphProperties(paragraph.formatting);
+  const paragraphMark =
+    fingerprint?.paragraphMark ?? selectParagraphMarkProperties(paragraph.formatting);
+  const propertyContext: SerializedParagraphPropertyProjectionContext = {
+    inheritedPPr,
+    numberingLevelIndent: paragraph.formatting?.numberingLevelIndent ?? null,
+    numPrFromStyle: paragraph.formatting?.numPrFromStyle ?? null,
+    paragraphMark: {
+      authored: paragraphMark,
+      effective: {
+        ...(attrs.defaultTextFormatting === undefined
+          ? {}
+          : { defaultTextFormatting: attrs.defaultTextFormatting }),
+        ...(attrs.runInWithNext === undefined ? {} : { runInWithNext: attrs.runInWithNext }),
+      },
+    },
+    spacingInheritance,
+  };
+  const token = getParagraphPropertySourceToken(paragraph);
+  const state = token
+    ? createImportedParagraphPropertyState({
+        token: token.serialized,
+        authoredPPr,
+        context: propertyContext,
+      })
+    : createEditorParagraphPropertyState({ authoredPPr, context: propertyContext });
+  const nonPropertyAttrs: Record<string, unknown> = { ...attrs };
+  for (const key of GOVERNED_PARAGRAPH_ATTR_KEY_LIST) {
+    Reflect.deleteProperty(nonPropertyAttrs, key);
+  }
+  const paragraphType = schema.nodes["paragraph"];
+  if (!paragraphType) {
+    return panic("The document schema does not define paragraph nodes");
+  }
+  return createParagraphNodeFromProjection({
+    type: paragraphType,
+    projection: createParagraphProperties({ attrs: nonPropertyAttrs, state }),
     content: inlineNodes,
   });
 }
@@ -937,6 +992,8 @@ function convertTrackedChange(
 type ParagraphFormattingProjection = {
   attrs: ParagraphAttrs;
   effectiveFrame: ParagraphFormatting["frame"];
+  inheritedPPr: AuthoredParagraphProperties;
+  spacingInheritance: ParagraphSpacingInheritance;
 };
 
 function paragraphFormattingToAttrs(
@@ -1025,10 +1082,6 @@ function paragraphFormattingToAttrs(
   if (paragraph.listRendering?.startOverride !== undefined) {
     attrs.listStartOverride = paragraph.listRendering.startOverride;
   }
-  // Store original inline formatting for lossless serialization round-trip
-  if (formatting) {
-    attrs._originalFormatting = formatting;
-  }
   // Carry `w:pPrChange` (paragraph-property-change tracking) opaquely
   // through ProseMirror. Without this, every edit strips the entries
   // off the paragraph because nothing in PM's schema represents them.
@@ -1057,9 +1110,11 @@ function paragraphFormattingToAttrs(
   // style's modeled paragraph fields in between docDefaults and this
   // paragraph's own style chain — see resolveParagraphStyleInTable.
   let stylePpr: Paragraph["formatting"] | undefined;
+  let spacingInheritance: ParagraphSpacingInheritance = {};
   if (styleResolver) {
     const resolved = styleResolver.resolveParagraphStyleInTable(styleId, tableParagraphOverlay);
     stylePpr = resolved.paragraphFormatting;
+    spacingInheritance = resolved.spacingInheritance ?? {};
 
     // Apply style-based values as defaults (inline overrides)
     set("alignment", formatting?.alignment ?? stylePpr?.alignment);
@@ -1233,6 +1288,8 @@ function paragraphFormattingToAttrs(
 
   return {
     attrs,
+    inheritedPPr: selectAuthoredParagraphProperties(stylePpr),
+    spacingInheritance,
     effectiveFrame:
       formatting?.frame === undefined
         ? stylePpr?.frame
@@ -4747,7 +4804,7 @@ export function headerFooterToProseDoc(
           );
           const paragraphNode = paragraphNodes[paragraphNodeIndex];
           if (paragraphNode) {
-            paragraphNodes[paragraphNodeIndex] = recreateProseNodeWithParagraphPropertySource(
+            paragraphNodes[paragraphNodeIndex] = recreateProseNode(
               paragraphNode,
               { attrs: { ...paragraphNode.attrs, _detachedWatermarkHost: true } },
             );

--- a/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -366,7 +366,7 @@ export function toProseDoc(document: Document, options?: ToProseDocOptions): PMN
       "doc",
       {
         [PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR]:
-          getDocumentParagraphPropertySourceContract(document) ?? null,
+          getDocumentParagraphPropertySourceContract(document)?.serialized ?? null,
         _finalSectionStart: finalSectionStart,
         _adjustLineHeightInTable: adjustLineHeightInTable,
       },

--- a/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
@@ -31,6 +31,8 @@ import { expectParagraphAttrs } from "../../attrs";
 import { autospacingMatchesBase } from "../../autospacingBase";
 import { directParagraphAlignment } from "../../paragraphAlignment";
 import { directionIsRtl } from "../../paragraphDirection";
+import { EMPTY_EDITOR_PARAGRAPH_PROPERTY_STATE } from "../../paragraphPropertyState";
+import { paragraphAttrsFromExternalDomImport } from "../../paragraphPropertyMutation";
 import { withDirectParagraphSpacing } from "../../paragraphSpacing";
 import type { ParagraphDirection } from "../../paragraphDirection";
 import type { ParagraphAttrs } from "../../schema/nodes";
@@ -338,6 +340,7 @@ const paragraphNodeSpec: NodeSpec = {
     kinsoku: { default: null },
     overflowPunctuation: { default: null },
     suppressAutoHyphens: { default: null },
+    suppressLineNumbers: { default: null },
     spaceBefore: { default: null },
     spaceAfter: { default: null },
     lineSpacing: { default: null },
@@ -392,9 +395,13 @@ const paragraphNodeSpec: NodeSpec = {
     // (`w:bidi`) or reaches the DOM (`dir`).
     direction: { default: null },
     outlineLevel: { default: null },
+    frame: { default: null },
     bookmarks: { default: null },
     _emptyHyperlinks: { default: null },
-    _originalFormatting: { default: null },
+    _paragraphPropertyState: { default: EMPTY_EDITOR_PARAGRAPH_PROPERTY_STATE },
+    _paragraphPropertyInheritance: { default: EMPTY_EDITOR_PARAGRAPH_PROPERTY_STATE.authoredPPr },
+    _paragraphMarkFormatting: { default: EMPTY_EDITOR_PARAGRAPH_PROPERTY_STATE.authoredPPr },
+    _numberingLevelIndent: { default: null },
     _autospacingBase: { default: null },
     _sectionProperties: { default: null },
     _propertyChanges: { default: null },
@@ -404,7 +411,7 @@ const paragraphNodeSpec: NodeSpec = {
   parseDOM: [
     {
       tag: "p",
-      getAttrs(dom): ParagraphAttrs | false {
+      getAttrs(dom) {
         if (!(dom instanceof HTMLElement)) {
           return false;
         }
@@ -420,7 +427,7 @@ const paragraphNodeSpec: NodeSpec = {
         const sectionBreakType = element.dataset["sectionBreak"] as
           | NonNullable<ParagraphAttrs["sectionBreakType"]>
           | undefined;
-        const attrs: ParagraphAttrs = {
+        const attrs: Partial<ParagraphAttrs> = {
           ...(paraId ? { paraId } : {}),
           ...(alignment ? { alignment } : {}),
           ...(alignmentFromStyle ? { alignmentFromStyle } : {}),
@@ -440,37 +447,40 @@ const paragraphNodeSpec: NodeSpec = {
         const mergedDirectAlignment =
           authoredAlignment ??
           (attrs.alignmentFromStyle === undefined ? mergedAlignment : undefined);
-        const originalFormatting: ParagraphFormatting = {
-          ...(styleId ? { styleId } : {}),
-          ...(mergedDirectAlignment ? { alignment: mergedDirectAlignment } : {}),
-        };
-        return {
+        const effectiveAttrs = {
           ...styleAttrs,
           ...attrs,
           // For alignment, prefer data-attribute if present, otherwise use CSS
           ...(mergedAlignment !== undefined ? { alignment: mergedAlignment } : {}),
-          ...(Object.keys(originalFormatting).length > 0
-            ? { _originalFormatting: originalFormatting }
-            : {}),
         };
+        return paragraphAttrsFromExternalDomImport({
+          effectiveAttrs,
+          authoredAttrs: {
+            ...effectiveAttrs,
+            ...(mergedDirectAlignment === undefined
+              ? { alignment: undefined }
+              : { alignment: mergedDirectAlignment }),
+          },
+          inheritedPPr:
+            alignmentFromStyle === undefined ? {} : { alignment: alignmentFromStyle },
+        });
       },
     },
     // Heading tags (h1-h6) — pasted from Google Docs, Word Online, etc.
     // Map to paragraphs with appropriate styleId and formatting extracted from CSS.
     ...(["h1", "h2", "h3", "h4", "h5", "h6"] as const).map((tag) => ({
       tag,
-      getAttrs(dom: HTMLElement): ParagraphAttrs {
+      getAttrs(dom: HTMLElement) {
         const level = Number.parseInt(tag.charAt(1), 10);
         const styleAttrs = extractParagraphAttrsFromStyle(dom);
 
-        return {
-          ...styleAttrs,
-          ...(styleAttrs.alignment
-            ? { _originalFormatting: { alignment: styleAttrs.alignment } }
-            : {}),
-          styleId: `Heading${level}`,
-          outlineLevel: level - 1,
-        };
+        return paragraphAttrsFromExternalDomImport({
+          effectiveAttrs: {
+            ...styleAttrs,
+            styleId: `Heading${level}`,
+            outlineLevel: level - 1,
+          },
+        });
       },
     })),
   ],

--- a/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
@@ -32,7 +32,14 @@ import { autospacingMatchesBase } from "../../autospacingBase";
 import { directParagraphAlignment } from "../../paragraphAlignment";
 import { directionIsRtl } from "../../paragraphDirection";
 import { EMPTY_EDITOR_PARAGRAPH_PROPERTY_STATE } from "../../paragraphPropertyState";
-import { paragraphAttrsFromExternalDomImport } from "../../paragraphPropertyMutation";
+import {
+  paragraphDomGetAttrs,
+  paragraphPropertiesFromExternalDomImport,
+} from "../../paragraphPropertyMutation";
+import {
+  attrsWithParagraphIndentationTransition,
+  type ParagraphIndentationTransition,
+} from "../../paragraphIndentation";
 import { withDirectParagraphSpacing } from "../../paragraphSpacing";
 import type { ParagraphDirection } from "../../paragraphDirection";
 import type { ParagraphAttrs } from "../../schema/nodes";
@@ -399,9 +406,6 @@ const paragraphNodeSpec: NodeSpec = {
     bookmarks: { default: null },
     _emptyHyperlinks: { default: null },
     _paragraphPropertyState: { default: EMPTY_EDITOR_PARAGRAPH_PROPERTY_STATE },
-    _paragraphPropertyInheritance: { default: EMPTY_EDITOR_PARAGRAPH_PROPERTY_STATE.authoredPPr },
-    _paragraphMarkFormatting: { default: EMPTY_EDITOR_PARAGRAPH_PROPERTY_STATE.authoredPPr },
-    _numberingLevelIndent: { default: null },
     _autospacingBase: { default: null },
     _sectionProperties: { default: null },
     _propertyChanges: { default: null },
@@ -411,7 +415,7 @@ const paragraphNodeSpec: NodeSpec = {
   parseDOM: [
     {
       tag: "p",
-      getAttrs(dom) {
+      getAttrs: paragraphDomGetAttrs((dom) => {
         if (!(dom instanceof HTMLElement)) {
           return false;
         }
@@ -453,7 +457,7 @@ const paragraphNodeSpec: NodeSpec = {
           // For alignment, prefer data-attribute if present, otherwise use CSS
           ...(mergedAlignment !== undefined ? { alignment: mergedAlignment } : {}),
         };
-        return paragraphAttrsFromExternalDomImport({
+        return paragraphPropertiesFromExternalDomImport({
           effectiveAttrs,
           authoredAttrs: {
             ...effectiveAttrs,
@@ -464,24 +468,24 @@ const paragraphNodeSpec: NodeSpec = {
           inheritedPPr:
             alignmentFromStyle === undefined ? {} : { alignment: alignmentFromStyle },
         });
-      },
+      }),
     },
     // Heading tags (h1-h6) — pasted from Google Docs, Word Online, etc.
     // Map to paragraphs with appropriate styleId and formatting extracted from CSS.
     ...(["h1", "h2", "h3", "h4", "h5", "h6"] as const).map((tag) => ({
       tag,
-      getAttrs(dom: HTMLElement) {
+      getAttrs: paragraphDomGetAttrs((dom: HTMLElement) => {
         const level = Number.parseInt(tag.charAt(1), 10);
         const styleAttrs = extractParagraphAttrsFromStyle(dom);
 
-        return paragraphAttrsFromExternalDomImport({
+        return paragraphPropertiesFromExternalDomImport({
           effectiveAttrs: {
             ...styleAttrs,
             styleId: `Heading${level}`,
             outlineLevel: level - 1,
           },
         });
-      },
+      }),
     })),
   ],
   toDOM(node) {

--- a/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
@@ -7,12 +7,11 @@
  */
 
 import { Fragment } from "prosemirror-model";
-import type { Mark, Node as PMNode, NodeSpec, Schema } from "prosemirror-model";
+import type { Node as PMNode, NodeSpec, Schema } from "prosemirror-model";
 import type { Command, EditorState, Transaction } from "prosemirror-state";
 
-import { PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR } from "../../../docx/paragraphPropertySource";
-
 import type { NumberingMap } from "../../../docx/numberingParser";
+import { setProseParagraphMarkupWithPropertySource } from "../../../docx/paragraphPropertySource";
 import type {
   ParagraphAlignment,
   LineSpacingRule,
@@ -26,13 +25,13 @@ import type {
 import { PARAGRAPH_ALIGNMENT_VALUES } from "../../../types/documentEnumValues";
 import { paragraphToStyle } from "../../../utils/formatToStyle";
 import { collectHeadings } from "../../../utils/headingCollector";
-import { tableOfContentsStyleLevel } from "../../../utils/tableOfContentsStyle";
 import { expectParagraphAttrs } from "../../attrs";
 import { autospacingMatchesBase } from "../../autospacingBase";
 import { directParagraphAlignment } from "../../paragraphAlignment";
 import { directionIsRtl } from "../../paragraphDirection";
 import { EMPTY_EDITOR_PARAGRAPH_PROPERTY_STATE } from "../../paragraphPropertyState";
 import {
+  createParagraphNodeFromProjection,
   paragraphDomGetAttrs,
   paragraphPropertiesFromExternalDomImport,
 } from "../../paragraphPropertyMutation";
@@ -41,12 +40,16 @@ import {
   type ParagraphIndentationTransition,
 } from "../../paragraphIndentation";
 import { withDirectParagraphSpacing } from "../../paragraphSpacing";
+import { getDocumentStyleResolver } from "../../plugins/documentStyles";
+import { getDocumentNumbering } from "../../plugins/documentNumbering";
+import {
+  inheritedParagraphRunFormatting,
+  setParagraphPropertiesWithRebasedRunFormatting,
+} from "../../rebaseParagraphRunFormatting";
 import type { ParagraphDirection } from "../../paragraphDirection";
 import type { ParagraphAttrs } from "../../schema/nodes";
-import {
-  paragraphAttrsFromResolvedStyle,
-  listAttrsFromResolvedStyle,
-} from "../../styles/resolvedStyleAttrs";
+import { paragraphPropertiesForStyleTransition } from "../../styles/resolvedStyleAttrs";
+import { tableParagraphStyleContextAtPositions } from "../../tableConditionalFormatting";
 import { createNodeExtension } from "../create";
 import type { ExtensionContext, ExtensionRuntime } from "../types";
 
@@ -337,7 +340,6 @@ const paragraphNodeSpec: NodeSpec = {
   group: "block",
   attrs: {
     paraId: { default: null },
-    [PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR]: { default: null },
     // Internal provenance for comparison alignment. It is intentionally not
     // parsed from or rendered to HTML/OOXML.
     idStability: { default: undefined },
@@ -361,6 +363,7 @@ const paragraphNodeSpec: NodeSpec = {
     indentRight: { default: null },
     indentFirstLine: { default: null },
     hangingIndent: { default: false },
+    _sourceIndentation: { default: null },
     numPr: { default: null },
     numPrFromStyle: { default: null },
     listNumFmt: { default: null },
@@ -632,6 +635,49 @@ function setParagraphAttrsCmd(attrs: Record<string, unknown>): Command {
   };
 }
 
+const mutateParagraphIndentation =
+  (transitionFor: (attrs: ParagraphAttrs) => ParagraphIndentationTransition): Command =>
+  (state, dispatch) => {
+    const { $from, $to } = state.selection;
+    const seen = new Set<number>();
+    const updates: { pos: number; attrs: ParagraphAttrs }[] = [];
+    let unsupported = false;
+    state.doc.nodesBetween($from.pos, $to.pos, (node, pos) => {
+      if (node.type.name !== "paragraph" || seen.has(pos)) {
+        return;
+      }
+      seen.add(pos);
+      const attrs = expectParagraphAttrs(node);
+      const result = attrsWithParagraphIndentationTransition(attrs, transitionFor(attrs));
+      if (result.type === "unsupported") {
+        unsupported = true;
+        return;
+      }
+      updates.push({ pos, attrs: result.attrs });
+    });
+
+    if (unsupported) {
+      return false;
+    }
+    if (!dispatch) {
+      return true;
+    }
+    const transaction = state.tr;
+    for (const update of updates) {
+      setProseParagraphMarkupWithPropertySource({
+        attrs: update.attrs,
+        ownership: "preserve",
+        pos: update.pos,
+        transaction,
+      });
+    }
+    dispatch(transaction.scrollIntoView());
+    return true;
+  };
+
+const setParagraphIndentation = (transition: ParagraphIndentationTransition): Command =>
+  mutateParagraphIndentation(() => transition);
+
 // ============================================================================
 // RESOLVED STYLE ATTRS (for applyStyle)
 // ============================================================================
@@ -692,62 +738,23 @@ function makeSetLineSpacing(value: number, rule: LineSpacingRule = "auto"): Comm
 }
 
 function makeIncreaseIndent(amount: number = 720): Command {
-  return (state, dispatch) => {
-    const { $from, $to } = state.selection;
-
-    if (!dispatch) {
-      return true;
-    }
-
-    let tr = state.tr;
-    const seen = new Set<number>();
-
-    state.doc.nodesBetween($from.pos, $to.pos, (node, pos) => {
-      if (node.type.name === "paragraph" && !seen.has(pos)) {
-        seen.add(pos);
-        const currentIndent = node.attrs["indentLeft"] || 0;
-        tr = tr.setNodeMarkup(pos, undefined, {
-          ...node.attrs,
-          indentLeft: currentIndent + amount,
-        });
-      }
-    });
-
-    dispatch(tr.scrollIntoView());
-    return true;
-  };
+  return mutateParagraphIndentation((attrs) => ({
+    type: "set-direct",
+    values: { indentLeft: (attrs.indentLeft ?? 0) + amount },
+  }));
 }
 
 function makeDecreaseIndent(amount: number = 720): Command {
-  return (state, dispatch) => {
-    const { $from, $to } = state.selection;
-
-    if (!dispatch) {
-      return true;
-    }
-
-    let tr = state.tr;
-    const seen = new Set<number>();
-
-    state.doc.nodesBetween($from.pos, $to.pos, (node, pos) => {
-      if (node.type.name === "paragraph" && !seen.has(pos)) {
-        seen.add(pos);
-        const currentIndent = node.attrs["indentLeft"] || 0;
-        const newIndent = Math.max(0, currentIndent - amount);
-        tr = tr.setNodeMarkup(pos, undefined, {
-          ...node.attrs,
-          indentLeft: newIndent > 0 ? newIndent : null,
-        });
-      }
-    });
-
-    dispatch(tr.scrollIntoView());
-    return true;
-  };
+  return mutateParagraphIndentation((attrs) => {
+    const newIndent = Math.max(0, (attrs.indentLeft ?? 0) - amount);
+    return newIndent === 0
+      ? { type: "force-visible-zero", sides: ["left"] }
+      : { type: "set-direct", values: { indentLeft: newIndent } };
+  });
 }
 
-function makeApplyStyle(schema: Schema) {
-  return (styleId: string, resolvedAttrs?: ResolvedStyleAttrs): Command =>
+function makeStyleTransition(transition: "preserve-direct" | "replace-style") {
+  return (styleId: string | null, resolvedAttrs?: ResolvedStyleAttrs): Command =>
     (state, dispatch) => {
       const { $from, $to } = state.selection;
 
@@ -757,139 +764,63 @@ function makeApplyStyle(schema: Schema) {
 
       let tr = state.tr;
       const seen = new Set<number>();
-
-      // Build marks from run formatting if provided
-      const styleMarks: Mark[] = [];
-      if (resolvedAttrs?.runFormatting) {
-        const rpr = resolvedAttrs.runFormatting;
-
-        if (rpr.bold && schema.marks["bold"]) {
-          styleMarks.push(schema.marks["bold"].create());
-        }
-        if (rpr.italic && schema.marks["italic"]) {
-          styleMarks.push(schema.marks["italic"].create());
-        }
-        if (rpr.fontSize && schema.marks["fontSize"]) {
-          styleMarks.push(schema.marks["fontSize"].create({ size: rpr.fontSize }));
-        }
-        if (rpr.fontFamily && schema.marks["fontFamily"]) {
-          styleMarks.push(
-            schema.marks["fontFamily"].create({
-              ascii: rpr.fontFamily.ascii,
-              hAnsi: rpr.fontFamily.hAnsi,
-              asciiTheme: rpr.fontFamily.asciiTheme,
-            }),
-          );
-        }
-        if (rpr.color && !rpr.color.auto && schema.marks["textColor"]) {
-          styleMarks.push(
-            schema.marks["textColor"].create({
-              rgb: rpr.color.rgb,
-              themeColor: rpr.color.themeColor,
-              themeTint: rpr.color.themeTint,
-              themeShade: rpr.color.themeShade,
-            }),
-          );
-        }
-        if (rpr.underline && rpr.underline.style !== "none" && schema.marks["underline"]) {
-          styleMarks.push(
-            schema.marks["underline"].create({
-              style: rpr.underline.style,
-              color: rpr.underline.color,
-            }),
-          );
-        }
-        if ((rpr.strike || rpr.doubleStrike) && schema.marks["strike"]) {
-          styleMarks.push(
-            schema.marks["strike"].create({
-              double: rpr.doubleStrike || false,
-            }),
-          );
-        }
-      }
-
-      // Mark types that are controlled by style definitions
-      const styleControlledMarks = [
-        schema.marks["bold"],
-        schema.marks["italic"],
-        schema.marks["fontSize"],
-        schema.marks["fontFamily"],
-        schema.marks["textColor"],
-        schema.marks["underline"],
-        schema.marks["strike"],
-      ].filter(Boolean);
+      const styleResolver = getDocumentStyleResolver(state);
+      const numbering = resolvedAttrs?.numbering ?? getDocumentNumbering(state);
+      const tableContextByPosition = tableParagraphStyleContextAtPositions(
+        state.doc,
+        styleResolver,
+      );
+      let storedMarks: readonly Mark[] | undefined;
 
       state.doc.nodesBetween($from.pos, $to.pos, (node, pos) => {
         if (node.type.name === "paragraph" && !seen.has(pos)) {
           seen.add(pos);
-
-          const newAttrs: Record<string, unknown> = {
-            ...node.attrs,
-            styleId,
-            _tableOfContentsLevel: tableOfContentsStyleLevel({ styleId }) ?? null,
-          };
-
-          if (resolvedAttrs) {
-            // When applying a style, explicitly reset all style-controlled
-            // paragraph attrs to the new style's values (or null to clear).
-            // This prevents old style properties (e.g. heading line spacing)
-            // from persisting when switching to a different style. The same
-            // projection drives the Enter handler's next-style switch, so
-            // both paths produce identical paragraph attrs — and the resulting
-            // `defaultTextFormatting` lets EmptyParagraphFormatExtension keep
-            // typed text styled after the style picker steals focus.
-            Object.assign(
-              newAttrs,
-              paragraphAttrsFromResolvedStyle(resolvedAttrs, {
-                styleId,
-                ...(resolvedAttrs.styleName ? { styleName: resolvedAttrs.styleName } : {}),
-              }),
-            );
-            const originalFormatting = {
-              ...expectParagraphAttrs(node)._originalFormatting,
-              styleId,
-            };
-            Reflect.deleteProperty(originalFormatting, "alignment");
-            newAttrs["_originalFormatting"] = withDirectParagraphSpacing(
-              originalFormatting,
-              undefined,
-            );
-            newAttrs["spacingExplicit"] = null;
-            // A style with `w:numPr` attaches its numbering (numPr + marker
-            // attrs). A style without numbering leaves existing list attrs
-            // untouched: direct numbering survives a style switch.
-            const listAttrs = listAttrsFromResolvedStyle(resolvedAttrs, resolvedAttrs.numbering);
-            if (listAttrs) {
-              Object.assign(newAttrs, listAttrs);
-            }
-          }
-
-          tr = tr.setNodeMarkup(pos, undefined, newAttrs);
-
-          // Only modify marks when we have resolved style attrs
-          // (fallback path without resolvedAttrs just sets styleId)
-          if (resolvedAttrs) {
-            const paragraphStart = pos + 1;
-            const paragraphEnd = pos + node.nodeSize - 1;
-
-            if (paragraphEnd > paragraphStart) {
-              // Clear old style-controlled marks first
-              for (const markType of styleControlledMarks) {
-                tr = tr.removeMark(paragraphStart, paragraphEnd, markType);
-              }
-              // Then add the new style's marks
-              for (const mark of styleMarks) {
-                tr = tr.addMark(paragraphStart, paragraphEnd, mark);
-              }
-            }
+          const tableContext = tableContextByPosition.get(pos);
+          const resolved = styleResolver
+            ? styleResolver.resolveParagraphStyleInTable(styleId, tableContext?.pPr)
+            : (resolvedAttrs ?? {});
+          const styleName =
+            styleId === null
+              ? undefined
+              : (resolvedAttrs?.styleName ?? styleResolver?.getStyle(styleId)?.name);
+          const projection = paragraphPropertiesForStyleTransition({
+            attrs: expectParagraphAttrs(node),
+            identity: { styleId, ...(styleName ? { styleName } : {}) },
+            numbering,
+            resolved,
+            styleResolver,
+            ...(tableContext?.rPr ? { tableRunFormatting: tableContext.rPr } : {}),
+            transition: { type: transition },
+          });
+          const projectedParagraph = createParagraphNodeFromProjection({
+            type: node.type,
+            projection,
+            content: node.content,
+            marks: node.marks,
+          });
+          const inherited = inheritedParagraphRunFormatting({
+            paragraph: projectedParagraph,
+            styleResolver,
+            tableRunFormatting:
+              styleResolver === null ? undefined : (tableContext?.rPr ?? null),
+          });
+          tr = setParagraphPropertiesWithRebasedRunFormatting({
+            projection,
+            paragraphPosition: pos,
+            styleResolver,
+            tableRunFormatting:
+              styleResolver === null ? undefined : (tableContext?.rPr ?? null),
+            tr,
+          });
+          if ($from.sameParent($to) && $from.parent === node && node.content.size === 0) {
+            storedMarks = inherited.marks;
           }
         }
       });
 
-      if (styleMarks.length > 0) {
-        tr = tr.setStoredMarks(styleMarks);
+      if (storedMarks !== undefined) {
+        tr.setStoredMarks(storedMarks);
       }
-
       dispatch(tr.scrollIntoView());
       return true;
     };
@@ -948,7 +879,8 @@ export const ParagraphExtension = createNodeExtension({
   schemaNodeName: "paragraph",
   nodeSpec: paragraphNodeSpec,
   onSchemaReady(ctx: ExtensionContext): ExtensionRuntime {
-    const applyStyleFn = makeApplyStyle(ctx.schema);
+    const applyStyleFn = makeStyleTransition("replace-style");
+    const clearStyleFn = makeStyleTransition("preserve-direct");
 
     return {
       commands: {
@@ -965,17 +897,36 @@ export const ParagraphExtension = createNodeExtension({
         setSpaceAfter: (twips: number) => setParagraphSpacingAttr("after", twips),
         increaseIndent: (amount?: number) => makeIncreaseIndent(amount),
         decreaseIndent: (amount?: number) => makeDecreaseIndent(amount),
-        setIndentLeft: (twips: number) => setParagraphAttr("indentLeft", twips > 0 ? twips : null),
+        setIndentLeft: (twips: number) =>
+          setParagraphIndentation(
+            twips === 0
+              ? { type: "force-visible-zero", sides: ["left"] }
+              : { type: "set-direct", values: { indentLeft: twips } },
+          ),
         setIndentRight: (twips: number) =>
-          setParagraphAttr("indentRight", twips > 0 ? twips : null),
-        setIndentFirstLine: (twips: number, hanging?: boolean) =>
-          setParagraphAttrsCmd({
-            indentFirstLine: twips > 0 ? twips : null,
-            hangingIndent: hanging ?? false,
-          }),
+          setParagraphIndentation(
+            twips === 0
+              ? { type: "force-visible-zero", sides: ["right"] }
+              : { type: "set-direct", values: { indentRight: twips } },
+          ),
+        setIndentFirstLine: (twips: number, hanging?: boolean) => {
+          const hangingIndent = hanging ?? twips < 0;
+          const magnitude = Math.abs(twips);
+          return setParagraphIndentation(
+            magnitude === 0
+              ? { type: "force-visible-zero", sides: ["firstLine"] }
+              : {
+                  type: "set-direct",
+                  values: {
+                    indentFirstLine: hangingIndent ? -magnitude : magnitude,
+                    hangingIndent,
+                  },
+                },
+          );
+        },
         applyStyle: (styleId: string, resolvedAttrs?: ResolvedStyleAttrs) =>
           applyStyleFn(styleId, resolvedAttrs),
-        clearStyle: () => setParagraphAttrsCmd({ styleId: null, _tableOfContentsLevel: null }),
+        clearStyle: () => clearStyleFn(null),
         insertSectionBreak: (breakType: "nextPage" | "continuous" | "oddPage" | "evenPage") =>
           setParagraphAttr("sectionBreakType", breakType),
         removeSectionBreak: () => setParagraphAttr("sectionBreakType", null),

--- a/packages/core/src/prosemirror/extensions/features/BaseKeymapExtension.ts
+++ b/packages/core/src/prosemirror/extensions/features/BaseKeymapExtension.ts
@@ -13,16 +13,30 @@ import {
   selectAll,
   selectParentNode,
 } from "prosemirror-commands";
-import type { Mark, Node as PMNode } from "prosemirror-model";
+import { panic } from "better-result";
+import type { Node as PMNode } from "prosemirror-model";
 import type { Command, Transaction } from "prosemirror-state";
 
-import type { TextFormatting } from "../../../types/document";
-import { mergeFontFamily } from "../../../utils/fontFamilyMerge";
+import { expectParagraphAttrs } from "../../attrs";
+import { attrsWithParagraphIndentationTransition } from "../../paragraphIndentation";
+import {
+  applyParagraphPropertyProjection,
+  createParagraphNodeFromProjection,
+  rebindJoinedParagraphProperties,
+  rebindSplitParagraphProperties,
+  transitionParagraphProperties,
+} from "../../paragraphPropertyMutation";
+import { expectParagraphPropertyState } from "../../paragraphPropertyState";
+import { getDocumentNumbering } from "../../plugins/documentNumbering";
 import { getDocumentStyleResolver } from "../../plugins/documentStyles";
-import { paragraphAttrsFromResolvedStyle } from "../../styles/resolvedStyleAttrs";
+import { inheritedParagraphRunFormatting } from "../../rebaseParagraphRunFormatting";
+import { paragraphPropertiesForStyleTransition } from "../../styles/resolvedStyleAttrs";
 import type { StyleResolver } from "../../styles/styleResolver";
+import {
+  tableParagraphStyleContextAtPositions,
+  type TableParagraphStyleContext,
+} from "../../tableConditionalFormatting";
 import { createExtension } from "../create";
-import { textFormattingToMarks } from "../marks/markUtils";
 import { Priority } from "../types";
 import type { ExtensionRuntime, ExtensionContext } from "../types";
 
@@ -72,93 +86,205 @@ const clearIndentOnBackspace: Command = (state, dispatch) => {
     return false;
   }
 
+  const transition = attrsWithParagraphIndentationTransition(
+    expectParagraphAttrs($cursor.parent as PMNode),
+    { type: "force-visible-zero", sides: ["left", "firstLine"] },
+  );
+  if (transition.type === "unsupported") {
+    return false;
+  }
+
   if (dispatch) {
     const pos = $cursor.before();
-    const tr = state.tr.setNodeMarkup(pos, undefined, {
-      ...attrs,
-      indentFirstLine: null,
-      hangingIndent: null,
-      indentLeft: null,
+    const tr = state.tr;
+    applyParagraphPropertyProjection({
+      projection: transition.projection,
+      source: { type: "preserve" },
+      pos,
+      transaction: tr,
     });
     dispatch(tr.scrollIntoView());
   }
   return true;
 };
 
-/**
- * Custom Enter handler: splits the block, inherits style-related attrs,
- * clears paragraph borders, and preserves font marks on the new paragraph.
- *
- * splitBlock creates a new paragraph with default attrs (all null),
- * so we must manually copy style-related attrs from the source paragraph.
- * Word does NOT propagate paragraph borders (w:pBdr) on Enter.
- */
-const INHERITED_PARA_ATTRS = [
-  "defaultTextFormatting",
-  "styleId",
-  "_tableOfContentsLevel",
-  "lineSpacing",
-  "lineSpacingRule",
-  "snapToGrid",
-  "spaceAfter",
-  "spaceBefore",
-  "contextualSpacing",
-] as const;
+type ParagraphJoinCandidate = {
+  leftContentSize: number;
+  leftPosition: number;
+  leftState: ReturnType<typeof expectParagraphPropertyState>;
+  rightContentSize: number;
+  rightState: ReturnType<typeof expectParagraphPropertyState>;
+};
 
-/** Mark types that represent style-inherited formatting (font, size, color). */
-const STYLE_MARK_NAMES = new Set(["fontFamily", "fontSize", "textColor"]);
-
-/**
- * If `sourcePara`'s style defines a `w:next`, replace the empty `newPara`
- * with that style's resolved attrs and seed stored marks from its run
- * formatting. Returns true when a switch happened (caller should dispatch
- * the transaction as-is), false when the source style has no `w:next` and
- * the caller should fall back to the regular inheritance path.
- */
-function applyNextParagraphStyle(
-  tr: Transaction,
-  sourcePara: PMNode,
-  newPara: PMNode,
-  resolver: StyleResolver,
-): boolean {
-  const nextStyleId = resolver.getNextStyleId(
-    sourcePara.attrs["styleId"] as string | null | undefined,
-  );
-  if (!nextStyleId) {
-    return false;
+const paragraphJoinCandidate = (
+  state: Parameters<Command>[0],
+  direction: "backward" | "forward",
+): ParagraphJoinCandidate | null => {
+  const { $cursor } = state.selection as {
+    $cursor?: {
+      before: () => number;
+      parent: PMNode;
+      parentOffset: number;
+    };
+  };
+  if (!$cursor || $cursor.parent.type.name !== "paragraph") {
+    return null;
   }
+  const current = $cursor.parent;
+  const currentPosition = $cursor.before();
+  let left: PMNode | null;
+  let right: PMNode | null;
+  let leftPosition: number;
+  if (direction === "backward") {
+    if ($cursor.parentOffset !== 0) {
+      return null;
+    }
+    right = current;
+    left = state.doc.resolve(currentPosition).nodeBefore;
+    leftPosition = left ? currentPosition - left.nodeSize : -1;
+  } else {
+    if ($cursor.parentOffset !== current.content.size) {
+      return null;
+    }
+    left = current;
+    leftPosition = currentPosition;
+    right = state.doc.resolve(currentPosition + current.nodeSize).nodeAfter;
+  }
+  if (left?.type.name !== "paragraph" || right?.type.name !== "paragraph") {
+    return null;
+  }
+  return {
+    leftContentSize: left.content.size,
+    leftPosition,
+    leftState: expectParagraphPropertyState(expectParagraphAttrs(left)._paragraphPropertyState),
+    rightContentSize: right.content.size,
+    rightState: expectParagraphPropertyState(expectParagraphAttrs(right)._paragraphPropertyState),
+  };
+};
 
-  const resolved = resolver.resolveParagraphStyle(nextStyleId);
-  const styleName = resolver.getStyle(nextStyleId)?.name;
-  const { $from } = tr.selection;
-  // `paragraphAttrsFromResolvedStyle` already projects the next style's
-  // borders (or null), which both clears the source paragraph's leftover
-  // border and applies a bordered next style (callouts, etc.).
-  tr.setNodeMarkup($from.before(), undefined, {
-    ...newPara.attrs,
-    styleId: nextStyleId,
-    ...paragraphAttrsFromResolvedStyle(resolved, {
-      styleId: nextStyleId,
-      ...(styleName ? { styleName } : {}),
-    }),
+const withParagraphJoinOwnership = (
+  command: Command,
+  direction: "backward" | "forward",
+): Command =>
+  (state, dispatch, view) => {
+    if (!dispatch) {
+      return command(state, undefined, view);
+    }
+    const candidate = paragraphJoinCandidate(state, direction);
+    let captured: Transaction | null = null;
+    const handled = command(
+      state,
+      (transaction) => {
+        if (captured !== null) {
+          panic("A base join command dispatched more than one transaction");
+        }
+        captured = transaction;
+      },
+      view,
+    );
+    if (!handled) {
+      return false;
+    }
+    if (captured === null) {
+      return true;
+    }
+    const transaction = captured;
+    if (candidate) {
+      const joinedPosition = transaction.mapping.map(candidate.leftPosition, -1);
+      const joined = transaction.doc.nodeAt(joinedPosition);
+      if (
+        joined?.type.name === "paragraph" &&
+        joined.content.size === candidate.leftContentSize + candidate.rightContentSize
+      ) {
+        rebindJoinedParagraphProperties({
+          transaction,
+          joinedPosition,
+          leftState: candidate.leftState,
+          rightState: candidate.rightState,
+          transition: { type: "join-right-paragraph-mark-retains" },
+        });
+      }
+    }
+    dispatch(transaction);
+    return true;
+  };
+
+/**
+ * Project the empty paragraph created by Enter from the complete inherited
+ * cascade at its table occurrence. A `w:next` style replaces the source
+ * style; otherwise the new paragraph keeps the source style while dropping
+ * direct paragraph formatting such as borders and indentation.
+ */
+type ProjectSplitParagraphOptions = {
+  context: TableParagraphStyleContext | null | undefined;
+  newPara: PMNode;
+  resolver: StyleResolver;
+  sourcePara: PMNode;
+  state: Parameters<Command>[0];
+  tr: Transaction;
+  useNextStyle: boolean;
+};
+
+const projectSplitParagraph = ({
+  context,
+  resolver,
+  sourcePara,
+  state,
+  tr,
+  newPara,
+  useNextStyle,
+}: ProjectSplitParagraphOptions): Transaction => {
+  const sourceStyleId = sourcePara.attrs["styleId"] as string | null | undefined;
+  const styleId = useNextStyle
+    ? (resolver.getNextStyleId(sourceStyleId) ?? sourceStyleId)
+    : sourceStyleId;
+  const resolved = resolver.resolveParagraphStyleInTable(styleId, context?.pPr);
+  const styleName = styleId ? resolver.getStyle(styleId)?.name : undefined;
+  const projection = paragraphPropertiesForStyleTransition({
+    attrs: expectParagraphAttrs(newPara),
+    identity: { styleId: styleId ?? null, ...(styleName ? { styleName } : {}) },
+    numbering: getDocumentNumbering(state),
+    resolved,
+    styleResolver: resolver,
+    ...(context?.rPr ? { tableRunFormatting: context.rPr } : {}),
+    transition: { type: "replace-style" },
   });
-
-  // setStoredMarks MUST come after setNodeMarkup — every step clears it.
-  tr.setStoredMarks(
-    resolved.runFormatting ? textFormattingToMarks(resolved.runFormatting, tr.doc.type.schema) : [],
-  );
-  return true;
-}
+  const projected = createParagraphNodeFromProjection({
+    type: newPara.type,
+    projection,
+    content: newPara.content,
+    marks: newPara.marks,
+  });
+  const inherited = inheritedParagraphRunFormatting({
+    paragraph: projected,
+    styleResolver: resolver,
+    tableRunFormatting: context?.rPr ?? null,
+  });
+  const { $from } = tr.selection;
+  applyParagraphPropertyProjection({
+    transaction: tr,
+    pos: $from.before(),
+    projection,
+    source: { type: "preserve" },
+  });
+  tr.setStoredMarks(inherited.marks);
+  return tr;
+};
 
 export const splitBlockClearBorders: Command = (state, dispatch, view) => {
   // Capture source paragraph info BEFORE split (splitBlock resets everything)
   const { $from: preSplitFrom } = state.selection;
   const sourcePara = preSplitFrom.parent.type.name === "paragraph" ? preSplitFrom.parent : null;
+  const sourcePropertyState = sourcePara
+    ? expectParagraphPropertyState(expectParagraphAttrs(sourcePara)._paragraphPropertyState)
+    : null;
 
-  // Collect style marks from the cursor position before splitting.
-  // Use storedMarks if set, otherwise resolve from the position.
-  const preMarks = state.storedMarks || preSplitFrom.marks();
-  const styleMarks = preMarks.filter((m) => STYLE_MARK_NAMES.has(m.type.name));
+  const sourcePosition = sourcePara ? preSplitFrom.before() : null;
+  const resolver = getDocumentStyleResolver(state);
+  const sourceTableContext =
+    resolver && sourcePosition !== null
+      ? tableParagraphStyleContextAtPositions(state.doc, resolver).get(sourcePosition)
+      : undefined;
 
   // Intercept splitBlock's transaction so we can modify it before dispatch.
   // This ensures attrs + stored marks are set in a single transaction,
@@ -182,6 +308,26 @@ export const splitBlockClearBorders: Command = (state, dispatch, view) => {
     const newPara = $from.parent;
 
     if (newPara.type.name === "paragraph") {
+      let projectedNewParagraph = newPara;
+      if (sourcePara && sourcePropertyState && sourcePosition !== null) {
+        const rightPosition = $from.before();
+        const leftParagraph = tr.doc.resolve(rightPosition).nodeBefore;
+        if (leftParagraph?.type.name !== "paragraph") {
+          panic("A block split lost its left paragraph");
+        }
+        rebindSplitParagraphProperties({
+          transaction: tr,
+          leftPosition: rightPosition - leftParagraph.nodeSize,
+          rightPosition,
+          sourceState: sourcePropertyState,
+          transition: { type: "split-left-created-right-retains" },
+        });
+        const rebound = tr.doc.nodeAt(rightPosition);
+        if (rebound?.type.name !== "paragraph") {
+          panic("A block split lost its right paragraph");
+        }
+        projectedNewParagraph = rebound;
+      }
       // Word's `w:next`: pressing Enter at the end of a paragraph (the new
       // paragraph is empty) switches it to the style's follow-on style — e.g.
       // a heading drops to body text. Only applies to an empty trailing
@@ -189,93 +335,42 @@ export const splitBlockClearBorders: Command = (state, dispatch, view) => {
       // Use `content.size === 0` rather than `textContent.length` so a
       // mid-paragraph split before an inline atom (image, equation, field,
       // sdt, shape) is not mistaken for an empty trailing paragraph.
-      const resolver = getDocumentStyleResolver(state);
-      if (
-        resolver !== null &&
-        sourcePara !== null &&
-        newPara.content.size === 0 &&
-        applyNextParagraphStyle(tr, sourcePara, newPara, resolver)
-      ) {
+      if (resolver !== null && sourcePara !== null && newPara.content.size === 0) {
+        const nextStyleId = resolver.getNextStyleId(
+          sourcePara.attrs["styleId"] as string | null | undefined,
+        );
+        projectSplitParagraph({
+          context: sourceTableContext,
+          resolver,
+          sourcePara,
+          state,
+          tr,
+          newPara: projectedNewParagraph,
+          useNextStyle: nextStyleId !== null,
+        });
         dispatch(tr.scrollIntoView());
         return true;
       }
 
-      const newAttrs = { ...newPara.attrs };
-      let attrsChanged = false;
-
-      // Copy inherited attrs from source paragraph
-      if (sourcePara) {
-        for (const key of INHERITED_PARA_ATTRS) {
-          const srcVal = sourcePara.attrs[key];
-          if (srcVal !== null && newAttrs[key] === null) {
-            newAttrs[key] = srcVal;
-            attrsChanged = true;
-          }
-        }
-      }
-
-      // Clear borders (Word does not propagate paragraph borders on Enter)
-      if (newAttrs["borders"]) {
-        newAttrs["borders"] = null;
-        attrsChanged = true;
-      }
-
-      if (attrsChanged) {
-        tr.setNodeMarkup($from.before(), undefined, newAttrs);
-      }
-
-      // For empty paragraphs (Enter at end of line), set stored marks so typed text
-      // inherits font family, font size, and text color. We skip bold/italic/etc —
-      // Word doesn't carry direct formatting to new paragraphs.
-      if (newPara.textContent.length === 0) {
-        // Determine effective style marks. When text has explicit marks (e.g. user
-        // applied a font override), use those. When text inherits formatting from
-        // the paragraph style chain (no explicit marks), derive marks from the
-        // source paragraph's defaultTextFormatting.
-        let effectiveMarks: Mark[] = styleMarks;
-
-        if (effectiveMarks.length === 0 && sourcePara) {
-          const dtf = sourcePara.attrs["defaultTextFormatting"] as TextFormatting | undefined;
-          if (dtf) {
-            const allMarks = textFormattingToMarks(dtf, state.schema);
-            effectiveMarks = allMarks.filter((m) => STYLE_MARK_NAMES.has(m.type.name));
-          }
-        }
-
-        if (effectiveMarks.length > 0) {
-          // Sync defaultTextFormatting with the actual cursor marks so the empty
-          // paragraph measurement (used for caret height) matches the stored marks.
-          const dtf = { ...newAttrs["defaultTextFormatting"] };
-          let dtfChanged = false;
-          for (const m of effectiveMarks) {
-            if (m.type.name === "fontSize" && m.attrs["size"] !== dtf.fontSize) {
-              dtf.fontSize = m.attrs["size"];
-              dtfChanged = true;
-            }
-            if (m.type.name === "fontFamily") {
-              const ascii = m.attrs["ascii"] as string | undefined;
-              if (ascii && (!dtf.fontFamily || dtf.fontFamily.ascii !== ascii)) {
-                const nextFontFamily: NonNullable<TextFormatting["fontFamily"]> = { ascii };
-                const hAnsi = m.attrs["hAnsi"] as string | undefined;
-                if (hAnsi !== undefined) {
-                  nextFontFamily.hAnsi = hAnsi;
-                }
-                dtf.fontFamily = mergeFontFamily(dtf.fontFamily, nextFontFamily);
-                dtfChanged = true;
-              }
-            }
-          }
-          if (dtfChanged) {
-            tr.setNodeMarkup($from.before(), undefined, {
-              ...newAttrs,
-              defaultTextFormatting: dtf,
-            });
-          }
-
-          // IMPORTANT: setStoredMarks MUST be called AFTER all setNodeMarkup calls.
-          // setNodeMarkup adds a ReplaceStep which clears storedMarks on the transaction.
-          tr.setStoredMarks(effectiveMarks);
-        }
+      const projectedAttrs = expectParagraphAttrs(projectedNewParagraph);
+      const propertyState = expectParagraphPropertyState(projectedAttrs._paragraphPropertyState);
+      if (propertyState.authoredPPr.borders !== undefined) {
+        applyParagraphPropertyProjection({
+          transaction: tr,
+          pos: $from.before(),
+          projection: transitionParagraphProperties({
+            attrs: projectedAttrs,
+            state: {
+              type: "update",
+              authored: {
+                type: "mutate",
+                mutations: [{ key: "borders", mutation: { type: "remove" } }],
+              },
+              context: { type: "preserve" },
+            },
+          }),
+          source: { type: "preserve" },
+        });
       }
     }
 
@@ -295,8 +390,15 @@ export const BaseKeymapExtension = createExtension({
         ...baseKeymap,
         // Override some keys with better defaults
         Enter: splitBlockClearBorders,
-        Backspace: chainCommands(deleteSelection, clearIndentOnBackspace, joinBackward),
-        Delete: chainCommands(deleteSelection, joinForward),
+        Backspace: chainCommands(
+          deleteSelection,
+          clearIndentOnBackspace,
+          withParagraphJoinOwnership(joinBackward, "backward"),
+        ),
+        Delete: chainCommands(
+          deleteSelection,
+          withParagraphJoinOwnership(joinForward, "forward"),
+        ),
         "Mod-a": selectAll,
         Escape: selectParentNode,
       },

--- a/packages/core/src/prosemirror/extensions/features/BaseKeymapExtension.ts
+++ b/packages/core/src/prosemirror/extensions/features/BaseKeymapExtension.ts
@@ -7,7 +7,6 @@
 import {
   baseKeymap,
   splitBlock,
-  deleteSelection,
   joinBackward,
   joinForward,
   selectAll,
@@ -15,18 +14,22 @@ import {
 } from "prosemirror-commands";
 import { panic } from "better-result";
 import type { Node as PMNode } from "prosemirror-model";
-import type { Command, Transaction } from "prosemirror-state";
+import { TextSelection, type Command, type Transaction } from "prosemirror-state";
+import { canJoin, canSplit } from "prosemirror-transform";
 
 import { expectParagraphAttrs } from "../../attrs";
 import { attrsWithParagraphIndentationTransition } from "../../paragraphIndentation";
 import {
   applyParagraphPropertyProjection,
   createParagraphNodeFromProjection,
-  rebindJoinedParagraphProperties,
+  joinParagraphsWithProperties,
+  replaceSelectionThenSplitParagraphWithProperties,
   rebindSplitParagraphProperties,
+  splitParagraphWithProperties,
   transitionParagraphProperties,
 } from "../../paragraphPropertyMutation";
 import { expectParagraphPropertyState } from "../../paragraphPropertyState";
+import { recordDeleteParagraphPropertyOwnershipProof } from "../../paragraphPropertyOwnership";
 import { getDocumentNumbering } from "../../plugins/documentNumbering";
 import { getDocumentStyleResolver } from "../../plugins/documentStyles";
 import { inheritedParagraphRunFormatting } from "../../rebaseParagraphRunFormatting";
@@ -50,6 +53,19 @@ function chainCommands(...commands: Command[]): Command {
     return false;
   };
 }
+
+const deleteSelectionWithParagraphOwnership: Command = (state, dispatch) => {
+  if (state.selection.empty) {
+    return false;
+  }
+  if (!dispatch) {
+    return true;
+  }
+  const transaction = state.tr;
+  recordDeleteParagraphPropertyOwnershipProof(transaction);
+  dispatch(transaction.deleteSelection().scrollIntoView());
+  return true;
+};
 
 /**
  * Backspace at the start of a paragraph clears first-line indent / hanging indent
@@ -110,10 +126,7 @@ const clearIndentOnBackspace: Command = (state, dispatch) => {
 
 type ParagraphJoinCandidate = {
   leftContentSize: number;
-  leftPosition: number;
-  leftState: ReturnType<typeof expectParagraphPropertyState>;
-  rightContentSize: number;
-  rightState: ReturnType<typeof expectParagraphPropertyState>;
+  joinPosition: number;
 };
 
 const paragraphJoinCandidate = (
@@ -155,22 +168,30 @@ const paragraphJoinCandidate = (
   }
   return {
     leftContentSize: left.content.size,
-    leftPosition,
-    leftState: expectParagraphPropertyState(expectParagraphAttrs(left)._paragraphPropertyState),
-    rightContentSize: right.content.size,
-    rightState: expectParagraphPropertyState(expectParagraphAttrs(right)._paragraphPropertyState),
+    joinPosition: leftPosition + left.nodeSize,
   };
 };
 
-const withParagraphJoinOwnership = (
-  command: Command,
-  direction: "backward" | "forward",
-): Command =>
+const withParagraphJoinOwnership =
+  (command: Command, direction: "backward" | "forward"): Command =>
   (state, dispatch, view) => {
     if (!dispatch) {
       return command(state, undefined, view);
     }
     const candidate = paragraphJoinCandidate(state, direction);
+    if (candidate && canJoin(state.doc, candidate.joinPosition)) {
+      const transaction = state.tr;
+      const joinedPosition = joinParagraphsWithProperties({
+        transaction,
+        joinPos: candidate.joinPosition,
+        transition: { type: "join-right-paragraph-mark-retains" },
+      });
+      transaction.setSelection(
+        TextSelection.near(transaction.doc.resolve(joinedPosition + candidate.leftContentSize + 1)),
+      );
+      dispatch(transaction.scrollIntoView());
+      return true;
+    }
     let captured: Transaction | null = null;
     const handled = command(
       state,
@@ -188,24 +209,7 @@ const withParagraphJoinOwnership = (
     if (captured === null) {
       return true;
     }
-    const transaction = captured;
-    if (candidate) {
-      const joinedPosition = transaction.mapping.map(candidate.leftPosition, -1);
-      const joined = transaction.doc.nodeAt(joinedPosition);
-      if (
-        joined?.type.name === "paragraph" &&
-        joined.content.size === candidate.leftContentSize + candidate.rightContentSize
-      ) {
-        rebindJoinedParagraphProperties({
-          transaction,
-          joinedPosition,
-          leftState: candidate.leftState,
-          rightState: candidate.rightState,
-          transition: { type: "join-right-paragraph-mark-retains" },
-        });
-      }
-    }
-    dispatch(transaction);
+    dispatch(captured);
     return true;
   };
 
@@ -289,14 +293,34 @@ export const splitBlockClearBorders: Command = (state, dispatch, view) => {
   // Intercept splitBlock's transaction so we can modify it before dispatch.
   // This ensures attrs + stored marks are set in a single transaction,
   // avoiding a flash where the empty paragraph has no formatting.
-  const splitResult = { tr: null as Transaction | null };
+  const splitResult = { ownershipRebound: false, tr: null as Transaction | null };
   const capturingDispatch = dispatch
     ? (tr: Transaction) => {
         splitResult.tr = tr;
       }
     : undefined;
 
-  if (!splitBlock(state, capturingDispatch, view)) {
+  if (dispatch && sourcePara && sourcePropertyState && sourcePosition !== null) {
+    const transaction = state.tr;
+    const preflight = state.selection.empty ? transaction : state.tr.deleteSelection();
+    const splitPosition = preflight.selection.from;
+    if (!canSplit(preflight.doc, splitPosition)) {
+      return false;
+    }
+    const { rightPosition } = state.selection.empty
+      ? splitParagraphWithProperties({
+          transaction,
+          pos: splitPosition,
+          transition: { type: "split-left-created-right-retains" },
+        })
+      : replaceSelectionThenSplitParagraphWithProperties({
+          transaction,
+          transition: { type: "split-left-created-right-retains" },
+        });
+    transaction.setSelection(TextSelection.near(transaction.doc.resolve(rightPosition + 1), 1));
+    splitResult.tr = transaction;
+    splitResult.ownershipRebound = true;
+  } else if (!splitBlock(state, capturingDispatch, view)) {
     return false;
   }
 
@@ -309,7 +333,12 @@ export const splitBlockClearBorders: Command = (state, dispatch, view) => {
 
     if (newPara.type.name === "paragraph") {
       let projectedNewParagraph = newPara;
-      if (sourcePara && sourcePropertyState && sourcePosition !== null) {
+      if (
+        !splitResult.ownershipRebound &&
+        sourcePara &&
+        sourcePropertyState &&
+        sourcePosition !== null
+      ) {
         const rightPosition = $from.before();
         const leftParagraph = tr.doc.resolve(rightPosition).nodeBefore;
         if (leftParagraph?.type.name !== "paragraph") {
@@ -391,12 +420,12 @@ export const BaseKeymapExtension = createExtension({
         // Override some keys with better defaults
         Enter: splitBlockClearBorders,
         Backspace: chainCommands(
-          deleteSelection,
+          deleteSelectionWithParagraphOwnership,
           clearIndentOnBackspace,
           withParagraphJoinOwnership(joinBackward, "backward"),
         ),
         Delete: chainCommands(
-          deleteSelection,
+          deleteSelectionWithParagraphOwnership,
           withParagraphJoinOwnership(joinForward, "forward"),
         ),
         "Mod-a": selectAll,

--- a/packages/core/src/prosemirror/extensions/features/EmptyParagraphFormatExtension.ts
+++ b/packages/core/src/prosemirror/extensions/features/EmptyParagraphFormatExtension.ts
@@ -23,8 +23,8 @@ import type { Schema } from "prosemirror-model";
 import { Plugin, PluginKey } from "prosemirror-state";
 
 import type { TextFormatting } from "../../../types/document";
+import { inheritedRunFormattingMarks } from "../../rebaseParagraphRunFormatting";
 import { createExtension } from "../create";
-import { textFormattingToMarks } from "../marks/markUtils";
 import type { ExtensionContext, ExtensionRuntime } from "../types";
 
 export const emptyParagraphFormatKey = new PluginKey("emptyParagraphFormat");
@@ -81,7 +81,7 @@ function createEmptyParagraphFormatPlugin(schema: Schema): Plugin {
         return null;
       }
 
-      const marks = textFormattingToMarks(dtf, schema);
+      const marks = inheritedRunFormattingMarks(dtf, schema);
       if (marks.length === 0) {
         return null;
       }

--- a/packages/core/src/prosemirror/extensions/features/ListExtension.ts
+++ b/packages/core/src/prosemirror/extensions/features/ListExtension.ts
@@ -6,17 +6,28 @@
  */
 
 import { panic } from "better-result";
+import type { Node as PMNode } from "prosemirror-model";
 import type { Command, EditorState } from "prosemirror-state";
 
 import { expectParagraphAttrs } from "../../attrs";
 import {
   hasSerializableParagraphPropertyChange,
-  PPR_CHANGE_SCOPED_ATTR_KEYS,
+  paragraphPropertiesSnapshot,
 } from "../../commands/propertyChangeScope";
+import { attrsWithParagraphIndentationTransition } from "../../paragraphIndentation";
+import {
+  applyParagraphPropertyProjection,
+  patchParagraphPropertyProjection,
+  splitParagraphWithProperties,
+  type ParagraphPropertyProjection,
+} from "../../paragraphPropertyMutation";
 import { makeRevisionInfo, SUGGESTION_META } from "../../plugins/suggestionMode";
-import { CLEARED_LIST_RENDERING_ATTRS, LIST_RENDERING_ATTR_KEYS } from "../../listMarker";
+import { LIST_RENDERING_ATTR_KEYS } from "../../listMarker";
 import { getDocumentNumbering } from "../../plugins/documentNumbering";
-import { listLevelAttrPatch } from "../../styles/resolvedStyleAttrs";
+import {
+  paragraphPropertiesForListLevelTransition,
+  paragraphPropertiesForListRemoval,
+} from "../../styles/resolvedStyleAttrs";
 import { createExtension } from "../create";
 import { goToNextCell, goToPrevCell } from "../nodes/TableExtension";
 import { Priority } from "../types";
@@ -42,14 +53,12 @@ function chainCommands(...commands: Command[]): Command {
 // TRACKED PARAGRAPH-PROPERTY CHANGE (suggesting mode)
 // ============================================================================
 
-function appendParagraphPropertyChange(
-  attrs: Record<string, unknown>,
+function paragraphPropertyChangePatch(
   existing: ParagraphPropertyChangeAttrs[] | undefined,
   previousFormatting: Record<string, unknown>,
   rev: { id: number; author: string; date: string },
 ): Record<string, unknown> {
   return {
-    ...attrs,
     _propertyChanges: [
       ...(existing ?? []),
       {
@@ -61,39 +70,15 @@ function appendParagraphPropertyChange(
   };
 }
 
-function getPreviousListFormatting(attrs: Record<string, unknown>): Record<string, unknown> {
-  const previousFormatting: Record<string, unknown> = {};
-  // Rejecting a pPrChange restores the stored record WHOLESALE within the
-  // CT_PPrBase scope (a scoped key absent from the record resets to null —
-  // see propertyChangeScope.ts). Snapshot every non-null in-scope attr so a
-  // reject cannot wipe formatting the list toggle never touched.
-  for (const key of PPR_CHANGE_SCOPED_ATTR_KEYS) {
-    const value = attrs[key];
-    if (value != null) {
-      previousFormatting[key] = value;
-    }
-  }
+function getPreviousListFormatting(node: PMNode): Record<string, unknown> {
+  const previousFormatting: Record<string, unknown> = paragraphPropertiesSnapshot(node);
+  const attrs = node.attrs;
   // List-rendering bookkeeping snapshots with explicit nulls: these attrs are
   // outside the wholesale scope, so only recorded keys restore on reject.
-  previousFormatting["numPr"] = attrs["numPr"] ?? null;
   for (const key of LIST_RENDERING_ATTR_KEYS) {
     previousFormatting[key] = attrs[key] ?? null;
   }
   return previousFormatting;
-}
-
-function clearListAttrs(attrs: ParagraphAttrs): Record<string, unknown> {
-  const styleNumPr = attrs.numPrFromStyle;
-  const numPr =
-    styleNumPr?.numId !== undefined && styleNumPr.numId !== 0
-      ? { numId: 0, ilvl: attrs.numPr?.ilvl ?? styleNumPr.ilvl ?? 0 }
-      : null;
-
-  return {
-    ...attrs,
-    numPr,
-    ...CLEARED_LIST_RENDERING_ATTRS,
-  };
 }
 
 type ActiveListParagraphAttrs = ParagraphAttrs & {
@@ -149,32 +134,32 @@ function toggleList(numId: number): Command {
       if (node.type.name === "paragraph" && !seen.has(pos)) {
         seen.add(pos);
 
-        let nextAttrs: Record<string, unknown>;
-
-        if (isInSameList) {
-          nextAttrs = clearListAttrs(expectParagraphAttrs(node));
-        } else {
-          const isBullet = numId === 1;
-          nextAttrs = {
-            ...node.attrs,
-            ...CLEARED_LIST_RENDERING_ATTRS,
-            numPr: { numId, ilvl: node.attrs["numPr"]?.ilvl || 0 },
-            listIsBullet: isBullet,
-            listNumFmt: isBullet ? null : "decimal",
-          };
-        }
+        const attrs = expectParagraphAttrs(node);
+        let projection = isInSameList
+          ? paragraphPropertiesForListRemoval(attrs)
+          : paragraphPropertiesForListLevelTransition({
+              attrs,
+              numPr: { numId, ilvl: attrs.numPr?.ilvl ?? 0 },
+              numbering: getDocumentNumbering(state),
+            });
 
         if (rev) {
-          const existing = expectParagraphAttrs(node)._propertyChanges;
-          nextAttrs = appendParagraphPropertyChange(
-            nextAttrs,
-            existing,
-            getPreviousListFormatting(node.attrs),
-            rev,
-          );
+          projection = patchParagraphPropertyProjection({
+            projection,
+            patch: paragraphPropertyChangePatch(
+              attrs._propertyChanges,
+              getPreviousListFormatting(node),
+              rev,
+            ),
+          });
         }
 
-        tr = tr.setNodeMarkup(pos, undefined, nextAttrs);
+        applyParagraphPropertyProjection({
+          transaction: tr,
+          pos,
+          projection,
+          source: { type: "preserve" },
+        });
       }
     });
 
@@ -191,22 +176,19 @@ export const toggleBulletList: Command = (state, dispatch) => toggleList(1)(stat
 
 export const toggleNumberedList: Command = (state, dispatch) => toggleList(2)(state, dispatch);
 
-const attrsForListLevel = (
+const propertiesForListLevel = (
   state: EditorState,
   attrs: ParagraphAttrs,
   level: number,
-): Record<string, unknown> => {
+): ParagraphPropertyProjection => {
   if (!hasActiveListNumbering(attrs)) {
     panic("Cannot change the level of a list without a numbering id");
   }
-  return {
-    ...attrs,
-    ...listLevelAttrPatch(
-      attrs,
-      { numId: attrs.numPr.numId, ilvl: level },
-      getDocumentNumbering(state),
-    ),
-  };
+  return paragraphPropertiesForListLevelTransition({
+    attrs,
+    numPr: { numId: attrs.numPr.numId, ilvl: level },
+    numbering: getDocumentNumbering(state),
+  });
 };
 
 const increaseListLevel: Command = (state, dispatch) => {
@@ -232,13 +214,14 @@ const increaseListLevel: Command = (state, dispatch) => {
 
   const paragraphPos = $from.before($from.depth);
 
-  dispatch(
-    state.tr
-      .setNodeMarkup(paragraphPos, undefined, {
-        ...attrsForListLevel(state, attrs, currentLevel + 1),
-      })
-      .scrollIntoView(),
-  );
+  const tr = state.tr;
+  applyParagraphPropertyProjection({
+    transaction: tr,
+    pos: paragraphPos,
+    projection: propertiesForListLevel(state, attrs, currentLevel + 1),
+    source: { type: "preserve" },
+  });
+  dispatch(tr.scrollIntoView());
 
   return true;
 };
@@ -264,24 +247,40 @@ const decreaseListLevel: Command = (state, dispatch) => {
   const paragraphPos = $from.before($from.depth);
 
   if (currentLevel <= 0) {
-    dispatch(
-      state.tr
-        .setNodeMarkup(paragraphPos, undefined, {
-          ...clearListAttrs(attrs),
-          indentLeft: null,
-          indentFirstLine: null,
-          hangingIndent: null,
-        })
-        .scrollIntoView(),
-    );
+    const tr = state.tr;
+    applyParagraphPropertyProjection({
+      transaction: tr,
+      pos: paragraphPos,
+      projection: paragraphPropertiesForListRemoval(attrs),
+      source: { type: "preserve" },
+    });
+    const cleared = tr.doc.nodeAt(paragraphPos);
+    if (cleared?.type.name !== "paragraph") {
+      panic("Clearing list properties lost the paragraph");
+    }
+    const transition = attrsWithParagraphIndentationTransition(expectParagraphAttrs(cleared), {
+      type: "force-visible-zero",
+      sides: ["left", "firstLine"],
+    });
+    if (transition.type === "unsupported") {
+      panic("Clearing paragraph numbering left an active numbering-indent owner.");
+    }
+    applyParagraphPropertyProjection({
+      projection: transition.projection,
+      source: { type: "preserve" },
+      pos: paragraphPos,
+      transaction: tr,
+    });
+    dispatch(tr.scrollIntoView());
   } else {
-    dispatch(
-      state.tr
-        .setNodeMarkup(paragraphPos, undefined, {
-          ...attrsForListLevel(state, attrs, currentLevel - 1),
-        })
-        .scrollIntoView(),
-    );
+    const tr = state.tr;
+    applyParagraphPropertyProjection({
+      transaction: tr,
+      pos: paragraphPos,
+      projection: propertiesForListLevel(state, attrs, currentLevel - 1),
+      source: { type: "preserve" },
+    });
+    dispatch(tr.scrollIntoView());
   }
 
   return true;
@@ -304,7 +303,12 @@ const removeList: Command = (state, dispatch) => {
       !seen.has(pos)
     ) {
       seen.add(pos);
-      tr = tr.setNodeMarkup(pos, undefined, clearListAttrs(expectParagraphAttrs(node)));
+      applyParagraphPropertyProjection({
+        transaction: tr,
+        pos,
+        projection: paragraphPropertiesForListRemoval(expectParagraphAttrs(node)),
+        source: { type: "preserve" },
+      });
     }
   });
 
@@ -370,7 +374,13 @@ function exitListOnEmptyEnter(): Command {
     }
 
     if (dispatch) {
-      const tr = state.tr.setNodeMarkup($from.before(), undefined, clearListAttrs(attrs));
+      const tr = state.tr;
+      applyParagraphPropertyProjection({
+        transaction: tr,
+        pos: $from.before(),
+        projection: paragraphPropertiesForListRemoval(attrs),
+        source: { type: "preserve" },
+      });
       dispatch(tr);
     }
     return true;
@@ -398,12 +408,17 @@ function splitListItem(): Command {
       const { tr } = state;
       const pos = $from.pos;
 
-      tr.split(pos, 1, [
-        {
-          type: state.schema.nodes["paragraph"]!,
-          attrs: { ...paragraph.attrs },
-        },
-      ]);
+      splitParagraphWithProperties({
+        transaction: tr,
+        pos,
+        transition: { type: "split-left-created-right-retains" },
+        typesAfter: [
+          {
+            type: state.schema.nodes["paragraph"]!,
+            attrs: { ...paragraph.attrs },
+          },
+        ],
+      });
 
       dispatch(tr.scrollIntoView());
     }
@@ -433,7 +448,13 @@ function backspaceExitList(): Command {
     }
 
     if (dispatch) {
-      const tr = state.tr.setNodeMarkup($from.before(), undefined, clearListAttrs(attrs));
+      const tr = state.tr;
+      applyParagraphPropertyProjection({
+        transaction: tr,
+        pos: $from.before(),
+        projection: paragraphPropertiesForListRemoval(attrs),
+        source: { type: "preserve" },
+      });
       dispatch(tr);
     }
     return true;
@@ -466,11 +487,12 @@ function increaseListIndent(): Command {
     if (dispatch) {
       let tr = state.tr;
       for (const { pos, attrs } of positions) {
-        tr = tr.setNodeMarkup(
+        applyParagraphPropertyProjection({
+          transaction: tr,
           pos,
-          undefined,
-          attrsForListLevel(state, attrs, (attrs.numPr?.ilvl ?? 0) + 1),
-        );
+          projection: propertiesForListLevel(state, attrs, (attrs.numPr?.ilvl ?? 0) + 1),
+          source: { type: "preserve" },
+        });
       }
       dispatch(tr);
     }
@@ -502,15 +524,35 @@ function decreaseListIndent(): Command {
       for (const { pos, attrs } of positions) {
         const currentLevel = attrs.numPr?.ilvl ?? 0;
         if (currentLevel <= 0) {
-          tr = tr.setNodeMarkup(pos, undefined, {
-            ...clearListAttrs(attrs),
-            indentLeft: null,
-            indentFirstLine: null,
-            hangingIndent: null,
+          applyParagraphPropertyProjection({
+            transaction: tr,
+            pos,
+            projection: paragraphPropertiesForListRemoval(attrs),
+            source: { type: "preserve" },
+          });
+          const cleared = tr.doc.nodeAt(pos);
+          if (cleared?.type.name !== "paragraph") {
+            panic("Clearing list properties lost the paragraph");
+          }
+          const transition = attrsWithParagraphIndentationTransition(expectParagraphAttrs(cleared), {
+            type: "force-visible-zero",
+            sides: ["left", "firstLine"],
+          });
+          if (transition.type === "unsupported") {
+            panic("Clearing paragraph numbering left an active numbering-indent owner.");
+          }
+          applyParagraphPropertyProjection({
+            projection: transition.projection,
+            source: { type: "preserve" },
+            pos,
+            transaction: tr,
           });
         } else {
-          tr = tr.setNodeMarkup(pos, undefined, {
-            ...attrsForListLevel(state, attrs, currentLevel - 1),
+          applyParagraphPropertyProjection({
+            transaction: tr,
+            pos,
+            projection: propertiesForListLevel(state, attrs, currentLevel - 1),
+            source: { type: "preserve" },
           });
         }
       }

--- a/packages/core/src/prosemirror/extensions/features/ParaIdAllocatorExtension.test.ts
+++ b/packages/core/src/prosemirror/extensions/features/ParaIdAllocatorExtension.test.ts
@@ -16,13 +16,22 @@ import { describe, expect, spyOn, test } from "bun:test";
 import { history, redo, undo } from "prosemirror-history";
 import { Schema, Slice, Fragment } from "prosemirror-model";
 import { EditorState } from "prosemirror-state";
+import { TextSelection } from "prosemirror-state";
 import type { Command } from "prosemirror-state";
+import { ySyncPluginKey } from "y-prosemirror";
 
+import { PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR } from "../../../docx/paragraphPropertySource";
 import {
-  PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR,
-  PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR,
-  joinProseParagraphsWithRightPropertySource,
-} from "../../../docx/paragraphPropertySource";
+  ParagraphPropertySourceContract,
+  ParagraphPropertySourceValidationError,
+  paragraphPropertySourceTokenWire,
+} from "../../../docx/paragraphPropertySourceIdentity";
+import {
+  joinParagraphsWithProperties,
+  replaceSelectionThenSplitParagraphWithProperties,
+  splitParagraphWithProperties,
+} from "../../paragraphPropertyMutation";
+import { EMPTY_EDITOR_PARAGRAPH_PROPERTY_STATE } from "../../paragraphPropertyState";
 import {
   getChangedParagraphIds,
   ParagraphChangeTrackerExtension,
@@ -46,7 +55,7 @@ const schema = new Schema({
       attrs: {
         paraId: { default: null },
         textId: { default: null },
-        [PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR]: { default: null },
+        _paragraphPropertyState: { default: EMPTY_EDITOR_PARAGRAPH_PROPERTY_STATE },
       },
       toDOM: () => ["p", 0],
     },
@@ -73,13 +82,22 @@ const para = (text: string, paraId: string | null = null) =>
   schema.node("paragraph", { paraId }, text.length > 0 ? [schema.text(text)] : []);
 
 const SOURCE_DIGEST = "a".repeat(64);
-const SOURCE_CONTRACT = `folio-ppr-v1:${SOURCE_DIGEST}`;
-const sourceToken = (ordinal: number, fingerprint = SOURCE_DIGEST.slice(0, 32)) =>
-  `p1d:${fingerprint}:${ordinal.toString(36)}`;
+const SOURCE_CONTRACT = ParagraphPropertySourceContract.fromSourceCensus(SOURCE_DIGEST, [
+  { paragraphCount: 10, story: { type: "document" } },
+]).serialized;
+const sourceToken = (ordinal: number) =>
+  paragraphPropertySourceTokenWire({ type: "document" }, ordinal);
 const sourcedPara = (text: string, paraId: string, ordinal: number) =>
   schema.node(
     "paragraph",
-    { paraId, [PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR]: sourceToken(ordinal) },
+    {
+      paraId,
+      _paragraphPropertyState: {
+        ...EMPTY_EDITOR_PARAGRAPH_PROPERTY_STATE,
+        type: "imported",
+        token: sourceToken(ordinal),
+      },
+    },
     text.length > 0 ? [schema.text(text)] : [],
   );
 
@@ -104,6 +122,12 @@ const createTrackedState = (...paras: ReturnType<typeof para>[]) =>
 const createHistoryState = (...paras: ReturnType<typeof para>[]) =>
   EditorState.create({
     doc: schema.node("doc", null, paras),
+    plugins: [plugin, history()],
+  });
+
+const createSourcedHistoryState = (...paras: ReturnType<typeof sourcedPara>[]) =>
+  EditorState.create({
+    doc: schema.node("doc", { [PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR]: SOURCE_CONTRACT }, paras),
     plugins: [plugin, history()],
   });
 
@@ -133,8 +157,12 @@ const collectSourceTokens = (state: EditorState): (string | null)[] => {
   const out: (string | null)[] = [];
   state.doc.descendants((node) => {
     if (node.type.name === "paragraph") {
-      const token = node.attrs[PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR];
-      out.push(typeof token === "string" ? token : null);
+      const state = node.attrs["_paragraphPropertyState"];
+      out.push(
+        typeof state === "object" && state !== null && state.type === "imported"
+          ? state.token
+          : null,
+      );
       return false;
     }
     return true;
@@ -390,44 +418,93 @@ describe("ParaIdAllocatorExtension", () => {
   });
 
   test.each(["", "Hello"])(
-    "an attribute-only paragraph recreation restores an omitted seeded source token for %j",
+    "an attribute-only paragraph recreation cannot omit imported state for %j",
     (text) => {
       const initial = createSourcedState(sourcedPara(text, "AAAA1111", 0));
-      const next = initial.apply(
-        initial.tr.setNodeMarkup(0, undefined, {
-          paraId: "AAAA1111",
-          textId: "BBBB2222",
-        }),
-      );
-
-      expect(collectSourceTokens(next)).toEqual([sourceToken(0)]);
+      expect(() =>
+        initial.apply(
+          initial.tr.setNodeMarkup(0, undefined, {
+            paraId: "AAAA1111",
+            textId: "BBBB2222",
+          }),
+        ),
+      ).toThrow(ParagraphPropertySourceValidationError);
     },
   );
 
-  test("a nested paragraph recreation restores an omitted seeded source token", () => {
+  test("a nested paragraph recreation cannot omit imported state", () => {
     const initial = EditorState.create({
       doc: schema.node("doc", { [PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR]: SOURCE_CONTRACT }, [
         schema.node("blockquote", null, [sourcedPara("Nested", "AAAA1111", 0)]),
       ]),
       plugins: [plugin],
     });
-    const next = initial.apply(
-      initial.tr.setNodeMarkup(1, undefined, {
-        paraId: "AAAA1111",
-        textId: "BBBB2222",
-      }),
-    );
+    expect(() =>
+      initial.apply(
+        initial.tr.setNodeMarkup(1, undefined, {
+          paraId: "AAAA1111",
+          textId: "BBBB2222",
+        }),
+      ),
+    ).toThrow(ParagraphPropertySourceValidationError);
+  });
 
-    expect(collectSourceTokens(next)).toEqual([sourceToken(0)]);
+  test.each([0, 2, 5])("a raw split at offset %i cannot duplicate imported ownership", (offset) => {
+    const initial = createSourcedState(sourcedPara("Hello", "AAAA1111", 0));
+    expect(() => initial.apply(initial.tr.split(offset + 1))).toThrow(
+      ParagraphPropertySourceValidationError,
+    );
+  });
+
+  test("the ownership proof step survives split undo and redo", () => {
+    const initial = createSourcedHistoryState(sourcedPara("Hello", "AAAA1111", 0));
+    const transaction = initial.tr;
+    splitParagraphWithProperties({
+      transaction,
+      pos: 3,
+      transition: { type: "split-left-created-right-retains" },
+    });
+    const split = initial.apply(transaction);
+    const undone = applyCommand(split, undo);
+    const redone = applyCommand(undone, redo);
+
+    expect(collectSourceTokens(split)).toEqual([null, sourceToken(0)]);
+    expect(collectSourceTokens(undone)).toEqual([sourceToken(0)]);
+    expect(collectSourceTokens(redone)).toEqual([null, sourceToken(0)]);
+  });
+
+  test("replace-selection and split records ownership before either structural step", () => {
+    const initial = createSourcedHistoryState(
+      sourcedPara("First", "AAAA1111", 0),
+      sourcedPara("Second", "BBBB2222", 1),
+    );
+    const transaction = initial.tr.setSelection(TextSelection.create(initial.doc, 3, 10));
+    replaceSelectionThenSplitParagraphWithProperties({
+      transaction,
+      transition: { type: "split-left-created-right-retains" },
+    });
+    const changed = initial.apply(transaction);
+    const undone = applyCommand(changed, undo);
+    const redone = applyCommand(undone, redo);
+
+    expect(collectSourceTokens(changed)).toEqual([null, sourceToken(0)]);
+    expect(collectSourceTokens(undone)).toEqual([sourceToken(0), sourceToken(1)]);
+    expect(collectSourceTokens(redone)).toEqual([null, sourceToken(0)]);
   });
 
   test.each([0, 2, 5])(
-    "split at offset %i retains the token only on the mapped original half",
+    "the canonical split at offset %i carries an issuer proof and retains the right owner",
     (offset) => {
       const initial = createSourcedState(sourcedPara("Hello", "AAAA1111", 0));
-      const next = initial.apply(initial.tr.split(offset + 1));
+      const transaction = initial.tr;
+      splitParagraphWithProperties({
+        transaction,
+        pos: offset + 1,
+        transition: { type: "split-left-created-right-retains" },
+      });
+      const next = initial.apply(transaction);
 
-      expect(collectSourceTokens(next)).toEqual([sourceToken(0), null]);
+      expect(collectSourceTokens(next)).toEqual([null, sourceToken(0)]);
     },
   );
 
@@ -438,47 +515,198 @@ describe("ParaIdAllocatorExtension", () => {
       { ...original.attrs, paraId: "BBBB2222" },
       schema.text("Copy"),
     );
-    const next = initial.apply(initial.tr.replace(0, 0, new Slice(Fragment.from(copy), 0, 0)));
-
-    expect(collectSourceTokens(next)).toEqual([null, sourceToken(0)]);
+    expect(() =>
+      initial.apply(initial.tr.replace(0, 0, new Slice(Fragment.from(copy), 0, 0))),
+    ).toThrow(ParagraphPropertySourceValidationError);
   });
 
-  test("a token from a different source fingerprint is cleared", () => {
+  test("a contract-owned token cannot appear without an ownership transition", () => {
     const initial = createSourcedState(sourcedPara("Original", "AAAA1111", 0));
     const foreign = schema.node(
       "paragraph",
       {
         paraId: "BBBB2222",
-        [PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR]: sourceToken(0, "b".repeat(32)),
+        _paragraphPropertyState: {
+          ...EMPTY_EDITOR_PARAGRAPH_PROPERTY_STATE,
+          type: "imported",
+          token: sourceToken(9),
+        },
       },
       schema.text("Foreign"),
     );
-    const next = initial.apply(
-      initial.tr.replace(
-        initial.doc.content.size,
-        initial.doc.content.size,
-        new Slice(Fragment.from(foreign), 0, 0),
+    expect(() =>
+      initial.apply(
+        initial.tr.replace(
+          initial.doc.content.size,
+          initial.doc.content.size,
+          new Slice(Fragment.from(foreign), 0, 0),
+        ),
       ),
-    );
-
-    expect(collectSourceTokens(next)).toEqual([sourceToken(0), null]);
+    ).toThrow(ParagraphPropertySourceValidationError);
   });
 
-  test("a uniquely seeded token survives delete then paste", () => {
+  test("a valid-looking token outside the contract census is rejected", () => {
+    const initial = createSourcedState(sourcedPara("Original", "AAAA1111", 0));
+    const forged = schema.node(
+      "paragraph",
+      {
+        paraId: "BBBB2222",
+        _paragraphPropertyState: {
+          ...EMPTY_EDITOR_PARAGRAPH_PROPERTY_STATE,
+          type: "imported",
+          token: sourceToken(10),
+        },
+      },
+      schema.text("Forged"),
+    );
+
+    expect(() =>
+      initial.apply(
+        initial.tr.replace(
+          initial.doc.content.size,
+          initial.doc.content.size,
+          new Slice(Fragment.from(forged), 0, 0),
+        ),
+      ),
+    ).toThrow(ParagraphPropertySourceValidationError);
+  });
+
+  test("a token from another contract story cannot enter the editable body", () => {
+    const contract = ParagraphPropertySourceContract.fromSourceCensus(SOURCE_DIGEST, [
+      { paragraphCount: 1, story: { type: "document" } },
+      { paragraphCount: 1, story: { relationshipId: "rId1", type: "header" } },
+    ]);
+    const headerToken = paragraphPropertySourceTokenWire(
+      { relationshipId: "rId1", type: "header" },
+      0,
+    );
+    const headerOwned = schema.node(
+      "paragraph",
+      {
+        paraId: "AAAA1111",
+        _paragraphPropertyState: {
+          ...EMPTY_EDITOR_PARAGRAPH_PROPERTY_STATE,
+          type: "imported",
+          token: headerToken,
+        },
+      },
+      schema.text("Header"),
+    );
+
+    expect(() =>
+      EditorState.create({
+        doc: schema.node("doc", { [PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR]: contract.serialized }, [
+          headerOwned,
+        ]),
+        plugins: [plugin],
+      }),
+    ).toThrow(ParagraphPropertySourceValidationError);
+  });
+
+  test("a raw paragraph deletion cannot discard imported ownership", () => {
     const original = sourcedPara("Original", "AAAA1111", 0);
     const sibling = sourcedPara("Sibling", "BBBB2222", 1);
     const initial = createSourcedState(original, sibling);
-    const deleted = initial.apply(initial.tr.delete(0, original.nodeSize));
+    expect(() => initial.apply(initial.tr.delete(0, original.nodeSize))).toThrow(
+      ParagraphPropertySourceValidationError,
+    );
+  });
+
+  test("a remote deletion is accepted only when the mapping deletes the owner interior", () => {
+    const original = sourcedPara("Original", "AAAA1111", 0);
+    const sibling = sourcedPara("Sibling", "BBBB2222", 1);
+    const initial = createSourcedState(original, sibling);
+    const transaction = initial.tr
+      .delete(0, original.nodeSize)
+      .setMeta(ySyncPluginKey, { type: "synthetic-remote-boundary" });
+    const next = initial.apply(transaction);
+
+    expect(collectSourceTokens(next)).toEqual([sourceToken(1)]);
+  });
+
+  test("a remote undo can restore an exact previously observed deleted owner", () => {
+    const original = sourcedPara("Original", "AAAA1111", 0);
+    const sibling = sourcedPara("Sibling", "BBBB2222", 1);
+    const initial = createSourcedState(original, sibling);
+    const deleted = initial.apply(
+      initial.tr
+        .delete(0, original.nodeSize)
+        .setMeta(ySyncPluginKey, { type: "synthetic-remote-boundary" }),
+    );
     const restored = deleted.apply(
-      deleted.tr.replace(
-        deleted.doc.content.size,
-        deleted.doc.content.size,
-        new Slice(Fragment.from(original), 0, 0),
-      ),
+      deleted.tr
+        .replace(0, 0, new Slice(Fragment.from(original), 0, 0))
+        .setMeta(ySyncPluginKey, { type: "synthetic-remote-boundary" }),
     );
 
-    expect(collectSourceTokens(deleted)).toEqual([sourceToken(1)]);
-    expect(collectSourceTokens(restored)).toEqual([sourceToken(1), sourceToken(0)]);
+    expect(collectSourceTokens(restored)).toEqual([sourceToken(0), sourceToken(1)]);
+  });
+
+  test("a remote insertion cannot mint an unobserved contract-owned owner", () => {
+    const initial = createSourcedState(sourcedPara("Original", "AAAA1111", 0));
+    const unseen = sourcedPara("Unseen", "BBBB2222", 9);
+    const transaction = initial.tr
+      .replace(
+        initial.doc.content.size,
+        initial.doc.content.size,
+        new Slice(Fragment.from(unseen), 0, 0),
+      )
+      .setMeta(ySyncPluginKey, { type: "synthetic-remote-boundary" });
+
+    expect(() => initial.apply(transaction)).toThrow(ParagraphPropertySourceValidationError);
+  });
+
+  test("a remote split cannot reuse an imported owner without a structural proof", () => {
+    const initial = createSourcedState(sourcedPara("Original", "AAAA1111", 0));
+    const transaction = initial.tr
+      .split(4)
+      .setMeta(ySyncPluginKey, { type: "synthetic-remote-boundary" });
+
+    expect(() => initial.apply(transaction)).toThrow(ParagraphPropertySourceValidationError);
+  });
+
+  test("a remote split is reified from an exact content partition and owner transition", () => {
+    const initial = createSourcedState(sourcedPara("Original", "AAAA1111", 0));
+    const transaction = initial.tr.split(4);
+    const left = transaction.doc.child(0);
+    transaction.setNodeMarkup(0, undefined, {
+      ...left.attrs,
+      _paragraphPropertyState: EMPTY_EDITOR_PARAGRAPH_PROPERTY_STATE,
+    });
+    transaction.setMeta(ySyncPluginKey, { type: "synthetic-remote-boundary" });
+    const next = initial.apply(transaction);
+
+    expect(collectSourceTokens(next)).toEqual([null, sourceToken(0)]);
+  });
+
+  test("a remote owner relocation without an exact split or join topology is rejected", () => {
+    const initial = createSourcedState(sourcedPara("Original", "AAAA1111", 0));
+    const original = initial.doc.child(0);
+    const detached = original.type.create(
+      {
+        ...original.attrs,
+        _paragraphPropertyState: EMPTY_EDITOR_PARAGRAPH_PROPERTY_STATE,
+      },
+      original.content,
+      original.marks,
+    );
+    const forged = sourcedPara("Different", "BBBB2222", 0);
+    const transaction = initial.tr
+      .replaceWith(0, original.nodeSize, [detached, forged])
+      .setMeta(ySyncPluginKey, { type: "synthetic-remote-boundary" });
+
+    expect(() => initial.apply(transaction)).toThrow(ParagraphPropertySourceValidationError);
+  });
+
+  test("a remote whole-paragraph join is reified from adjacent exact content", () => {
+    const left = sourcedPara("Left", "AAAA1111", 0);
+    const initial = createSourcedState(left, sourcedPara("Right", "BBBB2222", 1));
+    const transaction = initial.tr
+      .join(left.nodeSize)
+      .setMeta(ySyncPluginKey, { type: "synthetic-remote-boundary" });
+    const next = initial.apply(transaction);
+
+    expect(collectSourceTokens(next)).toEqual([sourceToken(0)]);
   });
 
   test("the explicit revision join can select the right paragraph owner", () => {
@@ -487,10 +715,10 @@ describe("ParaIdAllocatorExtension", () => {
       sourcedPara("Right", "BBBB2222", 1),
     );
     const transaction = initial.tr;
-    joinProseParagraphsWithRightPropertySource({
-      attrs: transaction.doc.child(1).attrs,
-      pos: transaction.doc.child(0).nodeSize,
+    joinParagraphsWithProperties({
+      joinPos: transaction.doc.child(0).nodeSize,
       transaction,
+      transition: { type: "join-right-paragraph-mark-retains" },
     });
     const next = initial.apply(transaction);
 

--- a/packages/core/src/prosemirror/extensions/features/ParaIdAllocatorExtension.ts
+++ b/packages/core/src/prosemirror/extensions/features/ParaIdAllocatorExtension.ts
@@ -41,33 +41,16 @@ import { Plugin, PluginKey } from "prosemirror-state";
 import type { EditorState, Transaction } from "prosemirror-state";
 
 import { deterministicHexId, generateHexId } from "../../../utils/hexId";
-import {
-  type ParagraphPropertySourceContract,
-  ParagraphPropertySourceValidationError,
-  getExplicitParagraphPropertySourceTransfers,
-  readProseDocumentParagraphPropertySourceContract,
-  setProseParagraphMarkupWithPropertySource,
-} from "../../../docx/paragraphPropertySource";
+import { setProseParagraphMarkupWithPropertySource } from "../../../docx/paragraphPropertySource";
+import { ParagraphPropertyDocumentContext } from "../../paragraphPropertyOwnership";
 import { recreateProseNode } from "../../recreateNode";
-import {
-  readParagraphPropertyState,
-  paragraphPropertyStateAttribute,
-  transitionParagraphPropertyState,
-  type ParagraphPropertyState,
-} from "../../paragraphPropertyState";
 import { createExtension } from "../create";
 import type { ExtensionRuntime } from "../types";
 import { ignoreTrackedChanges } from "./ParagraphChangeTrackerExtension";
 
-type ParagraphPropertySourceSeed =
-  | { type: "unbound" }
-  | {
-      contract: ParagraphPropertySourceContract;
-      tokens: ReadonlySet<string>;
-      type: "bound";
-    };
-
-export const paraIdAllocatorKey = new PluginKey<ParagraphPropertySourceSeed>("paraIdAllocator");
+export const paraIdAllocatorKey = new PluginKey<ParagraphPropertyDocumentContext>(
+  "paraIdAllocator",
+);
 
 /**
  * Transaction meta asking this plugin to derive the ids it mints from a
@@ -119,108 +102,22 @@ type ParagraphOccurrence = {
 const isUsableParaId = (value: unknown): value is string =>
   typeof value === "string" && value.length > 0 && value !== "00000000";
 
-const paragraphPropertyStateOf = (node: PMNode): ParagraphPropertyState => {
-  const state = readParagraphPropertyState(node.attrs["_paragraphPropertyState"]);
-  if (state.status !== "valid") {
-    throw new ParagraphPropertySourceValidationError({
-      code: "invalid_state",
-      message: "A paragraph contains invalid paragraph-property state.",
-      ...(state.status === "invalid" ? { token: state.raw } : {}),
-    });
-  }
-  return state.value;
-};
-
-const importedTokenOf = (state: ParagraphPropertyState): string | null =>
-  state.type === "imported" ? state.token : null;
-
-const contractAcceptsWireToken = (
-  contract: ParagraphPropertySourceContract,
-  token: string,
-): boolean => contract.readToken(token).status === "valid";
-
-const collectParagraphPropertySourceSeed = (doc: PMNode): ParagraphPropertySourceSeed => {
-  const contract = readProseDocumentParagraphPropertySourceContract(doc);
-  if (contract.status === "invalid") {
-    throw new ParagraphPropertySourceValidationError({
-      code: "contract_mismatch",
-      message: "The ProseMirror document contains an invalid paragraph-property source contract.",
-    });
-  }
-  if (contract.status === "absent") {
-    doc.descendants((node) => {
-      if (node.type.name !== "paragraph") {
-        return true;
-      }
-      const state = paragraphPropertyStateOf(node);
-      if (state.type === "imported") {
-        throw new ParagraphPropertySourceValidationError({
-          code: "contract_mismatch",
-          message: "An imported paragraph-property state requires its source contract.",
-          token: state.token,
-        });
-      }
-      return false;
-    });
-    return { type: "unbound" };
-  }
-  const counts = new Map<string, number>();
-  doc.descendants((node) => {
-    if (node.type.name !== "paragraph") {
-      return true;
-    }
-    const state = paragraphPropertyStateOf(node);
-    if (state.type === "imported" && !contractAcceptsWireToken(contract.value, state.token)) {
-      throw new ParagraphPropertySourceValidationError({
-        code: "unknown_token",
-        message: "A paragraph-property token belongs to a different source document.",
-        token: state.token,
-      });
-    }
-    if (state.type === "imported") {
-      const serialized = state.token;
-      counts.set(serialized, (counts.get(serialized) ?? 0) + 1);
-    }
-    return false;
-  });
-  return {
-    contract: contract.value,
-    tokens: new Set([...counts].filter(([, count]) => count === 1).map(([token]) => token)),
-    type: "bound",
-  };
-};
-
-type ParagraphPropertySourceKeeper =
-  | { status: "ambiguous" }
-  | { pos: number; status: "deleted" | "mapped" };
-
 type MappedParagraphKeepers = {
   paraIds: Map<string, number>;
-  sourceTokens: Map<string, ParagraphPropertySourceKeeper>;
 };
 
 const mapParagraphKeepers = (
   oldDoc: PMNode,
   transactions: readonly Transaction[],
-  sourceSeed: ParagraphPropertySourceSeed,
 ): MappedParagraphKeepers => {
   const paraIds = new Map<string, number>();
-  const sourceTokens = new Map<string, ParagraphPropertySourceKeeper>();
   oldDoc.descendants((node, pos) => {
     if (node.type.name !== "paragraph") {
       return true;
     }
     const id = node.attrs["paraId"];
-    const token = importedTokenOf(paragraphPropertyStateOf(node));
     const mapsParaId = isUsableParaId(id) && !paraIds.has(id);
-    const sourceToken =
-      sourceSeed.type === "bound" &&
-      token !== null &&
-      sourceSeed.tokens.has(token)
-        ? token
-        : null;
-    const mapsSourceToken = sourceToken !== null;
-    if (!mapsParaId && !mapsSourceToken) {
+    if (!mapsParaId) {
       return false;
     }
 
@@ -237,41 +134,21 @@ const mapParagraphKeepers = (
     if (mapsParaId && !deleted) {
       paraIds.set(id, mapped);
     }
-    if (mapsSourceToken) {
-      sourceTokens.set(
-        sourceToken,
-        sourceTokens.has(sourceToken)
-          ? { status: "ambiguous" }
-          : { pos: mapped, status: deleted ? "deleted" : "mapped" },
-      );
-    }
     return false;
   });
-  return { paraIds, sourceTokens };
+  return { paraIds };
 };
 
 type ParagraphCensus = {
-  detachedSourceStates: ParagraphOccurrence[];
   missingParaIds: ParagraphOccurrence[];
   paraIds: Map<string, ParagraphOccurrence[]>;
-  sourceTokens: Map<string, ParagraphOccurrence[]>;
 };
 
-const collectParagraphCensus = (
-  doc: PMNode,
-  sourceSeed?: ParagraphPropertySourceSeed,
-): ParagraphCensus => {
+const collectParagraphCensus = (doc: PMNode): ParagraphCensus => {
   const census: ParagraphCensus = {
-    detachedSourceStates: [],
     missingParaIds: [],
     paraIds: new Map(),
-    sourceTokens: new Map(),
   };
-  const contract = readProseDocumentParagraphPropertySourceContract(doc);
-  const contractMatchesSeed =
-    sourceSeed?.type === "bound" &&
-    contract.status === "valid" &&
-    contract.value.serialized === sourceSeed.contract.serialized;
 
   doc.descendants((node, pos) => {
     if (node.type.name !== "paragraph") {
@@ -287,24 +164,6 @@ const collectParagraphCensus = (
       census.missingParaIds.push(occurrence);
     }
 
-    if (sourceSeed) {
-      const state = paragraphPropertyStateOf(node);
-      if (state.type === "imported") {
-        if (
-          !contractMatchesSeed ||
-          sourceSeed.type !== "bound" ||
-          !sourceSeed.tokens.has(state.token) ||
-          !contractAcceptsWireToken(sourceSeed.contract, state.token)
-        ) {
-          census.detachedSourceStates.push(occurrence);
-        } else {
-          const serialized = state.token;
-          const occurrences = census.sourceTokens.get(serialized) ?? [];
-          occurrences.push(occurrence);
-          census.sourceTokens.set(serialized, occurrences);
-        }
-      }
-    }
     return false;
   });
   return census;
@@ -342,70 +201,6 @@ const collectParaIdUpdatesFromCensus = (
 
 const collectParaIdUpdates = (doc: PMNode): ParaIdUpdate[] =>
   collectParaIdUpdatesFromCensus(collectParagraphCensus(doc));
-
-type ParagraphPropertySourceUpdate = {
-  pos: number;
-  state: ParagraphPropertyState;
-};
-
-const collectParagraphPropertySourceUpdates = (
-  census: ParagraphCensus,
-  keeperPositions: ReadonlyMap<string, ParagraphPropertySourceKeeper>,
-  transactions: readonly Transaction[],
-): ParagraphPropertySourceUpdate[] => {
-  const updates = new Map<number, ParagraphPropertyState>();
-  for (const { attrs, pos } of census.detachedSourceStates) {
-    const state = readParagraphPropertyState(attrs["_paragraphPropertyState"]);
-    if (state.status !== "valid") {
-      panic("Validated paragraph-property state became malformed during allocation");
-    }
-    updates.set(pos, transitionParagraphPropertyState(state.value, { type: "editor-copy" }));
-  }
-  const explicitTransfers = transactions.flatMap((transaction) => [
-    ...getExplicitParagraphPropertySourceTransfers(transaction),
-  ]);
-  const explicitlySelected = new Set(
-    explicitTransfers
-      .map(({ selectedToken }) => selectedToken)
-      .filter((token): token is string => token !== null),
-  );
-  for (const [token, occurrences] of census.sourceTokens) {
-    const mappedOwner = keeperPositions.get(token);
-    const mappedKeeper =
-      mappedOwner?.status === "mapped"
-        ? occurrences.find(({ pos }) => pos === mappedOwner.pos)
-        : undefined;
-    const transferredKeeper =
-      !mappedKeeper && explicitlySelected.has(token) && occurrences.length === 1
-        ? occurrences.at(0)
-        : undefined;
-    const detachedKeeper =
-      !mappedKeeper &&
-      !transferredKeeper &&
-      occurrences.length === 1 &&
-      (mappedOwner === undefined ||
-        (mappedOwner.status === "deleted" && mappedOwner.pos === occurrences.at(0)?.pos))
-        ? occurrences.at(0)
-        : undefined;
-    const keeper = mappedKeeper ?? transferredKeeper ?? detachedKeeper;
-    for (const occurrence of occurrences) {
-      if (occurrence !== keeper) {
-        const state = readParagraphPropertyState(occurrence.attrs["_paragraphPropertyState"]);
-        if (state.status !== "valid") {
-          panic("Validated paragraph-property state became malformed during allocation");
-        }
-        updates.set(
-          occurrence.pos,
-          transitionParagraphPropertyState(state.value, { type: "editor-copy" }),
-        );
-      }
-    }
-  }
-
-  return [...updates]
-    .map(([pos, state]) => ({ pos, state }))
-    .sort((left, right) => left.pos - right.pos);
-};
 
 type InitialParaIds = {
   needsRewrite: boolean;
@@ -504,12 +299,13 @@ export const ensureParaIdsInState = (state: EditorState): EditorState => {
   return state.apply(tr);
 };
 
-const createParaIdAllocatorPlugin = (): Plugin<ParagraphPropertySourceSeed> =>
+const createParaIdAllocatorPlugin = (): Plugin<ParagraphPropertyDocumentContext> =>
   new Plugin({
     key: paraIdAllocatorKey,
     state: {
-      init: (_config, state) => collectParagraphPropertySourceSeed(state.doc),
-      apply: (_transaction, seed) => seed,
+      init: (_config, state) =>
+        ParagraphPropertyDocumentContext.fromDocument(state.doc, { type: "document" }),
+      apply: (transaction, context) => context.advance(transaction),
     },
     appendTransaction(transactions, oldState, newState) {
       // Skip selection-only / mark-only transactions — they can't have
@@ -518,27 +314,18 @@ const createParaIdAllocatorPlugin = (): Plugin<ParagraphPropertySourceSeed> =>
         return null;
       }
 
-      const paragraphSourceSeed = paraIdAllocatorKey.getState(oldState);
-      if (!paragraphSourceSeed) {
-        panic("ParaId allocator lost its paragraph-property source seed");
-      }
-      const keeperPositions = mapParagraphKeepers(oldState.doc, transactions, paragraphSourceSeed);
+      const keeperPositions = mapParagraphKeepers(oldState.doc, transactions);
       const deterministicSeed =
         transactions
           .map((transaction) => transaction.getMeta(deterministicParaIdSeedKey))
           .find((value) => typeof value === "string") ?? null;
-      const census = collectParagraphCensus(newState.doc, paragraphSourceSeed);
+      const census = collectParagraphCensus(newState.doc);
       const updates = collectParaIdUpdatesFromCensus(
         census,
         keeperPositions.paraIds,
         deterministicSeed,
       );
-      const paragraphSourceUpdates = collectParagraphPropertySourceUpdates(
-        census,
-        keeperPositions.sourceTokens,
-        transactions,
-      );
-      if (updates.length === 0 && paragraphSourceUpdates.length === 0) {
+      if (updates.length === 0) {
         return null;
       }
 
@@ -548,21 +335,6 @@ const createParaIdAllocatorPlugin = (): Plugin<ParagraphPropertySourceSeed> =>
           attrs: u.attrs,
           ownership: "transfer-allocated-id",
           pos: u.pos,
-          transaction: tr,
-        });
-      }
-      for (const { pos, state } of paragraphSourceUpdates) {
-        const paragraph = tr.doc.nodeAt(pos);
-        if (!paragraph || paragraph.type.name !== "paragraph") {
-          panic("Paragraph-property token update lost its paragraph");
-        }
-        setProseParagraphMarkupWithPropertySource({
-          attrs: {
-            ...paragraph.attrs,
-            _paragraphPropertyState: paragraphPropertyStateAttribute(state),
-          },
-          ownership: "preserve",
-          pos,
           transaction: tr,
         });
       }

--- a/packages/core/src/prosemirror/extensions/features/ParaIdAllocatorExtension.ts
+++ b/packages/core/src/prosemirror/extensions/features/ParaIdAllocatorExtension.ts
@@ -42,23 +42,30 @@ import type { EditorState, Transaction } from "prosemirror-state";
 
 import { deterministicHexId, generateHexId } from "../../../utils/hexId";
 import {
-  PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR,
+  type ParagraphPropertySourceContract,
+  ParagraphPropertySourceValidationError,
   getExplicitParagraphPropertySourceTransfers,
-  getProseDocumentParagraphPropertySourceContract,
-  getProseParagraphPropertySourceToken,
-  paragraphPropertySourceTokenMatchesContract,
-  recreateProseNodeWithParagraphPropertySource,
+  readProseDocumentParagraphPropertySourceContract,
   setProseParagraphMarkupWithPropertySource,
-  transferProseParagraphPropertySource,
 } from "../../../docx/paragraphPropertySource";
+import { recreateProseNode } from "../../recreateNode";
+import {
+  readParagraphPropertyState,
+  paragraphPropertyStateAttribute,
+  transitionParagraphPropertyState,
+  type ParagraphPropertyState,
+} from "../../paragraphPropertyState";
 import { createExtension } from "../create";
 import type { ExtensionRuntime } from "../types";
 import { ignoreTrackedChanges } from "./ParagraphChangeTrackerExtension";
 
-type ParagraphPropertySourceSeed = {
-  contract: string | null;
-  tokens: ReadonlySet<string>;
-};
+type ParagraphPropertySourceSeed =
+  | { type: "unbound" }
+  | {
+      contract: ParagraphPropertySourceContract;
+      tokens: ReadonlySet<string>;
+      type: "bound";
+    };
 
 export const paraIdAllocatorKey = new PluginKey<ParagraphPropertySourceSeed>("paraIdAllocator");
 
@@ -112,25 +119,74 @@ type ParagraphOccurrence = {
 const isUsableParaId = (value: unknown): value is string =>
   typeof value === "string" && value.length > 0 && value !== "00000000";
 
+const paragraphPropertyStateOf = (node: PMNode): ParagraphPropertyState => {
+  const state = readParagraphPropertyState(node.attrs["_paragraphPropertyState"]);
+  if (state.status !== "valid") {
+    throw new ParagraphPropertySourceValidationError({
+      code: "invalid_state",
+      message: "A paragraph contains invalid paragraph-property state.",
+      ...(state.status === "invalid" ? { token: state.raw } : {}),
+    });
+  }
+  return state.value;
+};
+
+const importedTokenOf = (state: ParagraphPropertyState): string | null =>
+  state.type === "imported" ? state.token : null;
+
+const contractAcceptsWireToken = (
+  contract: ParagraphPropertySourceContract,
+  token: string,
+): boolean => contract.readToken(token).status === "valid";
+
 const collectParagraphPropertySourceSeed = (doc: PMNode): ParagraphPropertySourceSeed => {
-  const contract = getProseDocumentParagraphPropertySourceContract(doc);
-  if (!contract) {
-    return { contract: null, tokens: new Set() };
+  const contract = readProseDocumentParagraphPropertySourceContract(doc);
+  if (contract.status === "invalid") {
+    throw new ParagraphPropertySourceValidationError({
+      code: "contract_mismatch",
+      message: "The ProseMirror document contains an invalid paragraph-property source contract.",
+    });
+  }
+  if (contract.status === "absent") {
+    doc.descendants((node) => {
+      if (node.type.name !== "paragraph") {
+        return true;
+      }
+      const state = paragraphPropertyStateOf(node);
+      if (state.type === "imported") {
+        throw new ParagraphPropertySourceValidationError({
+          code: "contract_mismatch",
+          message: "An imported paragraph-property state requires its source contract.",
+          token: state.token,
+        });
+      }
+      return false;
+    });
+    return { type: "unbound" };
   }
   const counts = new Map<string, number>();
   doc.descendants((node) => {
     if (node.type.name !== "paragraph") {
       return true;
     }
-    const token = getProseParagraphPropertySourceToken(node);
-    if (paragraphPropertySourceTokenMatchesContract(token, contract)) {
-      counts.set(token, (counts.get(token) ?? 0) + 1);
+    const state = paragraphPropertyStateOf(node);
+    if (state.type === "imported" && !contractAcceptsWireToken(contract.value, state.token)) {
+      throw new ParagraphPropertySourceValidationError({
+        code: "unknown_token",
+        message: "A paragraph-property token belongs to a different source document.",
+        token: state.token,
+      });
+    }
+    if (state.type === "imported") {
+      const serialized = state.token;
+      counts.set(serialized, (counts.get(serialized) ?? 0) + 1);
     }
     return false;
   });
   return {
-    contract,
+    contract: contract.value,
     tokens: new Set([...counts].filter(([, count]) => count === 1).map(([token]) => token)),
+    type: "bound",
   };
 };
 
@@ -155,9 +211,15 @@ const mapParagraphKeepers = (
       return true;
     }
     const id = node.attrs["paraId"];
-    const token = getProseParagraphPropertySourceToken(node);
+    const token = importedTokenOf(paragraphPropertyStateOf(node));
     const mapsParaId = isUsableParaId(id) && !paraIds.has(id);
-    const mapsSourceToken = typeof token === "string" && sourceSeed.tokens.has(token);
+    const sourceToken =
+      sourceSeed.type === "bound" &&
+      token !== null &&
+      sourceSeed.tokens.has(token)
+        ? token
+        : null;
+    const mapsSourceToken = sourceToken !== null;
     if (!mapsParaId && !mapsSourceToken) {
       return false;
     }
@@ -177,8 +239,8 @@ const mapParagraphKeepers = (
     }
     if (mapsSourceToken) {
       sourceTokens.set(
-        token,
-        sourceTokens.has(token)
+        sourceToken,
+        sourceTokens.has(sourceToken)
           ? { status: "ambiguous" }
           : { pos: mapped, status: deleted ? "deleted" : "mapped" },
       );
@@ -189,9 +251,8 @@ const mapParagraphKeepers = (
 };
 
 type ParagraphCensus = {
-  invalidSourceTokens: ParagraphOccurrence[];
+  detachedSourceStates: ParagraphOccurrence[];
   missingParaIds: ParagraphOccurrence[];
-  paragraphs: Map<number, ParagraphOccurrence>;
   paraIds: Map<string, ParagraphOccurrence[]>;
   sourceTokens: Map<string, ParagraphOccurrence[]>;
 };
@@ -201,23 +262,22 @@ const collectParagraphCensus = (
   sourceSeed?: ParagraphPropertySourceSeed,
 ): ParagraphCensus => {
   const census: ParagraphCensus = {
-    invalidSourceTokens: [],
+    detachedSourceStates: [],
     missingParaIds: [],
-    paragraphs: new Map(),
     paraIds: new Map(),
     sourceTokens: new Map(),
   };
+  const contract = readProseDocumentParagraphPropertySourceContract(doc);
   const contractMatchesSeed =
-    sourceSeed?.contract !== null &&
-    sourceSeed?.contract !== undefined &&
-    getProseDocumentParagraphPropertySourceContract(doc) === sourceSeed.contract;
+    sourceSeed?.type === "bound" &&
+    contract.status === "valid" &&
+    contract.value.serialized === sourceSeed.contract.serialized;
 
   doc.descendants((node, pos) => {
     if (node.type.name !== "paragraph") {
       return true;
     }
     const occurrence = { pos, attrs: node.attrs };
-    census.paragraphs.set(pos, occurrence);
     const id = node.attrs["paraId"];
     if (isUsableParaId(id)) {
       const occurrences = census.paraIds.get(id) ?? [];
@@ -228,20 +288,20 @@ const collectParagraphCensus = (
     }
 
     if (sourceSeed) {
-      const token = getProseParagraphPropertySourceToken(node);
-      if (token !== null && token !== undefined) {
+      const state = paragraphPropertyStateOf(node);
+      if (state.type === "imported") {
         if (
-          typeof token !== "string" ||
           !contractMatchesSeed ||
-          !sourceSeed.contract ||
-          !sourceSeed.tokens.has(token) ||
-          !paragraphPropertySourceTokenMatchesContract(token, sourceSeed.contract)
+          sourceSeed.type !== "bound" ||
+          !sourceSeed.tokens.has(state.token) ||
+          !contractAcceptsWireToken(sourceSeed.contract, state.token)
         ) {
-          census.invalidSourceTokens.push(occurrence);
+          census.detachedSourceStates.push(occurrence);
         } else {
-          const occurrences = census.sourceTokens.get(token) ?? [];
+          const serialized = state.token;
+          const occurrences = census.sourceTokens.get(serialized) ?? [];
           occurrences.push(occurrence);
-          census.sourceTokens.set(token, occurrences);
+          census.sourceTokens.set(serialized, occurrences);
         }
       }
     }
@@ -285,7 +345,7 @@ const collectParaIdUpdates = (doc: PMNode): ParaIdUpdate[] =>
 
 type ParagraphPropertySourceUpdate = {
   pos: number;
-  token: string | null;
+  state: ParagraphPropertyState;
 };
 
 const collectParagraphPropertySourceUpdates = (
@@ -293,9 +353,13 @@ const collectParagraphPropertySourceUpdates = (
   keeperPositions: ReadonlyMap<string, ParagraphPropertySourceKeeper>,
   transactions: readonly Transaction[],
 ): ParagraphPropertySourceUpdate[] => {
-  const updates = new Map<number, string | null>();
-  for (const { pos } of census.invalidSourceTokens) {
-    updates.set(pos, null);
+  const updates = new Map<number, ParagraphPropertyState>();
+  for (const { attrs, pos } of census.detachedSourceStates) {
+    const state = readParagraphPropertyState(attrs["_paragraphPropertyState"]);
+    if (state.status !== "valid") {
+      panic("Validated paragraph-property state became malformed during allocation");
+    }
+    updates.set(pos, transitionParagraphPropertyState(state.value, { type: "editor-copy" }));
   }
   const explicitTransfers = transactions.flatMap((transaction) => [
     ...getExplicitParagraphPropertySourceTransfers(transaction),
@@ -305,13 +369,6 @@ const collectParagraphPropertySourceUpdates = (
       .map(({ selectedToken }) => selectedToken)
       .filter((token): token is string => token !== null),
   );
-  const explicitlyDisplaced = new Set(
-    explicitTransfers
-      .map(({ displacedToken }) => displacedToken)
-      .filter((token): token is string => token !== null),
-  );
-  const keptPositions = new Set<number>();
-  const keptTokens = new Set<string>();
   for (const [token, occurrences] of census.sourceTokens) {
     const mappedOwner = keeperPositions.get(token);
     const mappedKeeper =
@@ -331,36 +388,22 @@ const collectParagraphPropertySourceUpdates = (
         ? occurrences.at(0)
         : undefined;
     const keeper = mappedKeeper ?? transferredKeeper ?? detachedKeeper;
-    if (keeper) {
-      keptPositions.add(keeper.pos);
-      keptTokens.add(token);
-    }
     for (const occurrence of occurrences) {
       if (occurrence !== keeper) {
-        updates.set(occurrence.pos, null);
+        const state = readParagraphPropertyState(occurrence.attrs["_paragraphPropertyState"]);
+        if (state.status !== "valid") {
+          panic("Validated paragraph-property state became malformed during allocation");
+        }
+        updates.set(
+          occurrence.pos,
+          transitionParagraphPropertyState(state.value, { type: "editor-copy" }),
+        );
       }
     }
   }
 
-  // Attribute-only node replacement preserves the paragraph's content gap but
-  // callers may accidentally omit its private token. Restore only the mapped
-  // surviving owner. Whole-paragraph deletion marks the interior boundary as
-  // deleted-across, so a replacement paragraph cannot borrow the old source.
-  for (const [token, mappedOwner] of keeperPositions) {
-    if (
-      mappedOwner.status !== "mapped" ||
-      keptTokens.has(token) ||
-      explicitlyDisplaced.has(token) ||
-      keptPositions.has(mappedOwner.pos) ||
-      !census.paragraphs.has(mappedOwner.pos)
-    ) {
-      continue;
-    }
-    updates.set(mappedOwner.pos, token);
-  }
-
   return [...updates]
-    .map(([pos, token]) => ({ pos, token }))
+    .map(([pos, state]) => ({ pos, state }))
     .sort((left, right) => left.pos - right.pos);
 };
 
@@ -402,20 +445,16 @@ const rewriteInitialParaIds = (parent: PMNode, taken: Set<string>, seen: Set<str
         }
         taken.add(newId);
         seen.add(newId);
-        next = recreateProseNodeWithParagraphPropertySource(child, {
+        next = recreateProseNode(child, {
           attrs: { ...child.attrs, paraId: newId },
         });
       } else {
         seen.add(id);
       }
-      const paraId = next.attrs["paraId"];
-      if (typeof paraId === "string") {
-        transferProseParagraphPropertySource(next, child, paraId);
-      }
     } else if (child.childCount > 0) {
       const content = rewriteInitialParaIds(child, taken, seen);
       if (content !== child.content) {
-        next = recreateProseNodeWithParagraphPropertySource(child, { content });
+        next = recreateProseNode(child, { content });
       }
     }
     if (next !== child) {
@@ -439,7 +478,7 @@ export const ensureParaIdsInDoc = (doc: PMNode): PMNode => {
     return doc;
   }
 
-  return recreateProseNodeWithParagraphPropertySource(doc, {
+  return recreateProseNode(doc, {
     content: rewriteInitialParaIds(doc, taken, new Set()),
   });
 };
@@ -512,13 +551,16 @@ const createParaIdAllocatorPlugin = (): Plugin<ParagraphPropertySourceSeed> =>
           transaction: tr,
         });
       }
-      for (const { pos, token } of paragraphSourceUpdates) {
+      for (const { pos, state } of paragraphSourceUpdates) {
         const paragraph = tr.doc.nodeAt(pos);
         if (!paragraph || paragraph.type.name !== "paragraph") {
           panic("Paragraph-property token update lost its paragraph");
         }
         setProseParagraphMarkupWithPropertySource({
-          attrs: { ...paragraph.attrs, [PROSE_PARAGRAPH_SOURCE_TOKEN_ATTR]: token },
+          attrs: {
+            ...paragraph.attrs,
+            _paragraphPropertyState: paragraphPropertyStateAttribute(state),
+          },
           ownership: "preserve",
           pos,
           transaction: tr,

--- a/packages/core/src/prosemirror/paragraphAlignment.ts
+++ b/packages/core/src/prosemirror/paragraphAlignment.ts
@@ -1,18 +1,13 @@
 import type { ParagraphAlignment } from "../types/document";
+import { expectParagraphPropertyState } from "./paragraphPropertyState";
 import type { ParagraphAttrs } from "./schema/nodes";
 
 /**
  * Read the authored paragraph-level `w:jc`, independently of the effective
- * alignment used for layout. Imported and command-authored paragraphs carry
- * explicit provenance; the final branch covers PM-created content whose
- * effective value is observably different from its style.
+ * alignment used for layout. Mandatory authored state is the sole source;
+ * effective attrs never acquire authorship merely because they differ from a
+ * style.
  */
 export const directParagraphAlignment = (attrs: ParagraphAttrs): ParagraphAlignment | undefined => {
-  if (attrs._originalFormatting?.alignment != null) {
-    return attrs._originalFormatting.alignment;
-  }
-  if (attrs.alignment != null && attrs.alignment !== attrs.alignmentFromStyle) {
-    return attrs.alignment;
-  }
-  return undefined;
+  return expectParagraphPropertyState(attrs._paragraphPropertyState).authoredPPr.alignment;
 };

--- a/packages/core/src/prosemirror/paragraphIndentation.ts
+++ b/packages/core/src/prosemirror/paragraphIndentation.ts
@@ -1,0 +1,199 @@
+import {
+  type NonEmptyNumberingLevelIndentGeometry,
+  type NumberingLevelIndentGeometry,
+} from "@stll/docx-core/model";
+import { createNumberingLevelIndentProvenance } from "../docx/numberingProvenance";
+import {
+  transitionParagraphProperties,
+  type ParagraphPropertyProjection,
+} from "./paragraphPropertyMutation";
+import {
+  expectParagraphPropertyState,
+  type ParagraphPropertyMutation,
+} from "./paragraphPropertyState";
+import type { ParagraphAttrs } from "./schema/nodes";
+
+const PARAGRAPH_INDENT_SIDES = ["left", "right", "firstLine"] as const;
+export type ParagraphIndentSide = (typeof PARAGRAPH_INDENT_SIDES)[number];
+
+type DirectParagraphIndentation = {
+  indentLeft?: number;
+  indentRight?: number;
+  indentFirstLine?: number;
+  hangingIndent?: boolean;
+};
+
+export type ParagraphIndentationTransition =
+  | { type: "set-direct"; values: DirectParagraphIndentation }
+  | { type: "force-visible-zero"; sides: readonly ParagraphIndentSide[] }
+  | {
+      type: "reset-to-inherited";
+      inherited: DirectParagraphIndentation & {
+        numberingLevelIndent?: NonEmptyNumberingLevelIndentGeometry;
+      };
+      sides: readonly ParagraphIndentSide[];
+    };
+
+export type ParagraphIndentationTransitionResult =
+  | { type: "applied"; projection: ParagraphPropertyProjection }
+  | {
+      type: "unsupported";
+      reason: "numbering-first-line-zero-is-not-paragraph-representable";
+    };
+
+const keysForSide = (
+  side: ParagraphIndentSide,
+): readonly ("indentLeft" | "indentRight" | "indentFirstLine" | "hangingIndent")[] => {
+  switch (side) {
+    case "left":
+      return ["indentLeft"];
+    case "right":
+      return ["indentRight"];
+    case "firstLine":
+      return ["indentFirstLine", "hangingIndent"];
+  }
+};
+
+const directSides = (values: DirectParagraphIndentation): ParagraphIndentSide[] => {
+  const sides: ParagraphIndentSide[] = [];
+  if (values.indentLeft !== undefined) {
+    sides.push("left");
+  }
+  if (values.indentRight !== undefined) {
+    sides.push("right");
+  }
+  if (values.indentFirstLine !== undefined || values.hangingIndent !== undefined) {
+    sides.push("firstLine");
+  }
+  return sides;
+};
+
+const valuesForTransition = (
+  transition: ParagraphIndentationTransition,
+): { sides: readonly ParagraphIndentSide[]; values: DirectParagraphIndentation } => {
+  switch (transition.type) {
+    case "set-direct":
+      return { sides: directSides(transition.values), values: transition.values };
+    case "force-visible-zero": {
+      const values: DirectParagraphIndentation = {};
+      for (const side of transition.sides) {
+        if (side === "left") {
+          values.indentLeft = 0;
+        } else if (side === "right") {
+          values.indentRight = 0;
+        } else {
+          values.indentFirstLine = 0;
+          values.hangingIndent = false;
+        }
+      }
+      return { sides: transition.sides, values };
+    }
+    case "reset-to-inherited":
+      return { sides: transition.sides, values: transition.inherited };
+  }
+};
+
+const activeNumberingHasFirstLineBaseline = (attrs: ParagraphAttrs): boolean => {
+  const active = attrs.numPr;
+  const inherited = expectParagraphPropertyState(
+    attrs._paragraphPropertyState,
+  ).context.numberingLevelIndent;
+  return (
+    active?.numId !== undefined &&
+    active.numId !== 0 &&
+    inherited !== undefined &&
+    inherited.numId === active.numId &&
+    (inherited.ilvl ?? 0) === (active.ilvl ?? 0) &&
+    inherited.baseline.indentFirstLine !== undefined &&
+    inherited.baseline.indentFirstLine !== 0
+  );
+};
+
+const forcesUnrepresentableFirstLineZero = (
+  attrs: ParagraphAttrs,
+  transition: ParagraphIndentationTransition,
+): boolean => {
+  if (transition.type === "reset-to-inherited" || !activeNumberingHasFirstLineBaseline(attrs)) {
+    return false;
+  }
+  if (transition.type === "force-visible-zero") {
+    return transition.sides.includes("firstLine");
+  }
+  return transition.values.indentFirstLine === 0 && transition.values.hangingIndent !== true;
+};
+
+/** Apply one explicit direct-indent transition and update its ownership atomically. */
+export const attrsWithParagraphIndentationTransition = (
+  attrs: ParagraphAttrs,
+  transition: ParagraphIndentationTransition,
+): ParagraphIndentationTransitionResult => {
+  if (forcesUnrepresentableFirstLineZero(attrs, transition)) {
+    return {
+      type: "unsupported",
+      reason: "numbering-first-line-zero-is-not-paragraph-representable",
+    };
+  }
+  const { sides, values } = valuesForTransition(transition);
+  const state = expectParagraphPropertyState(attrs._paragraphPropertyState);
+  const numberingLevelIndent = state.context.numberingLevelIndent;
+  const ownedNumberingIndent: NumberingLevelIndentGeometry =
+    numberingLevelIndent?.type === "owned" ? { ...numberingLevelIndent.owned } : {};
+  const mutations: ParagraphPropertyMutation[] = [];
+
+  for (const side of sides) {
+    for (const key of keysForSide(side)) {
+      mutations.push({ key, mutation: { type: "remove" } });
+    }
+    if (side === "left") {
+      Reflect.deleteProperty(ownedNumberingIndent, "indentLeft");
+    } else if (side === "right") {
+      Reflect.deleteProperty(ownedNumberingIndent, "indentRight");
+    } else if (side === "firstLine") {
+      Reflect.deleteProperty(ownedNumberingIndent, "indentFirstLine");
+      Reflect.deleteProperty(ownedNumberingIndent, "hangingIndent");
+    }
+  }
+
+  if (transition.type === "reset-to-inherited") {
+    const inheritedNumbering = transition.inherited.numberingLevelIndent;
+    if (inheritedNumbering) {
+      Object.assign(ownedNumberingIndent, inheritedNumbering);
+    }
+  } else {
+    for (const side of sides) {
+      for (const key of keysForSide(side)) {
+        const value = values[key];
+        if (value !== undefined) {
+          mutations.push({ key, mutation: { type: "set", value } });
+        }
+      }
+    }
+  }
+
+  const nextNumberingLevelIndent = numberingLevelIndent
+    ? createNumberingLevelIndentProvenance({
+        numId: numberingLevelIndent.numId,
+        ilvl: numberingLevelIndent.ilvl,
+        baseline: numberingLevelIndent.baseline,
+        owned: ownedNumberingIndent,
+      })
+    : null;
+
+  return {
+    type: "applied",
+    projection: transitionParagraphProperties({
+      attrs,
+      state: {
+        type: "update",
+        authored: { type: "mutate", mutations },
+        context: {
+          type: "replace",
+          context: {
+            ...state.context,
+            numberingLevelIndent: nextNumberingLevelIndent ?? null,
+          },
+        },
+      },
+    }),
+  };
+};

--- a/packages/core/src/prosemirror/paragraphPropertyContext.ts
+++ b/packages/core/src/prosemirror/paragraphPropertyContext.ts
@@ -1,0 +1,37 @@
+import type {
+  AuthoredParagraphProperties,
+  ParagraphMarkProperties,
+} from "../docx/paragraphPropertyDescriptor";
+import type { ParagraphFormatting, TextFormatting } from "../types/document";
+
+export const PARAGRAPH_SPACING_INHERITANCE_SOURCE = {
+  documentDefault: "document-default",
+  implicitDefaultStyle: "implicit-default-style",
+  style: "style",
+} as const;
+
+export type ParagraphSpacingInheritanceSource =
+  (typeof PARAGRAPH_SPACING_INHERITANCE_SOURCE)[keyof typeof PARAGRAPH_SPACING_INHERITANCE_SOURCE];
+
+export type ParagraphSpacingInheritance = {
+  before?: ParagraphSpacingInheritanceSource;
+  after?: ParagraphSpacingInheritanceSource;
+};
+
+export type ParagraphMarkEffectiveProperties = {
+  defaultTextFormatting?: TextFormatting;
+  runInWithNext?: boolean;
+};
+
+export type ParagraphMarkProjectionContext = {
+  authored: ParagraphMarkProperties;
+  effective: ParagraphMarkEffectiveProperties;
+};
+
+export type SerializedParagraphPropertyProjectionContext = {
+  inheritedPPr: AuthoredParagraphProperties;
+  numberingLevelIndent: ParagraphFormatting["numberingLevelIndent"] | null;
+  numPrFromStyle: ParagraphFormatting["numPr"] | null;
+  paragraphMark: ParagraphMarkProjectionContext;
+  spacingInheritance: ParagraphSpacingInheritance;
+};

--- a/packages/core/src/prosemirror/paragraphPropertyContext.ts
+++ b/packages/core/src/prosemirror/paragraphPropertyContext.ts
@@ -1,7 +1,4 @@
-import type {
-  AuthoredParagraphProperties,
-  ParagraphMarkProperties,
-} from "../docx/paragraphPropertyDescriptor";
+import type { AuthoredParagraphProperties, ParagraphMarkProperties } from "@stll/docx-core/model";
 import type { ParagraphFormatting, TextFormatting } from "../types/document";
 
 export const PARAGRAPH_SPACING_INHERITANCE_SOURCE = {

--- a/packages/core/src/prosemirror/paragraphPropertyMutation.ts
+++ b/packages/core/src/prosemirror/paragraphPropertyMutation.ts
@@ -11,6 +11,11 @@ import { setProseParagraphMarkupWithPropertySource } from "../docx/paragraphProp
 import type { ParagraphFormatting } from "../types/document";
 import { mergeParagraphFormatting } from "../utils/paragraphFormattingMerge";
 import { expectParagraphAttrs } from "./attrs";
+import {
+  recordJoinParagraphPropertyOwnershipProof,
+  recordReplaceSelectionThenSplitParagraphPropertyOwnershipProof,
+  recordSplitParagraphPropertyOwnershipProof,
+} from "./paragraphPropertyOwnership";
 import { directionFromBidi, directionToBidi } from "./paragraphDirection";
 import {
   PARAGRAPH_FORMATTING_PROPERTY_ATTRS,
@@ -85,10 +90,7 @@ type CreateParagraphPropertiesOptions = {
   state: ParagraphPropertyState;
 };
 
-type CreateEditorParagraphPropertiesOptions = Omit<
-  CreateParagraphPropertiesOptions,
-  "state"
-> & {
+type CreateEditorParagraphPropertiesOptions = Omit<CreateParagraphPropertiesOptions, "state"> & {
   authoredPPr: AuthoredParagraphProperties;
   context?: ParagraphPropertyProjectionContext;
 };
@@ -267,10 +269,7 @@ const numberingIndentFormatting = (
   };
 };
 
-const projectAttrs = (
-  attrs: ParagraphAttrs,
-  state: ParagraphPropertyState,
-): ParagraphAttrs => {
+const projectAttrs = (attrs: ParagraphAttrs, state: ParagraphPropertyState): ParagraphAttrs => {
   const { context } = state;
   const authoredPPr = cloneFormatting(state.authoredPPr);
   const inheritedPPr = cloneFormatting(context.inheritedPPr);
@@ -344,9 +343,8 @@ const projectAttrs = (
   return next;
 };
 
-const proveParagraphPropertyProjection = (
-  attrs: ParagraphAttrs,
-): ParagraphPropertyProjection => ParagraphPropertyProjectionCapsule.fromProjectedAttrs(attrs);
+const proveParagraphPropertyProjection = (attrs: ParagraphAttrs): ParagraphPropertyProjection =>
+  ParagraphPropertyProjectionCapsule.fromProjectedAttrs(attrs);
 
 export const transitionParagraphProperties = ({
   attrs,
@@ -431,8 +429,7 @@ type SplitParagraphWithPropertiesOptions = {
   transition: ParagraphPropertySplitTransition;
 };
 
-/** Split a paragraph and update both property-source branches atomically. */
-export const splitParagraphWithProperties = ({
+const splitAndRebindParagraphProperties = ({
   transaction,
   pos,
   typesAfter,
@@ -460,6 +457,44 @@ export const splitParagraphWithProperties = ({
     transition,
   });
   return { leftPosition, rightPosition };
+};
+
+/** Split a paragraph and update both property-source branches atomically. */
+export const splitParagraphWithProperties = ({
+  transaction,
+  pos,
+  typesAfter,
+  transition,
+}: SplitParagraphWithPropertiesOptions): { leftPosition: number; rightPosition: number } => {
+  recordSplitParagraphPropertyOwnershipProof({ transaction, pos });
+  return splitAndRebindParagraphProperties({ transaction, pos, typesAfter, transition });
+};
+
+type ReplaceSelectionThenSplitParagraphWithPropertiesOptions = {
+  transaction: Transaction;
+  transition: ParagraphPropertySplitTransition;
+};
+
+/** Delete a selection and split its source paragraph under one history-native proof. */
+export const replaceSelectionThenSplitParagraphWithProperties = ({
+  transaction,
+  transition,
+}: ReplaceSelectionThenSplitParagraphWithPropertiesOptions): {
+  leftPosition: number;
+  rightPosition: number;
+} => {
+  if (transaction.selection.empty || transaction.selection.$from.parent.type.name !== "paragraph") {
+    panic("Replace-and-split requires a non-empty selection starting in a paragraph");
+  }
+  recordReplaceSelectionThenSplitParagraphPropertyOwnershipProof({
+    transaction,
+  });
+  transaction.deleteSelection();
+  return splitAndRebindParagraphProperties({
+    transaction,
+    pos: transaction.selection.from,
+    transition,
+  });
 };
 
 type JoinParagraphsWithPropertiesOptions = {
@@ -516,6 +551,11 @@ export const joinParagraphsWithProperties = ({
   const rightState = expectParagraphPropertyState(
     expectParagraphAttrs(right)._paragraphPropertyState,
   );
+  recordJoinParagraphPropertyOwnershipProof({
+    transaction,
+    joinPos,
+    transition,
+  });
   transaction.join(joinPos);
   rebindJoinedParagraphProperties({
     transaction,
@@ -570,12 +610,7 @@ const valuesEqual = (left: unknown, right: unknown): boolean => {
     }
     return left.every((entry, index) => valuesEqual(entry, right[index]));
   }
-  if (
-    typeof left !== "object" ||
-    left === null ||
-    typeof right !== "object" ||
-    right === null
-  ) {
+  if (typeof left !== "object" || left === null || typeof right !== "object" || right === null) {
     return false;
   }
   const leftEntries = Object.entries(left);
@@ -588,9 +623,7 @@ const valuesEqual = (left: unknown, right: unknown): boolean => {
   );
 };
 
-export type ParagraphPropertyInvariantBoundary =
-  | { type: "internal" }
-  | { type: "persistence" };
+export type ParagraphPropertyInvariantBoundary = { type: "internal" } | { type: "persistence" };
 
 /** Prove state, context, and every descriptor-governed effective attr are a fixed point. */
 export const assertParagraphPropertyInvariant = (
@@ -722,9 +755,10 @@ export const paragraphPropertiesFromExternalDomImport = ({
   });
 
 /** Bind the sole raw-attr unwrap to a paragraph NodeSpec `getAttrs` callback. */
-export const paragraphDomGetAttrs = <Dom>(
-  project: (dom: Dom) => ParagraphPropertyProjection | false,
-): ((dom: Dom) => ParagraphAttrs | false) =>
+export const paragraphDomGetAttrs =
+  <Dom>(
+    project: (dom: Dom) => ParagraphPropertyProjection | false,
+  ): ((dom: Dom) => ParagraphAttrs | false) =>
   (dom) => {
     const projection = project(dom);
     return projection === false ? false : ParagraphPropertyProjectionCapsule.attrs(projection);

--- a/packages/core/src/prosemirror/paragraphPropertyMutation.ts
+++ b/packages/core/src/prosemirror/paragraphPropertyMutation.ts
@@ -1,27 +1,34 @@
 import { panic } from "better-result";
+import {
+  PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR,
+  PARAGRAPH_FORMATTING_PROPERTY_KEY_LIST,
+  type AuthoredParagraphProperties,
+} from "@stll/docx-core/model";
 import type { Fragment, Mark, Node as PMNode, NodeType } from "prosemirror-model";
 import type { Transaction } from "prosemirror-state";
 
 import { setProseParagraphMarkupWithPropertySource } from "../docx/paragraphPropertySource";
 import type { ParagraphFormatting } from "../types/document";
 import { mergeParagraphFormatting } from "../utils/paragraphFormattingMerge";
+import { expectParagraphAttrs } from "./attrs";
 import { directionFromBidi, directionToBidi } from "./paragraphDirection";
 import {
-  PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR,
   PARAGRAPH_FORMATTING_PROPERTY_ATTRS,
-  PARAGRAPH_FORMATTING_PROPERTY_KEY_LIST,
-  PARAGRAPH_MARK_ATTR_KEYS,
-  PPR_CHANGE_SCOPED_ATTR_KEYS,
-  type AuthoredParagraphProperties,
+  PARAGRAPH_PROPERTY_PROJECTED_ATTR_KEY_LIST,
+  isParagraphPropertyProjectedAttr,
 } from "./paragraphPropertyProjection";
 import {
   authoredParagraphPropertiesFromFormatting,
   createEditorParagraphPropertyState,
   expectParagraphPropertyState,
+  joinParagraphPropertyStates,
   paragraphPropertyStateAttribute,
   serializePersistableParagraphPropertyState,
+  splitParagraphPropertyState,
   transitionParagraphPropertyState,
+  type ParagraphPropertyJoinTransition,
   type ParagraphPropertyProjectionContext,
+  type ParagraphPropertySplitTransition,
   type ParagraphPropertyState,
   type ParagraphPropertyStateTransition,
 } from "./paragraphPropertyState";
@@ -86,28 +93,9 @@ type CreateEditorParagraphPropertiesOptions = Omit<
   context?: ParagraphPropertyProjectionContext;
 };
 
-const PROJECTION_CONTEXT_ATTR_KEYS = [
-  "_paragraphPropertyState",
-  "numPrFromStyle",
-  "alignmentFromStyle",
-  "_sourceIndentation",
-  "_autospacingBase",
-  "spacingFromDocDefaults",
-  "spacingFromImplicitDefaultStyle",
-] as const satisfies readonly (keyof ParagraphAttrs)[];
-
-export const GOVERNED_PARAGRAPH_ATTR_KEY_LIST = Object.freeze([
-  ...new Set<keyof ParagraphAttrs>([
-    ...PPR_CHANGE_SCOPED_ATTR_KEYS,
-    ...PARAGRAPH_MARK_ATTR_KEYS,
-    ...PROJECTION_CONTEXT_ATTR_KEYS,
-  ]),
-]);
-const GOVERNED_PARAGRAPH_ATTR_KEY_SET = new Set<keyof ParagraphAttrs>(
-  GOVERNED_PARAGRAPH_ATTR_KEY_LIST,
-);
+export const GOVERNED_PARAGRAPH_ATTR_KEY_LIST = PARAGRAPH_PROPERTY_PROJECTED_ATTR_KEY_LIST;
 export const isGovernedParagraphAttr = (key: string): key is keyof ParagraphAttrs =>
-  GOVERNED_PARAGRAPH_ATTR_KEY_SET.has(key as keyof ParagraphAttrs);
+  isParagraphPropertyProjectedAttr(key);
 
 /** Select exact authored pPr from editor attrs through the total descriptor. */
 const authoredParagraphPropertiesFromExternalDomAttrs = (
@@ -385,6 +373,160 @@ export const createParagraphProperties = ({
   return proveParagraphPropertyProjection(projectAttrs(seed, state));
 };
 
+type RebindParagraphPropertiesOptions = {
+  attrs: ParagraphAttrs;
+  state: ParagraphPropertyState;
+};
+
+/** Replace source/state identity while reprojecting every governed cache. */
+export const rebindParagraphProperties = ({
+  attrs,
+  state,
+}: RebindParagraphPropertiesOptions): ParagraphPropertyProjection =>
+  proveParagraphPropertyProjection(projectAttrs(attrs, state));
+
+type RebindSplitParagraphPropertiesOptions = {
+  transaction: Transaction;
+  leftPosition: number;
+  rightPosition: number;
+  sourceState: ParagraphPropertyState;
+  transition: ParagraphPropertySplitTransition;
+};
+
+/** Restore paragraph-mark ownership after a structural split. */
+export const rebindSplitParagraphProperties = ({
+  transaction,
+  leftPosition,
+  rightPosition,
+  sourceState,
+  transition,
+}: RebindSplitParagraphPropertiesOptions): void => {
+  const left = transaction.doc.nodeAt(leftPosition);
+  const right = transaction.doc.nodeAt(rightPosition);
+  if (left?.type.name !== "paragraph" || right?.type.name !== "paragraph") {
+    panic("A paragraph split did not produce two paragraph nodes");
+  }
+  const split = splitParagraphPropertyState(sourceState, transition);
+  applyParagraphPropertyProjection({
+    transaction,
+    pos: leftPosition,
+    projection: rebindParagraphProperties({ attrs: expectParagraphAttrs(left), state: split.left }),
+    source: { type: "preserve" },
+  });
+  applyParagraphPropertyProjection({
+    transaction,
+    pos: rightPosition,
+    projection: rebindParagraphProperties({
+      attrs: expectParagraphAttrs(right),
+      state: split.right,
+    }),
+    source: { type: "preserve" },
+  });
+};
+
+type SplitParagraphWithPropertiesOptions = {
+  transaction: Transaction;
+  pos: number;
+  typesAfter?: Parameters<Transaction["split"]>[2];
+  transition: ParagraphPropertySplitTransition;
+};
+
+/** Split a paragraph and update both property-source branches atomically. */
+export const splitParagraphWithProperties = ({
+  transaction,
+  pos,
+  typesAfter,
+  transition,
+}: SplitParagraphWithPropertiesOptions): { leftPosition: number; rightPosition: number } => {
+  const $pos = transaction.doc.resolve(pos);
+  if ($pos.parent.type.name !== "paragraph") {
+    panic("Paragraph-property split requires a position inside a paragraph");
+  }
+  const leftPosition = $pos.before();
+  const sourceState = expectParagraphPropertyState(
+    expectParagraphAttrs($pos.parent)._paragraphPropertyState,
+  );
+  transaction.split(pos, 1, typesAfter);
+  const left = transaction.doc.nodeAt(leftPosition);
+  if (left?.type.name !== "paragraph") {
+    panic("A paragraph split lost its left paragraph");
+  }
+  const rightPosition = leftPosition + left.nodeSize;
+  rebindSplitParagraphProperties({
+    transaction,
+    leftPosition,
+    rightPosition,
+    sourceState,
+    transition,
+  });
+  return { leftPosition, rightPosition };
+};
+
+type JoinParagraphsWithPropertiesOptions = {
+  transaction: Transaction;
+  joinPos: number;
+  transition: ParagraphPropertyJoinTransition;
+};
+
+type RebindJoinedParagraphPropertiesOptions = {
+  transaction: Transaction;
+  joinedPosition: number;
+  leftState: ParagraphPropertyState;
+  rightState: ParagraphPropertyState;
+  transition: ParagraphPropertyJoinTransition;
+};
+
+/** Restore the paragraph-mark property owner after another command performs a join. */
+export const rebindJoinedParagraphProperties = ({
+  transaction,
+  joinedPosition,
+  leftState,
+  rightState,
+  transition,
+}: RebindJoinedParagraphPropertiesOptions): void => {
+  const joined = transaction.doc.nodeAt(joinedPosition);
+  if (joined?.type.name !== "paragraph") {
+    panic("A paragraph join did not produce a paragraph node");
+  }
+  const state = joinParagraphPropertyStates(leftState, rightState, transition);
+  applyParagraphPropertyProjection({
+    transaction,
+    pos: joinedPosition,
+    projection: rebindParagraphProperties({ attrs: expectParagraphAttrs(joined), state }),
+    source: { type: "preserve" },
+  });
+};
+
+/** Join adjacent paragraphs and retain the selected paragraph-mark property owner. */
+export const joinParagraphsWithProperties = ({
+  transaction,
+  joinPos,
+  transition,
+}: JoinParagraphsWithPropertiesOptions): number => {
+  const $join = transaction.doc.resolve(joinPos);
+  const left = $join.nodeBefore;
+  const right = $join.nodeAfter;
+  if (left?.type.name !== "paragraph" || right?.type.name !== "paragraph") {
+    panic("Paragraph-property join requires two adjacent paragraphs");
+  }
+  const leftPosition = joinPos - left.nodeSize;
+  const leftState = expectParagraphPropertyState(
+    expectParagraphAttrs(left)._paragraphPropertyState,
+  );
+  const rightState = expectParagraphPropertyState(
+    expectParagraphAttrs(right)._paragraphPropertyState,
+  );
+  transaction.join(joinPos);
+  rebindJoinedParagraphProperties({
+    transaction,
+    joinedPosition: leftPosition,
+    leftState,
+    rightState,
+    transition,
+  });
+  return leftPosition;
+};
+
 export const createEditorParagraphProperties = ({
   attrs,
   authoredPPr,
@@ -393,6 +535,29 @@ export const createEditorParagraphProperties = ({
   createParagraphProperties({
     attrs,
     state: createEditorParagraphPropertyState({ authoredPPr, context }),
+  });
+
+type CreateEditorParagraphPropertiesFromExistingOptions = {
+  sourceAttrs: ParagraphAttrs;
+  authoredPPr: AuthoredParagraphProperties;
+  destinationContext: ParagraphPropertyProjectionContext;
+  nonPropertyPatch?: Readonly<Record<string, unknown>>;
+};
+
+/**
+ * Create an editor-owned paragraph from an existing paragraph while requiring
+ * the caller to supply the destination cascade explicitly.
+ */
+export const createEditorParagraphPropertiesFromExisting = ({
+  sourceAttrs,
+  authoredPPr,
+  destinationContext,
+  nonPropertyPatch = {},
+}: CreateEditorParagraphPropertiesFromExistingOptions): ParagraphPropertyProjection =>
+  createEditorParagraphProperties({
+    attrs: { ...nonGovernedAttrs(sourceAttrs), ...nonPropertyPatch },
+    authoredPPr,
+    context: destinationContext,
   });
 
 const valuesEqual = (left: unknown, right: unknown): boolean => {
@@ -459,6 +624,18 @@ export const preserveParagraphProperties = (
   expectParagraphPropertyState(next._paragraphPropertyState);
   return proveParagraphPropertyProjection(next);
 };
+
+type PatchParagraphPropertyProjectionOptions = {
+  projection: ParagraphPropertyProjection;
+  patch: Readonly<Record<string, unknown>>;
+};
+
+/** Add non-property attrs to an existing projection without exposing its raw attrs. */
+export const patchParagraphPropertyProjection = ({
+  projection,
+  patch,
+}: PatchParagraphPropertyProjectionOptions): ParagraphPropertyProjection =>
+  preserveParagraphProperties(ParagraphPropertyProjectionCapsule.attrs(projection), patch);
 
 type ApplyParagraphPropertyProjectionOptions = {
   transaction: Transaction;

--- a/packages/core/src/prosemirror/paragraphPropertyMutation.ts
+++ b/packages/core/src/prosemirror/paragraphPropertyMutation.ts
@@ -1,0 +1,566 @@
+import { panic } from "better-result";
+import type { Fragment, Mark, Node as PMNode, NodeType } from "prosemirror-model";
+import type { Transaction } from "prosemirror-state";
+
+import { setProseParagraphMarkupWithPropertySource } from "../docx/paragraphPropertySource";
+import type { ParagraphFormatting } from "../types/document";
+import { mergeParagraphFormatting } from "../utils/paragraphFormattingMerge";
+import { directionFromBidi, directionToBidi } from "./paragraphDirection";
+import {
+  PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR,
+  PARAGRAPH_FORMATTING_PROPERTY_ATTRS,
+  PARAGRAPH_FORMATTING_PROPERTY_KEY_LIST,
+  PARAGRAPH_MARK_ATTR_KEYS,
+  PPR_CHANGE_SCOPED_ATTR_KEYS,
+  type AuthoredParagraphProperties,
+} from "./paragraphPropertyProjection";
+import {
+  authoredParagraphPropertiesFromFormatting,
+  createEditorParagraphPropertyState,
+  expectParagraphPropertyState,
+  readAuthoredParagraphProperties,
+  serializeParagraphPropertyState,
+  serializePersistableParagraphPropertyState,
+  transitionParagraphPropertyState,
+  type ParagraphPropertyState,
+  type ParagraphPropertyStateTransition,
+} from "./paragraphPropertyState";
+import { paragraphSpacingAttrPatch, paragraphSpacingFromFormatting } from "./paragraphSpacing";
+import { autospacingMatchesBase } from "./autospacingBase";
+import type { ParagraphAttrs } from "./schema/nodes";
+
+const deepFreezeProjectionValue = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      deepFreezeProjectionValue(entry);
+    }
+    return Object.freeze(value);
+  }
+  if (typeof value === "object" && value !== null) {
+    for (const entry of Object.values(value)) {
+      deepFreezeProjectionValue(entry);
+    }
+    return Object.freeze(value);
+  }
+  return value;
+};
+
+/** Nominal capsule proving governed attrs and authored state were projected together. */
+class ParagraphPropertyProjectionCapsule {
+  readonly #attrs: ParagraphAttrs;
+
+  private constructor(attrs: ParagraphAttrs) {
+    this.#attrs = deepFreezeProjectionValue(structuredClone(attrs)) as ParagraphAttrs;
+    Object.freeze(this);
+  }
+
+  static fromProjectedAttrs(attrs: ParagraphAttrs): ParagraphPropertyProjectionCapsule {
+    return new ParagraphPropertyProjectionCapsule(attrs);
+  }
+
+  static attrs(projection: ParagraphPropertyProjectionCapsule): ParagraphAttrs {
+    return projection.#attrs;
+  }
+}
+
+export type ParagraphPropertyProjection = ParagraphPropertyProjectionCapsule;
+
+export type ParagraphPropertyProjectionContext = {
+  inheritedPPr: AuthoredParagraphProperties;
+  numberingLevelIndent: ParagraphFormatting["numberingLevelIndent"] | null;
+  numPrFromStyle: ParagraphFormatting["numPr"] | null;
+};
+
+export type ParagraphPropertyContextTransition =
+  | { type: "preserve" }
+  | ({ type: "replace" } & ParagraphPropertyProjectionContext);
+
+type TransitionParagraphPropertiesOptions = {
+  attrs: ParagraphAttrs;
+  state: ParagraphPropertyStateTransition;
+  context: ParagraphPropertyContextTransition;
+};
+
+type CreateParagraphPropertiesOptions = {
+  attrs?: Readonly<Record<string, unknown>>;
+  state: ParagraphPropertyState;
+  context: ParagraphPropertyProjectionContext;
+  paragraphMarkFormatting?: ParagraphAttrs["_paragraphMarkFormatting"];
+};
+
+type CreateEditorParagraphPropertiesOptions = Omit<
+  CreateParagraphPropertiesOptions,
+  "state"
+> & {
+  authoredPPr: AuthoredParagraphProperties;
+};
+
+const PROJECTION_CONTEXT_ATTR_KEYS = [
+  "_paragraphPropertyState",
+  "_paragraphPropertyInheritance",
+  "_paragraphMarkFormatting",
+  "_numberingLevelIndent",
+  "numPrFromStyle",
+  "alignmentFromStyle",
+  "_sourceIndentation",
+  "_autospacingBase",
+  "spacingFromDocDefaults",
+  "spacingFromImplicitDefaultStyle",
+] as const satisfies readonly (keyof ParagraphAttrs)[];
+
+export const GOVERNED_PARAGRAPH_ATTR_KEYS: ReadonlySet<keyof ParagraphAttrs> = new Set([
+  ...PPR_CHANGE_SCOPED_ATTR_KEYS,
+  ...PARAGRAPH_MARK_ATTR_KEYS,
+  ...PROJECTION_CONTEXT_ATTR_KEYS,
+]);
+
+/** Select exact authored pPr from editor attrs through the total descriptor. */
+const authoredParagraphPropertiesFromExternalDomAttrs = (
+  attrs: Readonly<Partial<ParagraphAttrs>>,
+): AuthoredParagraphProperties => {
+  const authored: ParagraphFormatting = {};
+  for (const rawKey of PARAGRAPH_FORMATTING_PROPERTY_KEY_LIST) {
+    const descriptor = PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR[rawKey];
+    if (descriptor.owner !== "pPr-base") {
+      continue;
+    }
+    switch (descriptor.projection) {
+      case "alignment":
+        if (attrs.alignment !== undefined && attrs.alignment !== null) {
+          authored.alignment = attrs.alignment;
+        }
+        break;
+      case "direction": {
+        const bidi = directionToBidi(attrs.direction);
+        if (bidi !== undefined) {
+          authored.bidi = bidi;
+        }
+        break;
+      }
+      case "direct":
+      case "boolean":
+      case "opaque": {
+        const attr = PARAGRAPH_FORMATTING_PROPERTY_ATTRS[rawKey].at(0);
+        const value = attr === undefined ? undefined : Reflect.get(attrs, attr);
+        if (value !== undefined && value !== null) {
+          Reflect.set(authored, rawKey, structuredClone(value));
+        }
+        break;
+      }
+      case "indentation": {
+        const attr = PARAGRAPH_FORMATTING_PROPERTY_ATTRS[rawKey].at(0);
+        const value = attr === undefined ? undefined : Reflect.get(attrs, attr);
+        if (value !== undefined && value !== null) {
+          Reflect.set(authored, rawKey, value);
+        }
+        break;
+      }
+      case "spacing":
+        if (rawKey === "beforeAutospacing") {
+          if (autospacingMatchesBase(attrs._autospacingBase, "before", attrs.spaceBefore)) {
+            authored.beforeAutospacing = true;
+          }
+        } else if (rawKey === "afterAutospacing") {
+          if (autospacingMatchesBase(attrs._autospacingBase, "after", attrs.spaceAfter)) {
+            authored.afterAutospacing = true;
+          }
+        } else if (rawKey === "spacingExplicit") {
+          if (attrs.spacingExplicit !== undefined && attrs.spacingExplicit !== null) {
+            authored.spacingExplicit = structuredClone(attrs.spacingExplicit);
+          }
+        } else {
+          const attr = PARAGRAPH_FORMATTING_PROPERTY_ATTRS[rawKey].at(0);
+          const value = attr === undefined ? undefined : Reflect.get(attrs, attr);
+          if (value !== undefined && value !== null) {
+            Reflect.set(authored, rawKey, value);
+          }
+        }
+        break;
+      case "numbering-provenance":
+      case "preserve-live":
+        break;
+      default: {
+        const exhaustive: never = descriptor.projection;
+        return exhaustive;
+      }
+    }
+  }
+  return authoredParagraphPropertiesFromFormatting(authored);
+};
+
+const nonGovernedAttrs = (
+  attrs: Readonly<Record<string, unknown>>,
+): Readonly<Record<string, unknown>> => {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(attrs)) {
+    if (!GOVERNED_PARAGRAPH_ATTR_KEYS.has(key as keyof ParagraphAttrs)) {
+      result[key] = value;
+    }
+  }
+  return result;
+};
+
+type CreateEditorParagraphPropertiesFromAttrsOptions = {
+  effectiveAttrs: Readonly<Partial<ParagraphAttrs>>;
+  authoredAttrs?: Readonly<Partial<ParagraphAttrs>>;
+  inheritedPPr?: AuthoredParagraphProperties;
+};
+
+const createEditorParagraphPropertiesFromExternalDomAttrs = ({
+  effectiveAttrs,
+  authoredAttrs = effectiveAttrs,
+  inheritedPPr = {},
+}: CreateEditorParagraphPropertiesFromAttrsOptions): ParagraphPropertyProjection =>
+  createEditorParagraphProperties({
+    attrs: nonGovernedAttrs(effectiveAttrs),
+    authoredPPr: authoredParagraphPropertiesFromExternalDomAttrs(authoredAttrs),
+    context: { inheritedPPr, numberingLevelIndent: null, numPrFromStyle: null },
+    paragraphMarkFormatting: effectiveAttrs._paragraphMarkFormatting ?? {},
+  });
+
+const cloneFormatting = (formatting: Readonly<AuthoredParagraphProperties>): ParagraphFormatting =>
+  structuredClone(formatting);
+
+const sourceIndentation = (
+  direct: Readonly<AuthoredParagraphProperties>,
+  inherited: ParagraphFormatting | undefined,
+): ParagraphAttrs["_sourceIndentation"] | null => {
+  const result: NonNullable<ParagraphAttrs["_sourceIndentation"]> = {};
+  if (direct.indentLeft === undefined && inherited?.indentLeft !== undefined) {
+    result.indentLeft = inherited.indentLeft;
+  }
+  if (direct.indentRight === undefined && inherited?.indentRight !== undefined) {
+    result.indentRight = inherited.indentRight;
+  }
+  const ownsFirstLine = direct.indentFirstLine !== undefined || direct.hangingIndent !== undefined;
+  if (!ownsFirstLine && inherited?.indentFirstLine !== undefined) {
+    result.indentFirstLine = inherited.indentFirstLine;
+    result.hangingIndent = inherited.hangingIndent === true;
+  }
+  return Object.keys(result).length > 0 ? result : null;
+};
+
+const numberingIndentFormatting = (
+  provenance: ParagraphFormatting["numberingLevelIndent"] | null,
+): ParagraphFormatting | undefined => {
+  if (provenance?.type !== "owned") {
+    return undefined;
+  }
+  return {
+    ...(provenance.owned.indentLeft !== undefined
+      ? { indentLeft: provenance.owned.indentLeft }
+      : {}),
+    ...(provenance.owned.indentRight !== undefined
+      ? { indentRight: provenance.owned.indentRight }
+      : {}),
+    ...(provenance.owned.indentFirstLine !== undefined
+      ? { indentFirstLine: provenance.owned.indentFirstLine }
+      : {}),
+    ...(provenance.owned.hangingIndent !== undefined
+      ? { hangingIndent: provenance.owned.hangingIndent }
+      : {}),
+  };
+};
+
+const projectionContext = (
+  attrs: ParagraphAttrs,
+  transition: ParagraphPropertyContextTransition,
+): ParagraphPropertyProjectionContext => {
+  switch (transition.type) {
+    case "preserve":
+      return {
+        inheritedPPr: attrs._paragraphPropertyInheritance,
+        numberingLevelIndent: attrs._numberingLevelIndent ?? null,
+        numPrFromStyle: attrs.numPrFromStyle ?? null,
+      };
+    case "replace":
+      return {
+        inheritedPPr: authoredParagraphPropertiesFromFormatting(transition.inheritedPPr),
+        numberingLevelIndent: transition.numberingLevelIndent,
+        numPrFromStyle: transition.numPrFromStyle,
+      };
+    default: {
+      const exhaustive: never = transition;
+      return exhaustive;
+    }
+  }
+};
+
+const projectAttrs = (
+  attrs: ParagraphAttrs,
+  state: ParagraphPropertyState,
+  context: ParagraphPropertyProjectionContext,
+): ParagraphAttrs => {
+  const authoredPPr = cloneFormatting(state.authoredPPr);
+  const inheritedPPr = cloneFormatting(context.inheritedPPr);
+  const inheritedOverNumbering = mergeParagraphFormatting(
+    numberingIndentFormatting(context.numberingLevelIndent),
+    inheritedPPr,
+  );
+  const effective = mergeParagraphFormatting(inheritedOverNumbering, authoredPPr) ?? {};
+  const next: ParagraphAttrs = {
+    ...attrs,
+    _paragraphPropertyState: serializeParagraphPropertyState(state),
+    _paragraphPropertyInheritance: authoredParagraphPropertiesFromFormatting(inheritedPPr),
+  };
+  Reflect.set(next, "_numberingLevelIndent", context.numberingLevelIndent ?? null);
+  Reflect.set(next, "numPrFromStyle", context.numPrFromStyle ?? null);
+
+  Object.assign(
+    next,
+    paragraphSpacingAttrPatch({
+      direct: paragraphSpacingFromFormatting(authoredPPr),
+      inherited: paragraphSpacingFromFormatting(inheritedPPr),
+    }),
+  );
+  if (authoredPPr.spacingExplicit !== undefined) {
+    next.spacingExplicit = structuredClone(authoredPPr.spacingExplicit);
+  }
+
+  for (const rawKey of PARAGRAPH_FORMATTING_PROPERTY_KEY_LIST) {
+    const descriptor = PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR[rawKey];
+    switch (descriptor.projection) {
+      case "alignment":
+        Reflect.set(next, "alignment", effective.alignment ?? null);
+        Reflect.set(next, "alignmentFromStyle", inheritedPPr.alignment ?? null);
+        break;
+      case "direction":
+        next.direction = directionFromBidi(effective.bidi);
+        break;
+      case "direct":
+      case "boolean":
+      case "opaque":
+        for (const attr of PARAGRAPH_FORMATTING_PROPERTY_ATTRS[rawKey]) {
+          Reflect.set(next, attr, Reflect.get(effective, rawKey) ?? null);
+        }
+        break;
+      case "indentation":
+      case "spacing":
+      case "numbering-provenance":
+      case "preserve-live":
+        break;
+      default: {
+        const exhaustive: never = descriptor.projection;
+        return exhaustive;
+      }
+    }
+  }
+
+  Reflect.set(next, "indentLeft", effective.indentLeft ?? null);
+  Reflect.set(next, "indentRight", effective.indentRight ?? null);
+  Reflect.set(next, "indentFirstLine", effective.indentFirstLine ?? null);
+  Reflect.set(
+    next,
+    "hangingIndent",
+    effective.indentFirstLine === undefined ? null : (effective.hangingIndent ?? false),
+  );
+  Reflect.set(next, "_sourceIndentation", sourceIndentation(authoredPPr, inheritedOverNumbering));
+  return next;
+};
+
+const proveParagraphPropertyProjection = (
+  attrs: ParagraphAttrs,
+): ParagraphPropertyProjection => ParagraphPropertyProjectionCapsule.fromProjectedAttrs(attrs);
+
+export const transitionParagraphProperties = ({
+  attrs,
+  state: transition,
+  context: contextTransition,
+}: TransitionParagraphPropertiesOptions): ParagraphPropertyProjection => {
+  const current = expectParagraphPropertyState(attrs._paragraphPropertyState);
+  const state = transitionParagraphPropertyState(current, transition);
+  const context = projectionContext(attrs, contextTransition);
+  return proveParagraphPropertyProjection(projectAttrs(attrs, state, context));
+};
+
+export const createParagraphProperties = ({
+  attrs = {},
+  state,
+  context,
+  paragraphMarkFormatting = {},
+}: CreateParagraphPropertiesOptions): ParagraphPropertyProjection => {
+  for (const key of Object.keys(attrs)) {
+    if (GOVERNED_PARAGRAPH_ATTR_KEYS.has(key as keyof ParagraphAttrs)) {
+      panic(`Editor paragraph creation supplied governed attr directly: ${key}`);
+    }
+  }
+  const seed = {
+    ...attrs,
+    _paragraphPropertyState: serializeParagraphPropertyState(state),
+    _paragraphPropertyInheritance: context.inheritedPPr,
+    _paragraphMarkFormatting: paragraphMarkFormatting,
+  } as ParagraphAttrs;
+  return proveParagraphPropertyProjection(projectAttrs(seed, state, context));
+};
+
+export const createEditorParagraphProperties = ({
+  attrs,
+  authoredPPr,
+  context,
+  paragraphMarkFormatting,
+}: CreateEditorParagraphPropertiesOptions): ParagraphPropertyProjection =>
+  createParagraphProperties({
+    attrs,
+    state: createEditorParagraphPropertyState(authoredPPr),
+    context,
+    paragraphMarkFormatting,
+  });
+
+const valuesEqual = (left: unknown, right: unknown): boolean => {
+  if (Object.is(left, right)) {
+    return true;
+  }
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) {
+      return false;
+    }
+    return left.every((entry, index) => valuesEqual(entry, right[index]));
+  }
+  if (
+    typeof left !== "object" ||
+    left === null ||
+    typeof right !== "object" ||
+    right === null
+  ) {
+    return false;
+  }
+  const leftEntries = Object.entries(left);
+  const rightRecord = right as Record<string, unknown>;
+  if (leftEntries.length !== Object.keys(rightRecord).length) {
+    return false;
+  }
+  return leftEntries.every(
+    ([key, value]) => Object.hasOwn(rightRecord, key) && valuesEqual(value, rightRecord[key]),
+  );
+};
+
+export type ParagraphPropertyInvariantBoundary =
+  | { type: "internal" }
+  | { type: "persistence" };
+
+/** Prove state, context, and every descriptor-governed effective attr are a fixed point. */
+export const assertParagraphPropertyInvariant = (
+  attrs: ParagraphAttrs,
+  boundary: ParagraphPropertyInvariantBoundary,
+): ParagraphPropertyState => {
+  const state = expectParagraphPropertyState(attrs._paragraphPropertyState);
+  if (boundary.type === "persistence") {
+    serializePersistableParagraphPropertyState(state);
+  }
+  const inheritance = readAuthoredParagraphProperties(attrs._paragraphPropertyInheritance);
+  if (inheritance.status !== "valid") {
+    panic("Paragraph-property inheritance must be a valid authored-property projection");
+  }
+  const expected = projectAttrs(attrs, state, {
+    inheritedPPr: inheritance.value,
+    numberingLevelIndent: attrs._numberingLevelIndent ?? null,
+    numPrFromStyle: attrs.numPrFromStyle ?? null,
+  });
+  for (const key of GOVERNED_PARAGRAPH_ATTR_KEYS) {
+    if (!valuesEqual(attrs[key], expected[key])) {
+      panic(`Paragraph-property projection invariant failed for attr: ${String(key)}`);
+    }
+  }
+  return state;
+};
+
+/** Create proof for a mutation that leaves every governed property unchanged. */
+export const preserveParagraphProperties = (
+  attrs: ParagraphAttrs,
+  patch: Readonly<Record<string, unknown>>,
+): ParagraphPropertyProjection => {
+  const next = { ...attrs, ...patch } as ParagraphAttrs;
+  for (const key of GOVERNED_PARAGRAPH_ATTR_KEYS) {
+    if (!valuesEqual(attrs[key], next[key])) {
+      panic(`Non-governed paragraph mutation changed governed attr: ${String(key)}`);
+    }
+  }
+  expectParagraphPropertyState(next._paragraphPropertyState);
+  return proveParagraphPropertyProjection(next);
+};
+
+type ApplyParagraphPropertyProjectionOptions = {
+  transaction: Transaction;
+  pos: number;
+  projection: ParagraphPropertyProjection;
+  source: { type: "preserve" } | { type: "transfer-allocated-id" };
+};
+
+/** The only paragraph-markup mutation sink accepted by the ownership guard. */
+export const applyParagraphPropertyProjection = ({
+  transaction,
+  pos,
+  projection,
+  source,
+}: ApplyParagraphPropertyProjectionOptions): void => {
+  const attrs = ParagraphPropertyProjectionCapsule.attrs(projection);
+  assertParagraphPropertyInvariant(attrs, { type: "internal" });
+  setProseParagraphMarkupWithPropertySource({
+    transaction,
+    pos,
+    attrs,
+    ownership: source.type,
+  });
+};
+
+type CreateParagraphNodeFromProjectionOptions = {
+  type: NodeType;
+  projection: ParagraphPropertyProjection;
+  content?: Fragment | PMNode | readonly PMNode[] | null;
+  marks?: readonly Mark[];
+};
+
+/** The only paragraph-node creation sink accepted by the ownership guard. */
+export const createParagraphNodeFromProjection = ({
+  type,
+  projection,
+  content,
+  marks,
+}: CreateParagraphNodeFromProjectionOptions): PMNode => {
+  if (type.name !== "paragraph") {
+    panic("Paragraph-property projection can only create a paragraph node");
+  }
+  const attrs = ParagraphPropertyProjectionCapsule.attrs(projection);
+  assertParagraphPropertyInvariant(attrs, { type: "internal" });
+  return type.create(attrs, content, marks);
+};
+
+type ApplyNonParagraphMarkupOptions = {
+  transaction: Transaction;
+  pos: number;
+  attrs?: PMNode["attrs"];
+  type?: NodeType;
+  marks?: readonly Mark[];
+};
+
+/** Canonical markup sink for nodes that are runtime-proven not to be paragraphs. */
+export const applyNonParagraphMarkup = ({
+  transaction,
+  pos,
+  attrs,
+  type,
+  marks,
+}: ApplyNonParagraphMarkupOptions): void => {
+  const current = transaction.doc.nodeAt(pos);
+  if (!current) {
+    panic("Cannot mutate markup for a missing node");
+  }
+  if (current.type.name === "paragraph" || type?.name === "paragraph") {
+    panic("Non-paragraph markup sink cannot mutate a paragraph");
+  }
+  transaction.setNodeMarkup(pos, type, attrs, marks);
+};
+
+/** Explicit external-DOM import boundary used by the paragraph NodeSpec parser. */
+export const paragraphAttrsFromExternalDomImport = ({
+  effectiveAttrs,
+  authoredAttrs = effectiveAttrs,
+  inheritedPPr = {},
+}: CreateEditorParagraphPropertiesFromAttrsOptions): ParagraphAttrs => {
+  const projection = createEditorParagraphPropertiesFromExternalDomAttrs({
+    effectiveAttrs,
+    authoredAttrs,
+    inheritedPPr,
+  });
+  return ParagraphPropertyProjectionCapsule.attrs(projection);
+};

--- a/packages/core/src/prosemirror/paragraphPropertyMutation.ts
+++ b/packages/core/src/prosemirror/paragraphPropertyMutation.ts
@@ -18,10 +18,10 @@ import {
   authoredParagraphPropertiesFromFormatting,
   createEditorParagraphPropertyState,
   expectParagraphPropertyState,
-  readAuthoredParagraphProperties,
-  serializeParagraphPropertyState,
+  paragraphPropertyStateAttribute,
   serializePersistableParagraphPropertyState,
   transitionParagraphPropertyState,
+  type ParagraphPropertyProjectionContext,
   type ParagraphPropertyState,
   type ParagraphPropertyStateTransition,
 } from "./paragraphPropertyState";
@@ -50,7 +50,10 @@ class ParagraphPropertyProjectionCapsule {
   readonly #attrs: ParagraphAttrs;
 
   private constructor(attrs: ParagraphAttrs) {
-    this.#attrs = deepFreezeProjectionValue(structuredClone(attrs)) as ParagraphAttrs;
+    const state = attrs._paragraphPropertyState;
+    const cloned = structuredClone({ ...attrs, _paragraphPropertyState: undefined });
+    cloned._paragraphPropertyState = state;
+    this.#attrs = deepFreezeProjectionValue(cloned) as ParagraphAttrs;
     Object.freeze(this);
   }
 
@@ -65,27 +68,14 @@ class ParagraphPropertyProjectionCapsule {
 
 export type ParagraphPropertyProjection = ParagraphPropertyProjectionCapsule;
 
-export type ParagraphPropertyProjectionContext = {
-  inheritedPPr: AuthoredParagraphProperties;
-  numberingLevelIndent: ParagraphFormatting["numberingLevelIndent"] | null;
-  numPrFromStyle: ParagraphFormatting["numPr"] | null;
-};
-
-export type ParagraphPropertyContextTransition =
-  | { type: "preserve" }
-  | ({ type: "replace" } & ParagraphPropertyProjectionContext);
-
 type TransitionParagraphPropertiesOptions = {
   attrs: ParagraphAttrs;
   state: ParagraphPropertyStateTransition;
-  context: ParagraphPropertyContextTransition;
 };
 
 type CreateParagraphPropertiesOptions = {
   attrs?: Readonly<Record<string, unknown>>;
   state: ParagraphPropertyState;
-  context: ParagraphPropertyProjectionContext;
-  paragraphMarkFormatting?: ParagraphAttrs["_paragraphMarkFormatting"];
 };
 
 type CreateEditorParagraphPropertiesOptions = Omit<
@@ -93,13 +83,11 @@ type CreateEditorParagraphPropertiesOptions = Omit<
   "state"
 > & {
   authoredPPr: AuthoredParagraphProperties;
+  context?: ParagraphPropertyProjectionContext;
 };
 
 const PROJECTION_CONTEXT_ATTR_KEYS = [
   "_paragraphPropertyState",
-  "_paragraphPropertyInheritance",
-  "_paragraphMarkFormatting",
-  "_numberingLevelIndent",
   "numPrFromStyle",
   "alignmentFromStyle",
   "_sourceIndentation",
@@ -108,11 +96,18 @@ const PROJECTION_CONTEXT_ATTR_KEYS = [
   "spacingFromImplicitDefaultStyle",
 ] as const satisfies readonly (keyof ParagraphAttrs)[];
 
-export const GOVERNED_PARAGRAPH_ATTR_KEYS: ReadonlySet<keyof ParagraphAttrs> = new Set([
-  ...PPR_CHANGE_SCOPED_ATTR_KEYS,
-  ...PARAGRAPH_MARK_ATTR_KEYS,
-  ...PROJECTION_CONTEXT_ATTR_KEYS,
+export const GOVERNED_PARAGRAPH_ATTR_KEY_LIST = Object.freeze([
+  ...new Set<keyof ParagraphAttrs>([
+    ...PPR_CHANGE_SCOPED_ATTR_KEYS,
+    ...PARAGRAPH_MARK_ATTR_KEYS,
+    ...PROJECTION_CONTEXT_ATTR_KEYS,
+  ]),
 ]);
+const GOVERNED_PARAGRAPH_ATTR_KEY_SET = new Set<keyof ParagraphAttrs>(
+  GOVERNED_PARAGRAPH_ATTR_KEY_LIST,
+);
+export const isGovernedParagraphAttr = (key: string): key is keyof ParagraphAttrs =>
+  GOVERNED_PARAGRAPH_ATTR_KEY_SET.has(key as keyof ParagraphAttrs);
 
 /** Select exact authored pPr from editor attrs through the total descriptor. */
 const authoredParagraphPropertiesFromExternalDomAttrs = (
@@ -193,7 +188,7 @@ const nonGovernedAttrs = (
 ): Readonly<Record<string, unknown>> => {
   const result: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(attrs)) {
-    if (!GOVERNED_PARAGRAPH_ATTR_KEYS.has(key as keyof ParagraphAttrs)) {
+    if (!isGovernedParagraphAttr(key)) {
       result[key] = value;
     }
   }
@@ -214,8 +209,30 @@ const createEditorParagraphPropertiesFromExternalDomAttrs = ({
   createEditorParagraphProperties({
     attrs: nonGovernedAttrs(effectiveAttrs),
     authoredPPr: authoredParagraphPropertiesFromExternalDomAttrs(authoredAttrs),
-    context: { inheritedPPr, numberingLevelIndent: null, numPrFromStyle: null },
-    paragraphMarkFormatting: effectiveAttrs._paragraphMarkFormatting ?? {},
+    context: {
+      inheritedPPr,
+      numberingLevelIndent: null,
+      numPrFromStyle: null,
+      paragraphMark: {
+        authored: {
+          ...(authoredAttrs.defaultTextFormatting == null
+            ? {}
+            : { runProperties: authoredAttrs.defaultTextFormatting }),
+          ...(authoredAttrs.runInWithNext == null
+            ? {}
+            : { runInWithNext: authoredAttrs.runInWithNext }),
+        },
+        effective: {
+          ...(effectiveAttrs.defaultTextFormatting == null
+            ? {}
+            : { defaultTextFormatting: effectiveAttrs.defaultTextFormatting }),
+          ...(effectiveAttrs.runInWithNext == null
+            ? {}
+            : { runInWithNext: effectiveAttrs.runInWithNext }),
+        },
+      },
+      spacingInheritance: {},
+    },
   });
 
 const cloneFormatting = (formatting: Readonly<AuthoredParagraphProperties>): ParagraphFormatting =>
@@ -262,35 +279,11 @@ const numberingIndentFormatting = (
   };
 };
 
-const projectionContext = (
-  attrs: ParagraphAttrs,
-  transition: ParagraphPropertyContextTransition,
-): ParagraphPropertyProjectionContext => {
-  switch (transition.type) {
-    case "preserve":
-      return {
-        inheritedPPr: attrs._paragraphPropertyInheritance,
-        numberingLevelIndent: attrs._numberingLevelIndent ?? null,
-        numPrFromStyle: attrs.numPrFromStyle ?? null,
-      };
-    case "replace":
-      return {
-        inheritedPPr: authoredParagraphPropertiesFromFormatting(transition.inheritedPPr),
-        numberingLevelIndent: transition.numberingLevelIndent,
-        numPrFromStyle: transition.numPrFromStyle,
-      };
-    default: {
-      const exhaustive: never = transition;
-      return exhaustive;
-    }
-  }
-};
-
 const projectAttrs = (
   attrs: ParagraphAttrs,
   state: ParagraphPropertyState,
-  context: ParagraphPropertyProjectionContext,
 ): ParagraphAttrs => {
+  const { context } = state;
   const authoredPPr = cloneFormatting(state.authoredPPr);
   const inheritedPPr = cloneFormatting(context.inheritedPPr);
   const inheritedOverNumbering = mergeParagraphFormatting(
@@ -300,17 +293,22 @@ const projectAttrs = (
   const effective = mergeParagraphFormatting(inheritedOverNumbering, authoredPPr) ?? {};
   const next: ParagraphAttrs = {
     ...attrs,
-    _paragraphPropertyState: serializeParagraphPropertyState(state),
-    _paragraphPropertyInheritance: authoredParagraphPropertiesFromFormatting(inheritedPPr),
+    _paragraphPropertyState: paragraphPropertyStateAttribute(state),
   };
-  Reflect.set(next, "_numberingLevelIndent", context.numberingLevelIndent ?? null);
   Reflect.set(next, "numPrFromStyle", context.numPrFromStyle ?? null);
+  Reflect.set(
+    next,
+    "defaultTextFormatting",
+    context.paragraphMark.effective.defaultTextFormatting ?? null,
+  );
+  Reflect.set(next, "runInWithNext", context.paragraphMark.effective.runInWithNext ?? null);
 
   Object.assign(
     next,
     paragraphSpacingAttrPatch({
       direct: paragraphSpacingFromFormatting(authoredPPr),
       inherited: paragraphSpacingFromFormatting(inheritedPPr),
+      inheritance: context.spacingInheritance,
     }),
   );
   if (authoredPPr.spacingExplicit !== undefined) {
@@ -365,45 +363,36 @@ const proveParagraphPropertyProjection = (
 export const transitionParagraphProperties = ({
   attrs,
   state: transition,
-  context: contextTransition,
 }: TransitionParagraphPropertiesOptions): ParagraphPropertyProjection => {
   const current = expectParagraphPropertyState(attrs._paragraphPropertyState);
   const state = transitionParagraphPropertyState(current, transition);
-  const context = projectionContext(attrs, contextTransition);
-  return proveParagraphPropertyProjection(projectAttrs(attrs, state, context));
+  return proveParagraphPropertyProjection(projectAttrs(attrs, state));
 };
 
 export const createParagraphProperties = ({
   attrs = {},
   state,
-  context,
-  paragraphMarkFormatting = {},
 }: CreateParagraphPropertiesOptions): ParagraphPropertyProjection => {
   for (const key of Object.keys(attrs)) {
-    if (GOVERNED_PARAGRAPH_ATTR_KEYS.has(key as keyof ParagraphAttrs)) {
+    if (isGovernedParagraphAttr(key)) {
       panic(`Editor paragraph creation supplied governed attr directly: ${key}`);
     }
   }
   const seed = {
     ...attrs,
-    _paragraphPropertyState: serializeParagraphPropertyState(state),
-    _paragraphPropertyInheritance: context.inheritedPPr,
-    _paragraphMarkFormatting: paragraphMarkFormatting,
+    _paragraphPropertyState: paragraphPropertyStateAttribute(state),
   } as ParagraphAttrs;
-  return proveParagraphPropertyProjection(projectAttrs(seed, state, context));
+  return proveParagraphPropertyProjection(projectAttrs(seed, state));
 };
 
 export const createEditorParagraphProperties = ({
   attrs,
   authoredPPr,
   context,
-  paragraphMarkFormatting,
 }: CreateEditorParagraphPropertiesOptions): ParagraphPropertyProjection =>
   createParagraphProperties({
     attrs,
-    state: createEditorParagraphPropertyState(authoredPPr),
-    context,
-    paragraphMarkFormatting,
+    state: createEditorParagraphPropertyState({ authoredPPr, context }),
   });
 
 const valuesEqual = (left: unknown, right: unknown): boolean => {
@@ -447,16 +436,8 @@ export const assertParagraphPropertyInvariant = (
   if (boundary.type === "persistence") {
     serializePersistableParagraphPropertyState(state);
   }
-  const inheritance = readAuthoredParagraphProperties(attrs._paragraphPropertyInheritance);
-  if (inheritance.status !== "valid") {
-    panic("Paragraph-property inheritance must be a valid authored-property projection");
-  }
-  const expected = projectAttrs(attrs, state, {
-    inheritedPPr: inheritance.value,
-    numberingLevelIndent: attrs._numberingLevelIndent ?? null,
-    numPrFromStyle: attrs.numPrFromStyle ?? null,
-  });
-  for (const key of GOVERNED_PARAGRAPH_ATTR_KEYS) {
+  const expected = projectAttrs(attrs, state);
+  for (const key of GOVERNED_PARAGRAPH_ATTR_KEY_LIST) {
     if (!valuesEqual(attrs[key], expected[key])) {
       panic(`Paragraph-property projection invariant failed for attr: ${String(key)}`);
     }
@@ -470,7 +451,7 @@ export const preserveParagraphProperties = (
   patch: Readonly<Record<string, unknown>>,
 ): ParagraphPropertyProjection => {
   const next = { ...attrs, ...patch } as ParagraphAttrs;
-  for (const key of GOVERNED_PARAGRAPH_ATTR_KEYS) {
+  for (const key of GOVERNED_PARAGRAPH_ATTR_KEY_LIST) {
     if (!valuesEqual(attrs[key], next[key])) {
       panic(`Non-governed paragraph mutation changed governed attr: ${String(key)}`);
     }
@@ -552,15 +533,22 @@ export const applyNonParagraphMarkup = ({
 };
 
 /** Explicit external-DOM import boundary used by the paragraph NodeSpec parser. */
-export const paragraphAttrsFromExternalDomImport = ({
+export const paragraphPropertiesFromExternalDomImport = ({
   effectiveAttrs,
   authoredAttrs = effectiveAttrs,
   inheritedPPr = {},
-}: CreateEditorParagraphPropertiesFromAttrsOptions): ParagraphAttrs => {
-  const projection = createEditorParagraphPropertiesFromExternalDomAttrs({
+}: CreateEditorParagraphPropertiesFromAttrsOptions): ParagraphPropertyProjection =>
+  createEditorParagraphPropertiesFromExternalDomAttrs({
     effectiveAttrs,
     authoredAttrs,
     inheritedPPr,
   });
-  return ParagraphPropertyProjectionCapsule.attrs(projection);
-};
+
+/** Bind the sole raw-attr unwrap to a paragraph NodeSpec `getAttrs` callback. */
+export const paragraphDomGetAttrs = <Dom>(
+  project: (dom: Dom) => ParagraphPropertyProjection | false,
+): ((dom: Dom) => ParagraphAttrs | false) =>
+  (dom) => {
+    const projection = project(dom);
+    return projection === false ? false : ParagraphPropertyProjectionCapsule.attrs(projection);
+  };

--- a/packages/core/src/prosemirror/paragraphPropertyOwnership.ts
+++ b/packages/core/src/prosemirror/paragraphPropertyOwnership.ts
@@ -1,0 +1,809 @@
+import { panic } from "better-result";
+import type { Node as PMNode } from "prosemirror-model";
+import type { Transaction } from "prosemirror-state";
+import { Step, StepMap, StepResult, type Mappable } from "prosemirror-transform";
+import { ySyncPluginKey } from "y-prosemirror";
+
+import {
+  PARAGRAPH_PROPERTY_SOURCE_MAX_PARAGRAPHS,
+  ParagraphPropertySourceContract,
+  ParagraphPropertySourceValidationError,
+  type ParagraphPropertySourceStory,
+} from "../docx/paragraphPropertySourceIdentity";
+import { PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR } from "../docx/paragraphPropertySource";
+import { readParagraphPropertyState, type ParagraphPropertyState } from "./paragraphPropertyState";
+
+type ImportedOccurrence = {
+  node: PMNode;
+  nodeSize: number;
+  pos: number;
+  token: string;
+};
+
+const importedOccurrenceMatches = (left: ImportedOccurrence, right: ImportedOccurrence): boolean =>
+  left.token === right.token && left.pos === right.pos && left.nodeSize === right.nodeSize;
+
+type ParagraphOccurrence = {
+  node: PMNode;
+  pos: number;
+  state: ParagraphPropertyState;
+};
+
+type OwnershipSnapshot = {
+  imported: ReadonlyMap<string, ImportedOccurrence>;
+  paragraphs: readonly ParagraphOccurrence[];
+  paragraphCount: number;
+};
+
+const EDITABLE_DOCUMENT_STORY = Object.freeze({
+  type: "document",
+}) satisfies ParagraphPropertySourceStory;
+
+const readContract = (doc: PMNode): ParagraphPropertySourceContract | null => {
+  const result = ParagraphPropertySourceContract.read(
+    doc.attrs[PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR],
+  );
+  if (result.status === "invalid") {
+    throw new ParagraphPropertySourceValidationError({
+      code: "contract_mismatch",
+      message: "The ProseMirror document contains an invalid paragraph-property source contract.",
+    });
+  }
+  return result.status === "valid" ? result.value : null;
+};
+
+const ownershipSnapshot = (
+  doc: PMNode,
+  contract: ParagraphPropertySourceContract | null,
+  story: ParagraphPropertySourceStory,
+): OwnershipSnapshot => {
+  const imported = new Map<string, ImportedOccurrence>();
+  const paragraphs: ParagraphOccurrence[] = [];
+  let paragraphCount = 0;
+  doc.descendants((node, pos) => {
+    if (node.type.name !== "paragraph") {
+      return true;
+    }
+    paragraphCount += 1;
+    if (paragraphCount > PARAGRAPH_PROPERTY_SOURCE_MAX_PARAGRAPHS) {
+      throw new ParagraphPropertySourceValidationError({
+        code: "source_capacity_exceeded",
+        message: "Paragraph-property transaction census capacity was exceeded.",
+      });
+    }
+    const state = readParagraphPropertyState(node.attrs["_paragraphPropertyState"]);
+    if (state.status !== "valid") {
+      throw new ParagraphPropertySourceValidationError({
+        code: "invalid_state",
+        message: "A paragraph contains invalid paragraph-property state.",
+        ...(state.status === "invalid" ? { token: state.raw } : {}),
+      });
+    }
+    paragraphs.push(Object.freeze({ node, pos, state: state.value }));
+    if (state.value.type !== "imported") {
+      return false;
+    }
+    if (!contract) {
+      throw new ParagraphPropertySourceValidationError({
+        code: "contract_mismatch",
+        message: "An imported paragraph-property state requires its source contract.",
+        token: state.value.token,
+      });
+    }
+    const token = contract.readToken(state.value.token);
+    if (token.status !== "valid" || !token.value.belongsToStory(story)) {
+      throw new ParagraphPropertySourceValidationError({
+        code: "invalid_token",
+        message: "A paragraph-property token is outside the document ownership context.",
+        token: state.value.token,
+      });
+    }
+    if (imported.has(state.value.token)) {
+      throw new ParagraphPropertySourceValidationError({
+        code: "duplicate_token",
+        message: "A paragraph-property token is attached to more than one paragraph.",
+        token: state.value.token,
+      });
+    }
+    imported.set(
+      state.value.token,
+      Object.freeze({ node, nodeSize: node.nodeSize, pos, token: state.value.token }),
+    );
+    return false;
+  });
+  return {
+    imported,
+    paragraphs: Object.freeze(paragraphs),
+    paragraphCount,
+  };
+};
+
+type ParagraphPropertyOwnershipTransition =
+  | {
+      retained: ImportedOccurrence | null;
+      type: "split-left-created-right-retains";
+    }
+  | {
+      displaced: ImportedOccurrence | null;
+      retained: ImportedOccurrence | null;
+      sourceFrom: number;
+      sourceTo: number;
+      type: "join-left-paragraph-mark-retains" | "join-right-paragraph-mark-retains";
+    }
+  | {
+      affected: readonly ImportedOccurrence[];
+      type: "delete-selection";
+    }
+  | {
+      affected: readonly ImportedOccurrence[];
+      retained: ImportedOccurrence | null;
+      type: "replace-selection-then-split-right-retains";
+    };
+
+const paragraphPropertyOwnershipStepIssuer = Symbol("paragraphPropertyOwnershipStepIssuer");
+type ParagraphPropertyOwnershipStepIssuer = typeof paragraphPropertyOwnershipStepIssuer;
+
+class ParagraphPropertyOwnershipTransitionStep extends Step {
+  readonly #direction: "forward" | "inverse";
+  readonly #transition: ParagraphPropertyOwnershipTransition;
+
+  constructor(
+    issuer: ParagraphPropertyOwnershipStepIssuer,
+    transition: ParagraphPropertyOwnershipTransition,
+    direction: "forward" | "inverse" = "forward",
+  ) {
+    super();
+    if (issuer !== paragraphPropertyOwnershipStepIssuer) {
+      panic("Only paragraph-property structural sinks may issue ownership steps");
+    }
+    this.#transition = Object.freeze(transition);
+    this.#direction = direction;
+    Object.freeze(this);
+  }
+
+  apply(doc: PMNode): StepResult {
+    const snapshot = ownershipSnapshot(doc, readContract(doc), EDITABLE_DOCUMENT_STORY);
+    const expected: ImportedOccurrence[] = [];
+    switch (this.#transition.type) {
+      case "delete-selection":
+        expected.push(...this.#transition.affected);
+        break;
+      case "replace-selection-then-split-right-retains":
+        expected.push(...this.#transition.affected);
+        break;
+      case "join-left-paragraph-mark-retains":
+      case "join-right-paragraph-mark-retains":
+        if (this.#transition.retained !== null) {
+          expected.push(this.#transition.retained);
+        }
+        if (this.#transition.displaced !== null) {
+          expected.push(this.#transition.displaced);
+        }
+        break;
+      case "split-left-created-right-retains":
+        if (this.#transition.retained !== null) {
+          expected.push(this.#transition.retained);
+        }
+        break;
+      default: {
+        const exhaustive: never = this.#transition;
+        return exhaustive;
+      }
+    }
+    for (const occurrence of expected) {
+      const current = snapshot.imported.get(occurrence.token);
+      if (!current || !importedOccurrenceMatches(current, occurrence)) {
+        return StepResult.fail(
+          "Paragraph-property ownership proof does not match the transaction source census",
+        );
+      }
+    }
+    return StepResult.ok(doc);
+  }
+
+  getMap(): StepMap {
+    return StepMap.empty;
+  }
+
+  invert(): Step {
+    return new ParagraphPropertyOwnershipTransitionStep(
+      paragraphPropertyOwnershipStepIssuer,
+      this.#transition,
+      this.#direction === "forward" ? "inverse" : "forward",
+    );
+  }
+
+  map(_mapping: Mappable): Step {
+    return this;
+  }
+
+  merge(_other: Step): null {
+    return null;
+  }
+
+  toJSON(): never {
+    return panic("Paragraph-property ownership proof steps cannot cross a wire boundary");
+  }
+
+  read(): {
+    direction: "forward" | "inverse";
+    transition: ParagraphPropertyOwnershipTransition;
+  } {
+    return { direction: this.#direction, transition: this.#transition };
+  }
+}
+
+const importedOccurrence = (
+  state: ParagraphPropertyState,
+  node: PMNode,
+  pos: number,
+): ImportedOccurrence | null =>
+  state.type === "imported"
+    ? Object.freeze({ node, nodeSize: node.nodeSize, pos, token: state.token })
+    : null;
+
+const importedOccurrenceAt = (node: PMNode, pos: number): ImportedOccurrence | null => {
+  if (node.type.name !== "paragraph") {
+    panic("Paragraph-property ownership can only describe paragraphs");
+  }
+  const state = readParagraphPropertyState(node.attrs["_paragraphPropertyState"]);
+  if (state.status !== "valid") {
+    throw new ParagraphPropertySourceValidationError({
+      code: "invalid_state",
+      message: "A paragraph-property ownership sink received invalid state.",
+      ...(state.status === "invalid" ? { token: state.raw } : {}),
+    });
+  }
+  return importedOccurrence(state.value, node, pos);
+};
+
+const appendProof = (
+  transaction: Transaction,
+  transition: ParagraphPropertyOwnershipTransition,
+): void => {
+  transaction.step(
+    new ParagraphPropertyOwnershipTransitionStep(paragraphPropertyOwnershipStepIssuer, transition),
+  );
+};
+
+type RecordSplitOwnershipProofOptions = {
+  pos: number;
+  transaction: Transaction;
+};
+
+export const recordSplitParagraphPropertyOwnershipProof = ({
+  pos,
+  transaction,
+}: RecordSplitOwnershipProofOptions): void => {
+  const $pos = transaction.doc.resolve(pos);
+  const retained = importedOccurrenceAt($pos.parent, $pos.before());
+  if (retained === null) {
+    return;
+  }
+  appendProof(transaction, {
+    type: "split-left-created-right-retains",
+    retained,
+  });
+};
+
+type RecordJoinOwnershipProofOptions = {
+  joinPos: number;
+  transaction: Transaction;
+  transition: {
+    type: "join-left-paragraph-mark-retains" | "join-right-paragraph-mark-retains";
+  };
+};
+
+export const recordJoinParagraphPropertyOwnershipProof = ({
+  joinPos,
+  transaction,
+  transition,
+}: RecordJoinOwnershipProofOptions): void => {
+  const $join = transaction.doc.resolve(joinPos);
+  const left = $join.nodeBefore;
+  const right = $join.nodeAfter;
+  if (left?.type.name !== "paragraph" || right?.type.name !== "paragraph") {
+    panic("Paragraph-property join proof requires adjacent paragraphs");
+  }
+  const leftOccurrence = importedOccurrenceAt(left, joinPos - left.nodeSize);
+  const rightOccurrence = importedOccurrenceAt(right, joinPos);
+  if (leftOccurrence === null && rightOccurrence === null) {
+    return;
+  }
+  appendProof(transaction, {
+    type: transition.type,
+    retained:
+      transition.type === "join-left-paragraph-mark-retains" ? leftOccurrence : rightOccurrence,
+    displaced:
+      transition.type === "join-left-paragraph-mark-retains" ? rightOccurrence : leftOccurrence,
+    sourceFrom: joinPos - left.nodeSize,
+    sourceTo: joinPos + right.nodeSize,
+  });
+};
+
+export const recordDeleteParagraphPropertyOwnershipProof = (transaction: Transaction): void => {
+  if (transaction.selection.empty) {
+    panic("A paragraph deletion proof requires a non-empty selection");
+  }
+  const affected: ImportedOccurrence[] = [];
+  transaction.doc.nodesBetween(
+    transaction.selection.from,
+    transaction.selection.to,
+    (node, pos) => {
+      if (node.type.name !== "paragraph") {
+        return true;
+      }
+      const occurrence = importedOccurrenceAt(node, pos);
+      if (occurrence) {
+        affected.push(occurrence);
+      }
+      return false;
+    },
+  );
+  if (affected.length === 0) {
+    return;
+  }
+  appendProof(transaction, {
+    type: "delete-selection",
+    affected: Object.freeze(affected),
+  });
+};
+
+export const recordReplaceSelectionThenSplitParagraphPropertyOwnershipProof = ({
+  transaction,
+}: {
+  transaction: Transaction;
+}): void => {
+  if (transaction.selection.empty || transaction.selection.$from.parent.type.name !== "paragraph") {
+    panic("A replace-and-split proof requires a paragraph selection");
+  }
+  const retained = importedOccurrenceAt(
+    transaction.selection.$from.parent,
+    transaction.selection.$from.before(),
+  );
+  const affected: ImportedOccurrence[] = [];
+  transaction.doc.nodesBetween(
+    transaction.selection.from,
+    transaction.selection.to,
+    (node, pos) => {
+      if (node.type.name !== "paragraph") {
+        return true;
+      }
+      const occurrence = importedOccurrenceAt(node, pos);
+      if (occurrence) {
+        affected.push(occurrence);
+      }
+      return false;
+    },
+  );
+  if (retained === null && affected.length === 0) {
+    return;
+  }
+  appendProof(transaction, {
+    type: "replace-selection-then-split-right-retains",
+    affected: Object.freeze(affected),
+    retained,
+  });
+};
+
+type OwnershipException =
+  | { token: string; type: "added" }
+  | { token: string; type: "removed" }
+  | { token: string; type: "relocated" };
+
+const ownershipExceptions = (
+  before: OwnershipSnapshot,
+  after: OwnershipSnapshot,
+  transaction: Transaction,
+): OwnershipException[] => {
+  const exceptions: OwnershipException[] = [];
+  for (const [token, occurrence] of before.imported) {
+    const next = after.imported.get(token);
+    const mappedOwner = transaction.mapping.mapResult(occurrence.pos);
+    const mappedInterior = transaction.mapping.mapResult(occurrence.pos + 1, -1);
+    if (!next) {
+      exceptions.push({ token, type: "removed" });
+      continue;
+    }
+    if (mappedOwner.pos !== next.pos || mappedInterior.deletedAcross) {
+      exceptions.push({ token, type: "relocated" });
+    }
+  }
+  for (const token of after.imported.keys()) {
+    if (!before.imported.has(token)) {
+      exceptions.push({ token, type: "added" });
+    }
+  }
+  return exceptions;
+};
+
+const proofExceptions = (
+  transaction: Transaction,
+  before: OwnershipSnapshot,
+  after: OwnershipSnapshot,
+): ReadonlySet<string> => {
+  const permitted = new Set<string>();
+  const originalSide = (direction: "forward" | "inverse") =>
+    direction === "forward" ? before : after;
+  const assertOriginalOccurrence = (
+    direction: "forward" | "inverse",
+    occurrence: ImportedOccurrence,
+    message: string,
+  ): void => {
+    const actual = originalSide(direction).imported.get(occurrence.token);
+    if (!actual || !importedOccurrenceMatches(actual, occurrence)) {
+      panic(message);
+    }
+  };
+  const retainedTransitionIsBounded = (
+    direction: "forward" | "inverse",
+    occurrence: ImportedOccurrence,
+    sourceRange: { from: number; to: number } = {
+      from: occurrence.pos,
+      to: occurrence.pos + occurrence.nodeSize,
+    },
+  ): boolean => {
+    if (direction === "inverse") {
+      const restored = after.imported.get(occurrence.token);
+      return restored !== undefined && importedOccurrenceMatches(restored, occurrence);
+    }
+    const source = before.imported.get(occurrence.token);
+    const target = after.imported.get(occurrence.token);
+    if (!source || !target || !importedOccurrenceMatches(source, occurrence)) {
+      return false;
+    }
+    const mappedStart = transaction.mapping.map(sourceRange.from, -1);
+    const mappedEnd = transaction.mapping.map(sourceRange.to, 1);
+    return (
+      target.pos >= Math.min(mappedStart, mappedEnd) &&
+      target.pos <= Math.max(mappedStart, mappedEnd)
+    );
+  };
+  const proofs = transaction.steps.filter(
+    (step): step is ParagraphPropertyOwnershipTransitionStep =>
+      step instanceof ParagraphPropertyOwnershipTransitionStep,
+  );
+  for (const proof of proofs) {
+    const { direction, transition } = proof.read();
+    switch (transition.type) {
+      case "split-left-created-right-retains": {
+        if (transition.retained === null) {
+          break;
+        }
+        assertOriginalOccurrence(
+          direction,
+          transition.retained,
+          "A paragraph split proof does not match its source owner",
+        );
+        if (!retainedTransitionIsBounded(direction, transition.retained)) {
+          panic("A paragraph split proof does not match its retained source owner");
+        }
+        permitted.add(`relocated:${transition.retained.token}`);
+        break;
+      }
+      case "join-left-paragraph-mark-retains":
+      case "join-right-paragraph-mark-retains": {
+        if (transition.retained !== null) {
+          assertOriginalOccurrence(
+            direction,
+            transition.retained,
+            "A paragraph join proof does not match its source owner",
+          );
+          if (
+            !retainedTransitionIsBounded(direction, transition.retained, {
+              from: transition.sourceFrom,
+              to: transition.sourceTo,
+            })
+          ) {
+            panic("A paragraph join proof does not match its retained source owner");
+          }
+          permitted.add(`relocated:${transition.retained.token}`);
+        }
+        if (transition.displaced !== null) {
+          assertOriginalOccurrence(
+            direction,
+            transition.displaced,
+            "A paragraph join proof does not match its displaced source owner",
+          );
+          const displacedBefore = before.imported.has(transition.displaced.token);
+          const displacedAfter = after.imported.has(transition.displaced.token);
+          if (direction === "forward" && (!displacedBefore || displacedAfter)) {
+            panic("A paragraph join proof does not match its displaced source owner");
+          }
+          if (direction === "inverse" && (displacedBefore || !displacedAfter)) {
+            panic("An inverse paragraph join proof did not restore its displaced source owner");
+          }
+          permitted.add(
+            `${direction === "forward" ? "removed" : "added"}:${transition.displaced.token}`,
+          );
+        }
+        break;
+      }
+      case "delete-selection":
+        for (const occurrence of transition.affected) {
+          assertOriginalOccurrence(
+            direction,
+            occurrence,
+            "A paragraph deletion proof does not match its source owner",
+          );
+          const existsBefore = before.imported.has(occurrence.token);
+          const existsAfter = after.imported.has(occurrence.token);
+          if (direction === "forward" && !existsBefore) {
+            panic("A paragraph deletion proof does not match its source owner");
+          }
+          if (direction === "inverse" && !existsAfter) {
+            panic("An inverse paragraph deletion proof did not restore its source owner");
+          }
+          if (direction === "forward" && !existsAfter) {
+            permitted.add(`removed:${occurrence.token}`);
+          }
+          if (direction === "inverse" && !existsBefore) {
+            permitted.add(`added:${occurrence.token}`);
+          }
+          permitted.add(`relocated:${occurrence.token}`);
+        }
+        break;
+      case "replace-selection-then-split-right-retains": {
+        if (transition.retained !== null) {
+          assertOriginalOccurrence(
+            direction,
+            transition.retained,
+            "A replace-and-split proof does not match its source owner",
+          );
+          if (!retainedTransitionIsBounded(direction, transition.retained)) {
+            panic("A replace-and-split proof lost its retained source owner");
+          }
+          permitted.add(`relocated:${transition.retained.token}`);
+        }
+        for (const occurrence of transition.affected) {
+          assertOriginalOccurrence(
+            direction,
+            occurrence,
+            "A replace-and-split proof does not match its source owner",
+          );
+          const existsBefore = before.imported.has(occurrence.token);
+          const existsAfter = after.imported.has(occurrence.token);
+          if (direction === "forward" && !existsBefore) {
+            panic("A replace-and-split proof does not match its source owner");
+          }
+          if (direction === "inverse" && !existsAfter) {
+            panic("An inverse replace-and-split proof did not restore its source owner");
+          }
+          if (occurrence.token === transition.retained?.token) {
+            continue;
+          }
+          if (direction === "forward" && !existsAfter) {
+            permitted.add(`removed:${occurrence.token}`);
+          }
+          if (direction === "inverse" && !existsBefore) {
+            permitted.add(`added:${occurrence.token}`);
+          }
+          permitted.add(`relocated:${occurrence.token}`);
+        }
+        break;
+      }
+      default: {
+        const exhaustive: never = transition;
+        return exhaustive;
+      }
+    }
+  }
+  return permitted;
+};
+
+const isYjsTransaction = (transaction: Transaction): boolean =>
+  transaction.getMeta(ySyncPluginKey) !== undefined;
+
+const adjacentParagraphBefore = (
+  snapshot: OwnershipSnapshot,
+  target: ParagraphOccurrence,
+): ParagraphOccurrence | undefined =>
+  snapshot.paragraphs.find((paragraph) => paragraph.pos + paragraph.node.nodeSize === target.pos);
+
+const remoteSplitIsProven = (
+  token: string,
+  transaction: Transaction,
+  before: OwnershipSnapshot,
+  after: OwnershipSnapshot,
+): boolean => {
+  const source = before.imported.get(token);
+  const target = after.imported.get(token);
+  if (!source || !target) {
+    return false;
+  }
+  const targetParagraph = after.paragraphs.find((paragraph) => paragraph.pos === target.pos);
+  if (!targetParagraph) {
+    return false;
+  }
+  const left = adjacentParagraphBefore(after, targetParagraph);
+  if (!left || left.state.type !== "editor-created") {
+    return false;
+  }
+  if (!source.node.content.eq(left.node.content.append(target.node.content))) {
+    return false;
+  }
+  return (
+    transaction.mapping.map(source.pos, -1) === left.pos &&
+    transaction.mapping.map(source.pos + source.nodeSize, 1) === target.pos + target.nodeSize
+  );
+};
+
+const remoteJoinProofs = (
+  transaction: Transaction,
+  before: OwnershipSnapshot,
+  after: OwnershipSnapshot,
+): ReadonlySet<string> => {
+  const permitted = new Set<string>();
+  for (let index = 0; index + 1 < before.paragraphs.length; index += 1) {
+    const left = before.paragraphs[index];
+    const right = before.paragraphs[index + 1];
+    if (!left || !right || left.pos + left.node.nodeSize !== right.pos) {
+      continue;
+    }
+    const leftToken = left.state.type === "imported" ? left.state.token : null;
+    const rightToken = right.state.type === "imported" ? right.state.token : null;
+    if (leftToken === null && rightToken === null) {
+      continue;
+    }
+    const mappedStart = transaction.mapping.map(left.pos, -1);
+    const mappedEnd = transaction.mapping.map(right.pos + right.node.nodeSize, 1);
+    const joinedCandidates = after.paragraphs.filter(
+      (paragraph) =>
+        paragraph.pos >= Math.min(mappedStart, mappedEnd) &&
+        paragraph.pos <= Math.max(mappedStart, mappedEnd) &&
+        paragraph.node.content.eq(left.node.content.append(right.node.content)),
+    );
+    const joined = joinedCandidates.length === 1 ? joinedCandidates.at(0) : undefined;
+    if (!joined || joined.state.type !== "imported") {
+      continue;
+    }
+    const retainedToken = joined.state.token;
+    if (retainedToken !== leftToken && retainedToken !== rightToken) {
+      continue;
+    }
+    permitted.add(`relocated:${retainedToken}`);
+    const displacedToken = retainedToken === leftToken ? rightToken : leftToken;
+    if (displacedToken !== null) {
+      permitted.add(`removed:${displacedToken}`);
+    }
+  }
+  return permitted;
+};
+
+const remoteTransitionProofs = (
+  exceptions: readonly OwnershipException[],
+  transaction: Transaction,
+  before: OwnershipSnapshot,
+  after: OwnershipSnapshot,
+  knownOwners: ReadonlyMap<string, ImportedOccurrence>,
+): ReadonlySet<string> => {
+  const permitted = new Set(remoteJoinProofs(transaction, before, after));
+  for (const exception of exceptions) {
+    if (exception.type === "added") {
+      const known = knownOwners.get(exception.token);
+      const restored = after.imported.get(exception.token);
+      if (
+        known &&
+        restored &&
+        known.node.eq(restored.node) &&
+        (transaction.mapping.map(known.pos, -1) === restored.pos ||
+          transaction.mapping.map(known.pos, 1) === restored.pos)
+      ) {
+        permitted.add(`added:${exception.token}`);
+      }
+      continue;
+    }
+    if (exception.type === "removed") {
+      const source = before.imported.get(exception.token);
+      if (source && transaction.mapping.mapResult(source.pos + 1, -1).deletedAcross) {
+        permitted.add(`removed:${exception.token}`);
+      }
+      continue;
+    }
+    if (
+      exception.type === "relocated" &&
+      remoteSplitIsProven(exception.token, transaction, before, after)
+    ) {
+      permitted.add(`relocated:${exception.token}`);
+    }
+  }
+  return permitted;
+};
+
+const advanceKnownOwners = (
+  knownOwners: ReadonlyMap<string, ImportedOccurrence>,
+  after: OwnershipSnapshot,
+  transaction: Transaction,
+): ReadonlyMap<string, ImportedOccurrence> => {
+  const next = new Map<string, ImportedOccurrence>();
+  for (const [token, known] of knownOwners) {
+    const current = after.imported.get(token);
+    next.set(
+      token,
+      current ??
+        Object.freeze({
+          ...known,
+          pos: transaction.mapping.map(known.pos, -1),
+        }),
+    );
+  }
+  for (const [token, current] of after.imported) {
+    if (!next.has(token)) {
+      next.set(token, current);
+    }
+  }
+  return next;
+};
+
+/** Nominal transaction context created by a complete PM/Yjs ownership census. */
+export class ParagraphPropertyDocumentContext {
+  readonly #contract: ParagraphPropertySourceContract | null;
+  readonly #knownOwners: ReadonlyMap<string, ImportedOccurrence>;
+  readonly #snapshot: OwnershipSnapshot;
+  readonly #story: ParagraphPropertySourceStory;
+
+  private constructor(
+    contract: ParagraphPropertySourceContract | null,
+    snapshot: OwnershipSnapshot,
+    knownOwners: ReadonlyMap<string, ImportedOccurrence>,
+    story: ParagraphPropertySourceStory,
+  ) {
+    this.#contract = contract;
+    this.#snapshot = snapshot;
+    this.#knownOwners = knownOwners;
+    this.#story = story;
+    Object.freeze(this);
+  }
+
+  static fromDocument(
+    doc: PMNode,
+    story: ParagraphPropertySourceStory,
+  ): ParagraphPropertyDocumentContext {
+    const contract = readContract(doc);
+    const snapshot = ownershipSnapshot(doc, contract, story);
+    return new ParagraphPropertyDocumentContext(
+      contract,
+      snapshot,
+      new Map(snapshot.imported),
+      story,
+    );
+  }
+
+  advance(transaction: Transaction): ParagraphPropertyDocumentContext {
+    const contract = readContract(transaction.doc);
+    if (contract?.serialized !== this.#contract?.serialized) {
+      throw new ParagraphPropertySourceValidationError({
+        code: "contract_mismatch",
+        message: "A transaction changed its paragraph-property source contract.",
+      });
+    }
+    const after = ownershipSnapshot(transaction.doc, contract, this.#story);
+    const exceptions = ownershipExceptions(this.#snapshot, after, transaction);
+    const proofs = proofExceptions(transaction, this.#snapshot, after);
+    const yjs = isYjsTransaction(transaction);
+    const remoteProofs = yjs
+      ? remoteTransitionProofs(exceptions, transaction, this.#snapshot, after, this.#knownOwners)
+      : new Set<string>();
+    for (const exception of exceptions) {
+      if (proofs.has(`${exception.type}:${exception.token}`)) {
+        continue;
+      }
+      if (remoteProofs.has(`${exception.type}:${exception.token}`)) {
+        continue;
+      }
+      throw new ParagraphPropertySourceValidationError({
+        code: "ownership_transition_mismatch",
+        message: yjs
+          ? "A remote paragraph-property ownership transition is ambiguous."
+          : "A local paragraph-property ownership transition lacks an issuer-minted proof.",
+        token: exception.token,
+      });
+    }
+    return new ParagraphPropertyDocumentContext(
+      contract,
+      after,
+      advanceKnownOwners(this.#knownOwners, after, transaction),
+      this.#story,
+    );
+  }
+}

--- a/packages/core/src/prosemirror/paragraphPropertyProjection.ts
+++ b/packages/core/src/prosemirror/paragraphPropertyProjection.ts
@@ -1,0 +1,108 @@
+import {
+  PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR,
+  PARAGRAPH_FORMATTING_PROPERTY_KEY_LIST,
+  PARAGRAPH_PROPERTY_OWNER,
+  PARAGRAPH_PROPERTY_PROJECTION,
+  PARAGRAPH_STYLE_TRANSITION,
+  type ParagraphPropertyDescriptor,
+} from "../docx/paragraphPropertyDescriptor";
+import type { ParagraphAttrs } from "./schema/nodes";
+
+export * from "../docx/paragraphPropertyDescriptor";
+
+type ParagraphFormattingPropertyKey = keyof typeof PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR;
+
+/**
+ * Total ProseMirror projection of the representation-neutral formatting model.
+ *
+ * This companion belongs to the PM adapter: the model-level descriptor must not
+ * depend on schema attr names, while `satisfies` makes both a new model property
+ * and an attr rename fail compilation here.
+ */
+export const PARAGRAPH_FORMATTING_PROPERTY_ATTRS = {
+  alignment: ["alignment"],
+  bidi: ["direction"],
+  kinsoku: ["kinsoku"],
+  overflowPunctuation: ["overflowPunctuation"],
+  spaceBefore: ["spaceBefore"],
+  spaceAfter: ["spaceAfter"],
+  lineSpacing: ["lineSpacing"],
+  lineSpacingRule: ["lineSpacingRule", "lineSpacingExplicit"],
+  snapToGrid: ["snapToGrid"],
+  beforeAutospacing: ["_autospacingBase"],
+  afterAutospacing: ["_autospacingBase"],
+  spacingExplicit: ["spacingExplicit"],
+  indentLeft: ["indentLeft"],
+  indentRight: ["indentRight"],
+  indentFirstLine: ["indentFirstLine"],
+  hangingIndent: ["hangingIndent"],
+  numberingLevelIndent: ["_numberingLevelIndent"],
+  borders: ["borders"],
+  shading: ["shading"],
+  tabs: ["tabs"],
+  keepNext: ["keepNext"],
+  keepLines: ["keepLines"],
+  widowControl: ["widowControl"],
+  pageBreakBefore: ["pageBreakBefore"],
+  contextualSpacing: ["contextualSpacing"],
+  numPr: ["numPr"],
+  numPrFromStyle: ["numPrFromStyle"],
+  outlineLevel: ["outlineLevel"],
+  styleId: ["styleId"],
+  frame: ["frame"],
+  suppressLineNumbers: ["suppressLineNumbers"],
+  suppressAutoHyphens: ["suppressAutoHyphens"],
+  runProperties: ["defaultTextFormatting"],
+  runInWithNext: ["runInWithNext"],
+} as const satisfies Record<
+  ParagraphFormattingPropertyKey,
+  readonly (keyof ParagraphAttrs)[]
+>;
+
+type ParagraphPropertyDescriptorAttr =
+  (typeof PARAGRAPH_FORMATTING_PROPERTY_ATTRS)[ParagraphFormattingPropertyKey][number];
+
+const propertyAttrs = (
+  predicate: (descriptor: ParagraphPropertyDescriptor) => boolean,
+): readonly ParagraphPropertyDescriptorAttr[] => {
+  const attrs = new Set<ParagraphPropertyDescriptorAttr>();
+  for (const rawKey of PARAGRAPH_FORMATTING_PROPERTY_KEY_LIST) {
+    const descriptor = PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR[rawKey];
+    if (!predicate(descriptor)) {
+      continue;
+    }
+    for (const attr of PARAGRAPH_FORMATTING_PROPERTY_ATTRS[rawKey]) {
+      attrs.add(attr);
+    }
+  }
+  return [...attrs];
+};
+
+/** Paragraph attrs governed by a `w:pPrChange` CT_PPrBase payload. */
+export const PPR_CHANGE_SCOPED_ATTR_KEYS = propertyAttrs(
+  ({ owner }) => owner === PARAGRAPH_PROPERTY_OWNER.pPrBase,
+);
+
+/** The direct boolean attr class serialized as OOXML on/off properties. */
+export const PPR_CHANGE_BOOLEAN_ATTR_KEYS = propertyAttrs(
+  ({ owner, projection }) =>
+    owner === PARAGRAPH_PROPERTY_OWNER.pPrBase &&
+    projection === PARAGRAPH_PROPERTY_PROJECTION.boolean,
+);
+
+/** Paragraph-mark attrs governed beside, but not inside, CT_PPrBase state. */
+export const PARAGRAPH_MARK_ATTR_KEYS = propertyAttrs(
+  ({ owner }) => owner === PARAGRAPH_PROPERTY_OWNER.paragraphMark,
+);
+
+export const PPR_SPACING_ATTR_KEYS: ReadonlySet<keyof ParagraphAttrs> = new Set(
+  propertyAttrs(({ projection }) => projection === PARAGRAPH_PROPERTY_PROJECTION.spacing),
+);
+
+export const PPR_INDENT_ATTR_KEYS: ReadonlySet<keyof ParagraphAttrs> = new Set(
+  propertyAttrs(({ projection }) => projection === PARAGRAPH_PROPERTY_PROJECTION.indentation),
+);
+
+export const PPR_STYLE_REPLACED_ATTR_KEYS = propertyAttrs(
+  ({ styleTransition }) => styleTransition === PARAGRAPH_STYLE_TRANSITION.replace,
+);

--- a/packages/core/src/prosemirror/paragraphPropertyProjection.ts
+++ b/packages/core/src/prosemirror/paragraphPropertyProjection.ts
@@ -36,7 +36,7 @@ export const PARAGRAPH_FORMATTING_PROPERTY_ATTRS = {
   indentRight: ["indentRight"],
   indentFirstLine: ["indentFirstLine"],
   hangingIndent: ["hangingIndent"],
-  numberingLevelIndent: ["_numberingLevelIndent"],
+  numberingLevelIndent: [],
   borders: ["borders"],
   shading: ["shading"],
   tabs: ["tabs"],
@@ -75,7 +75,7 @@ const propertyAttrs = (
       attrs.add(attr);
     }
   }
-  return [...attrs];
+  return Object.freeze([...attrs]);
 };
 
 /** Paragraph attrs governed by a `w:pPrChange` CT_PPrBase payload. */
@@ -95,13 +95,19 @@ export const PARAGRAPH_MARK_ATTR_KEYS = propertyAttrs(
   ({ owner }) => owner === PARAGRAPH_PROPERTY_OWNER.paragraphMark,
 );
 
-export const PPR_SPACING_ATTR_KEYS: ReadonlySet<keyof ParagraphAttrs> = new Set(
+export const PPR_SPACING_ATTR_KEY_LIST = Object.freeze(
   propertyAttrs(({ projection }) => projection === PARAGRAPH_PROPERTY_PROJECTION.spacing),
 );
+const PPR_SPACING_ATTR_KEY_SET = new Set<keyof ParagraphAttrs>(PPR_SPACING_ATTR_KEY_LIST);
+export const isPprSpacingAttr = (key: keyof ParagraphAttrs): boolean =>
+  PPR_SPACING_ATTR_KEY_SET.has(key);
 
-export const PPR_INDENT_ATTR_KEYS: ReadonlySet<keyof ParagraphAttrs> = new Set(
+export const PPR_INDENT_ATTR_KEY_LIST = Object.freeze(
   propertyAttrs(({ projection }) => projection === PARAGRAPH_PROPERTY_PROJECTION.indentation),
 );
+const PPR_INDENT_ATTR_KEY_SET = new Set<keyof ParagraphAttrs>(PPR_INDENT_ATTR_KEY_LIST);
+export const isPprIndentAttr = (key: keyof ParagraphAttrs): boolean =>
+  PPR_INDENT_ATTR_KEY_SET.has(key);
 
 export const PPR_STYLE_REPLACED_ATTR_KEYS = propertyAttrs(
   ({ styleTransition }) => styleTransition === PARAGRAPH_STYLE_TRANSITION.replace,

--- a/packages/core/src/prosemirror/paragraphPropertyProjection.ts
+++ b/packages/core/src/prosemirror/paragraphPropertyProjection.ts
@@ -5,12 +5,75 @@ import {
   PARAGRAPH_PROPERTY_PROJECTION,
   PARAGRAPH_STYLE_TRANSITION,
   type ParagraphPropertyDescriptor,
-} from "../docx/paragraphPropertyDescriptor";
-import type { ParagraphAttrs } from "./schema/nodes";
-
-export * from "../docx/paragraphPropertyDescriptor";
+} from "@stll/docx-core/model";
+import type { ParagraphAttrs, ParagraphPropertyProjectedAttrs } from "./schema/nodes";
 
 type ParagraphFormattingPropertyKey = keyof typeof PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR;
+
+export const PARAGRAPH_PROPERTY_PROJECTED_ATTR_ROLE = {
+  state: "state",
+  effective: "effective",
+  provenance: "provenance",
+} as const;
+
+/** Total ownership decision for every attr derived from paragraph-property state. */
+export const PARAGRAPH_PROPERTY_PROJECTED_ATTR_DESCRIPTOR = {
+  _paragraphPropertyState: "state",
+  alignment: "effective",
+  alignmentFromStyle: "provenance",
+  kinsoku: "effective",
+  overflowPunctuation: "effective",
+  suppressAutoHyphens: "effective",
+  suppressLineNumbers: "effective",
+  spaceBefore: "effective",
+  spaceAfter: "effective",
+  lineSpacing: "effective",
+  lineSpacingRule: "effective",
+  lineSpacingExplicit: "provenance",
+  snapToGrid: "effective",
+  spacingExplicit: "provenance",
+  spacingFromDocDefaults: "provenance",
+  spacingFromImplicitDefaultStyle: "provenance",
+  indentLeft: "effective",
+  indentRight: "effective",
+  indentFirstLine: "effective",
+  hangingIndent: "effective",
+  _sourceIndentation: "provenance",
+  numPr: "effective",
+  numPrFromStyle: "provenance",
+  styleId: "effective",
+  borders: "effective",
+  shading: "effective",
+  tabs: "effective",
+  pageBreakBefore: "effective",
+  keepNext: "effective",
+  keepLines: "effective",
+  widowControl: "effective",
+  contextualSpacing: "effective",
+  defaultTextFormatting: "effective",
+  runInWithNext: "effective",
+  direction: "effective",
+  outlineLevel: "effective",
+  frame: "effective",
+  _autospacingBase: "provenance",
+} as const satisfies Record<
+  keyof ParagraphPropertyProjectedAttrs,
+  (typeof PARAGRAPH_PROPERTY_PROJECTED_ATTR_ROLE)[keyof typeof PARAGRAPH_PROPERTY_PROJECTED_ATTR_ROLE]
+>;
+
+// SAFETY: the total map establishes the exact projected-attr key union.
+export const PARAGRAPH_PROPERTY_PROJECTED_ATTR_KEY_LIST = Object.freeze(
+  Object.keys(PARAGRAPH_PROPERTY_PROJECTED_ATTR_DESCRIPTOR) as (
+    keyof ParagraphPropertyProjectedAttrs
+  )[],
+);
+const PARAGRAPH_PROPERTY_PROJECTED_ATTR_KEY_SET = new Set<string>(
+  PARAGRAPH_PROPERTY_PROJECTED_ATTR_KEY_LIST,
+);
+export const isParagraphPropertyProjectedAttr = (
+  key: string,
+): key is keyof ParagraphPropertyProjectedAttrs =>
+  PARAGRAPH_PROPERTY_PROJECTED_ATTR_KEY_SET.has(key);
 
 /**
  * Total ProseMirror projection of the representation-neutral formatting model.

--- a/packages/core/src/prosemirror/paragraphPropertyState.test.ts
+++ b/packages/core/src/prosemirror/paragraphPropertyState.test.ts
@@ -8,6 +8,7 @@ import {
 import {
   canonicalParagraphPropertySourceFingerprintJson,
   PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR,
+  paragraphFormattingWithPropertySourceFingerprint,
   paragraphPropertySourceFingerprintFromFormatting,
   paragraphPropertySourceFingerprintFromParts,
   type AuthoredParagraphProperties,
@@ -17,9 +18,9 @@ import {
   createImportedParagraphPropertyState,
   createTransientTemplateParagraphPropertyState,
   joinParagraphPropertyStates,
+  paragraphPropertyStateAttribute,
   readPersistableParagraphPropertyState,
   readParagraphPropertyState,
-  serializeParagraphPropertyState,
   serializePersistableParagraphPropertyState,
   splitParagraphPropertyState,
   transitionParagraphPropertyState,
@@ -27,7 +28,8 @@ import {
 import {
   assertParagraphPropertyInvariant,
   createEditorParagraphProperties,
-  paragraphAttrsFromExternalDomImport,
+  paragraphDomGetAttrs,
+  paragraphPropertiesFromExternalDomImport,
   preserveParagraphProperties,
 } from "./paragraphPropertyMutation";
 import type { ParagraphAttrs } from "./schema/nodes";
@@ -74,6 +76,26 @@ const token = (): ParagraphPropertySourceToken =>
     0,
   );
 
+const EMPTY_CONTEXT = {
+  inheritedPPr: {},
+  numberingLevelIndent: null,
+  numPrFromStyle: null,
+  paragraphMark: { authored: {}, effective: {} },
+  spacingInheritance: {},
+} as const;
+
+type ExternalImportOptions = Parameters<typeof paragraphPropertiesFromExternalDomImport>[0];
+const attrsFromExternalDom = (options: ExternalImportOptions): ParagraphAttrs => {
+  const getAttrs = paragraphDomGetAttrs(() =>
+    paragraphPropertiesFromExternalDomImport(options),
+  );
+  const attrs = getAttrs(undefined);
+  if (attrs === false) {
+    throw new Error("Expected projected paragraph attrs");
+  }
+  return attrs;
+};
+
 describe("mandatory paragraph property state", () => {
   test("the exhaustive authored fixture covers every descriptor-owned pPr property", () => {
     const descriptorKeys = Object.entries(PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR)
@@ -115,6 +137,36 @@ describe("mandatory paragraph property state", () => {
         }),
       ),
     );
+    expect(
+      paragraphFormattingWithPropertySourceFingerprint(
+        {
+          alignment: "right",
+          kinsoku: true,
+          numberingLevelIndent: {
+            type: "latent",
+            numId: 4,
+            ilvl: 1,
+            baseline: { indentLeft: 720 },
+          },
+          runProperties: { italic: true },
+        },
+        paragraphPropertySourceFingerprintFromParts(
+          { alignment: "center", kinsoku: false },
+          { runProperties: { bold: false }, runInWithNext: false },
+        ),
+      ),
+    ).toEqual({
+      alignment: "center",
+      kinsoku: false,
+      numberingLevelIndent: {
+        type: "latent",
+        numId: 4,
+        ilvl: 1,
+        baseline: { indentLeft: 720 },
+      },
+      runProperties: { bold: false },
+      runInWithNext: false,
+    });
   });
 
   test("reifies wire state into nominal, deeply immutable trusted state", () => {
@@ -122,6 +174,7 @@ describe("mandatory paragraph property state", () => {
       type: "imported",
       token: token().serialized,
       authoredPPr: ALL_AUTHORED_PROPERTIES,
+      context: EMPTY_CONTEXT,
     };
 
     const result = readParagraphPropertyState(serialized);
@@ -136,17 +189,18 @@ describe("mandatory paragraph property state", () => {
     expect(Object.isFrozen(result.value.authoredPPr.borders?.bottom)).toBe(true);
     expect(result.value.authoredPPr.kinsoku).toBe(false);
     expect(result.value.authoredPPr.numPr).toEqual({ ilvl: 2 });
-    expect(serializeParagraphPropertyState(result.value)).toEqual(serialized);
+    expect(serializePersistableParagraphPropertyState(result.value)).toEqual(serialized);
   });
 
   test("keeps empty authored pPr distinct from missing or invalid state", () => {
     expect(readParagraphPropertyState(undefined)).toEqual({ status: "absent" });
     expect(readParagraphPropertyState({ type: "editor-created" }).status).toBe("invalid");
 
-    const state = createEditorParagraphPropertyState({});
+    const state = createEditorParagraphPropertyState();
     expect(serializePersistableParagraphPropertyState(state)).toEqual({
       type: "editor-created",
       authoredPPr: {},
+      context: EMPTY_CONTEXT,
     });
   });
 
@@ -160,14 +214,19 @@ describe("mandatory paragraph property state", () => {
       { tabs: [{ position: 720, alignment: "invented" }] },
       { kinsoku: null },
     ]) {
-      expect(readParagraphPropertyState({ type: "editor-created", authoredPPr }).status).toBe(
-        "invalid",
-      );
+      expect(
+        readParagraphPropertyState({
+          type: "editor-created",
+          authoredPPr,
+          context: EMPTY_CONTEXT,
+        }).status,
+      ).toBe("invalid");
     }
     expect(
       readParagraphPropertyState({
         type: "editor-created",
         authoredPPr: {},
+        context: EMPTY_CONTEXT,
         token: token().serialized,
       }).status,
     ).toBe("invalid");
@@ -175,19 +234,27 @@ describe("mandatory paragraph property state", () => {
 
   test("patches exact authored values without losing imported identity", () => {
     const sourceToken = token();
-    const initial = createImportedParagraphPropertyState(sourceToken, {
-      kinsoku: false,
-      overflowPunctuation: true,
-      numPr: { ilvl: 4 },
+    const initial = createImportedParagraphPropertyState({
+      token: sourceToken,
+      authoredPPr: {
+        kinsoku: false,
+        overflowPunctuation: true,
+        numPr: { ilvl: 4 },
+      },
+      context: EMPTY_CONTEXT,
     });
 
     const next = transitionParagraphPropertyState(initial, {
-      type: "mutate-authored",
-      mutations: [
-        { key: "kinsoku", mutation: { type: "set", value: true } },
-        { key: "overflowPunctuation", mutation: { type: "remove" } },
-        { key: "numPr", mutation: { type: "set", value: { numId: 8 } } },
-      ],
+      type: "update",
+      authored: {
+        type: "mutate",
+        mutations: [
+          { key: "kinsoku", mutation: { type: "set", value: true } },
+          { key: "overflowPunctuation", mutation: { type: "remove" } },
+          { key: "numPr", mutation: { type: "set", value: { numId: 8 } } },
+        ],
+      },
+      context: { type: "preserve" },
     });
 
     expect(next.type).toBe("imported");
@@ -198,17 +265,25 @@ describe("mandatory paragraph property state", () => {
     expect(next.authoredPPr).toEqual({ kinsoku: true, numPr: { numId: 8 } });
     expect(() =>
       transitionParagraphPropertyState(initial, {
-        type: "mutate-authored",
-        mutations: [
-          { key: "kinsoku", mutation: { type: "remove" } },
-          { key: "kinsoku", mutation: { type: "set", value: true } },
-        ],
+        type: "update",
+        authored: {
+          type: "mutate",
+          mutations: [
+            { key: "kinsoku", mutation: { type: "remove" } },
+            { key: "kinsoku", mutation: { type: "set", value: true } },
+          ],
+        },
+        context: { type: "preserve" },
       }),
     ).toThrow("Paragraph-property mutation batch contains duplicate key: kinsoku");
   });
 
   test("models split, copy, join, and transient persistence boundaries explicitly", () => {
-    const imported = createImportedParagraphPropertyState(token(), { keepNext: false });
+    const imported = createImportedParagraphPropertyState({
+      token: token(),
+      authoredPPr: { keepNext: false },
+      context: EMPTY_CONTEXT,
+    });
     const split = splitParagraphPropertyState(imported, {
       type: "split-left-created-right-retains",
     });
@@ -235,27 +310,104 @@ describe("mandatory paragraph property state", () => {
       }),
     ).toBe(imported);
 
-    const transient = createTransientTemplateParagraphPropertyState(
-      ParagraphPropertyTransientTemplateHandle.forOrdinal(0),
-      {},
-    );
-    expect(serializeParagraphPropertyState(transient)).toEqual({
-      type: "transient-template",
-      handle: "folio-ppr-template-v1:0",
+    const transient = createTransientTemplateParagraphPropertyState({
+      handle: ParagraphPropertyTransientTemplateHandle.forOrdinal(0),
       authoredPPr: {},
+      context: EMPTY_CONTEXT,
     });
+    expect(paragraphPropertyStateAttribute(transient)).toBe(transient);
     expect(() => serializePersistableParagraphPropertyState(transient)).toThrow(
       "Transient paragraph-property state cannot cross a persistence boundary",
     );
+    expect(() => JSON.stringify(paragraphPropertyStateAttribute(transient))).toThrow(
+      "Transient paragraph-property state cannot cross a persistence boundary",
+    );
+    expect(readPersistableParagraphPropertyState(transient).status).toBe("invalid");
     expect(
-      readPersistableParagraphPropertyState(serializeParagraphPropertyState(transient)).status,
+      readParagraphPropertyState({
+        type: "transient-template",
+        handle: transient.handle.serialized,
+        authoredPPr: {},
+        context: EMPTY_CONTEXT,
+      }).status,
     ).toBe("invalid");
+  });
+
+  test("rejects malformed context and numbering provenance that can self-prove cache drift", () => {
+    const validContext = {
+      ...EMPTY_CONTEXT,
+      inheritedPPr: { numPr: { numId: 7, ilvl: 0 }, spaceBefore: 120 },
+      numberingLevelIndent: {
+        type: "owned",
+        numId: 7,
+        ilvl: 2,
+        baseline: { indentLeft: 720 },
+        owned: { indentLeft: 720 },
+      },
+      spacingInheritance: { before: "style" },
+    } as const;
+    expect(
+      readParagraphPropertyState({
+        type: "editor-created",
+        authoredPPr: { numPr: { ilvl: 2 } },
+        context: validContext,
+      }).status,
+    ).toBe("valid");
+    expect(
+      readParagraphPropertyState({
+        type: "editor-created",
+        authoredPPr: { numPr: { ilvl: 3 } },
+        context: validContext,
+      }).status,
+    ).toBe("invalid");
+    expect(
+      readParagraphPropertyState({
+        type: "editor-created",
+        authoredPPr: {},
+        context: { ...EMPTY_CONTEXT, spacingInheritance: { before: "style" } },
+      }).status,
+    ).toBe("invalid");
+  });
+
+  test("mutates authored and effective paragraph-mark values explicitly", () => {
+    const initial = createEditorParagraphPropertyState({
+      context: {
+        ...EMPTY_CONTEXT,
+        paragraphMark: {
+          authored: { runProperties: { bold: false }, runInWithNext: false },
+          effective: { defaultTextFormatting: { bold: true }, runInWithNext: false },
+        },
+      },
+    });
+    const next = transitionParagraphPropertyState(initial, {
+      type: "update",
+      authored: { type: "preserve" },
+      context: {
+        type: "mutate-paragraph-mark",
+        authored: [
+          { key: "runProperties", mutation: { type: "set", value: { italic: true } } },
+          { key: "runInWithNext", mutation: { type: "remove" } },
+        ],
+        effective: [
+          {
+            key: "defaultTextFormatting",
+            mutation: { type: "set", value: { italic: true } },
+          },
+          { key: "runInWithNext", mutation: { type: "set", value: true } },
+        ],
+      },
+    });
+
+    expect(next.context.paragraphMark).toEqual({
+      authored: { runProperties: { italic: true } },
+      effective: { defaultTextFormatting: { italic: true }, runInWithNext: true },
+    });
   });
 });
 
 describe("paragraph property projection proof", () => {
   test("keeps exact authored partial numbering separate from fieldwise effective numbering", () => {
-    const attrs = paragraphAttrsFromExternalDomImport({
+    const attrs = attrsFromExternalDom({
       effectiveAttrs: { numPr: { numId: 7, ilvl: 2 }, kinsoku: true },
       authoredAttrs: { numPr: { ilvl: 2 }, kinsoku: false },
       inheritedPPr: { numPr: { numId: 7, ilvl: 0 }, kinsoku: true },
@@ -270,11 +422,20 @@ describe("paragraph property projection proof", () => {
   test("capsules expose no attrs and the preserve path rejects governed drift", () => {
     const projection = createEditorParagraphProperties({
       authoredPPr: { alignment: "center" },
-      context: { inheritedPPr: {}, numberingLevelIndent: null, numPrFromStyle: null },
+      context: {
+        inheritedPPr: {},
+        numberingLevelIndent: null,
+        numPrFromStyle: null,
+        paragraphMark: {
+          authored: { runProperties: { bold: false }, runInWithNext: true },
+          effective: { defaultTextFormatting: { bold: true }, runInWithNext: true },
+        },
+        spacingInheritance: {},
+      },
     });
     expect(Object.keys(projection)).toEqual([]);
 
-    const attrs = paragraphAttrsFromExternalDomImport({
+    const attrs = attrsFromExternalDom({
       effectiveAttrs: { alignment: "center" },
     });
     expect(() => preserveParagraphProperties(attrs, { alignment: "right" })).toThrow(
@@ -286,5 +447,37 @@ describe("paragraph property projection proof", () => {
         { type: "internal" },
       ),
     ).toThrow("Paragraph-property projection invariant failed for attr: alignment");
+  });
+
+  test("projects paragraph-mark source and effective run context without spread-through", () => {
+    const attrs = attrsFromExternalDom({
+      effectiveAttrs: {
+        defaultTextFormatting: { bold: true },
+        runInWithNext: true,
+      },
+      authoredAttrs: {
+        defaultTextFormatting: { bold: false },
+        runInWithNext: false,
+      },
+    });
+
+    const mark = assertParagraphPropertyInvariant(attrs, { type: "internal" }).context
+      .paragraphMark;
+    expect(mark.authored).toEqual({
+      runProperties: { bold: false },
+      runInWithNext: false,
+    });
+    expect(mark.effective).toEqual({
+      defaultTextFormatting: { bold: true },
+      runInWithNext: true,
+    });
+    expect(attrs.defaultTextFormatting).toEqual({ bold: true });
+    expect(attrs.runInWithNext).toBe(true);
+    expect(() =>
+      assertParagraphPropertyInvariant(
+        { ...attrs, defaultTextFormatting: { bold: false } } as ParagraphAttrs,
+        { type: "internal" },
+      ),
+    ).toThrow("Paragraph-property projection invariant failed for attr: defaultTextFormatting");
   });
 });

--- a/packages/core/src/prosemirror/paragraphPropertyState.test.ts
+++ b/packages/core/src/prosemirror/paragraphPropertyState.test.ts
@@ -1,10 +1,4 @@
 import { describe, expect, test } from "bun:test";
-
-import {
-  ParagraphPropertySourceContract,
-  ParagraphPropertySourceToken,
-  ParagraphPropertyTransientTemplateHandle,
-} from "../docx/paragraphPropertySourceIdentity";
 import {
   canonicalParagraphPropertySourceFingerprintJson,
   PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR,
@@ -12,7 +6,11 @@ import {
   paragraphPropertySourceFingerprintFromFormatting,
   paragraphPropertySourceFingerprintFromParts,
   type AuthoredParagraphProperties,
-} from "../docx/paragraphPropertyDescriptor";
+} from "@stll/docx-core/model";
+
+import {
+  ParagraphPropertyTransientTemplateStore,
+} from "../docx/paragraphPropertySourceIdentity";
 import {
   createEditorParagraphPropertyState,
   createImportedParagraphPropertyState,
@@ -69,12 +67,7 @@ const ALL_AUTHORED_PROPERTIES = {
   suppressAutoHyphens: true,
 } satisfies Required<AuthoredParagraphProperties>;
 
-const token = (): ParagraphPropertySourceToken =>
-  ParagraphPropertySourceToken.forOrdinal(
-    ParagraphPropertySourceContract.fromDigest("a".repeat(64)),
-    { type: "document" },
-    0,
-  );
+const SOURCE_TOKEN = "p2s:document::0";
 
 const EMPTY_CONTEXT = {
   inheritedPPr: {},
@@ -172,7 +165,7 @@ describe("mandatory paragraph property state", () => {
   test("reifies wire state into nominal, deeply immutable trusted state", () => {
     const serialized = {
       type: "imported",
-      token: token().serialized,
+      token: SOURCE_TOKEN,
       authoredPPr: ALL_AUTHORED_PROPERTIES,
       context: EMPTY_CONTEXT,
     };
@@ -227,13 +220,13 @@ describe("mandatory paragraph property state", () => {
         type: "editor-created",
         authoredPPr: {},
         context: EMPTY_CONTEXT,
-        token: token().serialized,
+        token: SOURCE_TOKEN,
       }).status,
     ).toBe("invalid");
   });
 
   test("patches exact authored values without losing imported identity", () => {
-    const sourceToken = token();
+    const sourceToken = SOURCE_TOKEN;
     const initial = createImportedParagraphPropertyState({
       token: sourceToken,
       authoredPPr: {
@@ -278,9 +271,9 @@ describe("mandatory paragraph property state", () => {
     ).toThrow("Paragraph-property mutation batch contains duplicate key: kinsoku");
   });
 
-  test("models split, copy, join, and transient persistence boundaries explicitly", () => {
+  test("models split, join, and transient persistence boundaries explicitly", () => {
     const imported = createImportedParagraphPropertyState({
-      token: token(),
+      token: SOURCE_TOKEN,
       authoredPPr: { keepNext: false },
       context: EMPTY_CONTEXT,
     });
@@ -297,7 +290,10 @@ describe("mandatory paragraph property state", () => {
     }
     expect(split.right.token).toBe(imported.token);
 
-    const copied = transitionParagraphPropertyState(imported, { type: "editor-copy" });
+    const copied = createEditorParagraphPropertyState({
+      authoredPPr: imported.authoredPPr,
+      context: imported.context,
+    });
     expect(copied.type).toBe("editor-created");
     expect(
       joinParagraphPropertyStates(imported, copied, {
@@ -310,8 +306,13 @@ describe("mandatory paragraph property state", () => {
       }),
     ).toBe(imported);
 
+    const templateStore = new ParagraphPropertyTransientTemplateStore<string>(1);
+    const handle = templateStore.registerAll(["capture"]).at(0);
+    if (!handle) {
+      throw new Error("Expected one transient template handle");
+    }
     const transient = createTransientTemplateParagraphPropertyState({
-      handle: ParagraphPropertyTransientTemplateHandle.forOrdinal(0),
+      handle,
       authoredPPr: {},
       context: EMPTY_CONTEXT,
     });
@@ -326,7 +327,7 @@ describe("mandatory paragraph property state", () => {
     expect(
       readParagraphPropertyState({
         type: "transient-template",
-        handle: transient.handle.serialized,
+        handle: "forged-handle",
         authoredPPr: {},
         context: EMPTY_CONTEXT,
       }).status,

--- a/packages/core/src/prosemirror/paragraphPropertyState.test.ts
+++ b/packages/core/src/prosemirror/paragraphPropertyState.test.ts
@@ -9,6 +9,7 @@ import {
 } from "@stll/docx-core/model";
 
 import {
+  ParagraphPropertySourceValidationError,
   ParagraphPropertyTransientTemplateStore,
 } from "../docx/paragraphPropertySourceIdentity";
 import {
@@ -67,7 +68,7 @@ const ALL_AUTHORED_PROPERTIES = {
   suppressAutoHyphens: true,
 } satisfies Required<AuthoredParagraphProperties>;
 
-const SOURCE_TOKEN = "p2s:document::0";
+const SOURCE_TOKEN = "p3s:document::0";
 
 const EMPTY_CONTEXT = {
   inheritedPPr: {},
@@ -79,9 +80,7 @@ const EMPTY_CONTEXT = {
 
 type ExternalImportOptions = Parameters<typeof paragraphPropertiesFromExternalDomImport>[0];
 const attrsFromExternalDom = (options: ExternalImportOptions): ParagraphAttrs => {
-  const getAttrs = paragraphDomGetAttrs(() =>
-    paragraphPropertiesFromExternalDomImport(options),
-  );
+  const getAttrs = paragraphDomGetAttrs(() => paragraphPropertiesFromExternalDomImport(options));
   const attrs = getAttrs(undefined);
   if (attrs === false) {
     throw new Error("Expected projected paragraph attrs");
@@ -223,6 +222,41 @@ describe("mandatory paragraph property state", () => {
         token: SOURCE_TOKEN,
       }).status,
     ).toBe("invalid");
+  });
+
+  test("bounds adversarial wire state before recursive validation or cloning", () => {
+    expect(() =>
+      readParagraphPropertyState({
+        type: "editor-created",
+        authoredPPr: { styleId: "x".repeat(16_385) },
+        context: EMPTY_CONTEXT,
+      }),
+    ).toThrow(ParagraphPropertySourceValidationError);
+
+    let nested: Record<string, unknown> = {};
+    for (let depth = 0; depth < 18; depth += 1) {
+      nested = { nested };
+    }
+    expect(() =>
+      readParagraphPropertyState({
+        type: "editor-created",
+        authoredPPr: nested,
+        context: EMPTY_CONTEXT,
+      }),
+    ).toThrow(ParagraphPropertySourceValidationError);
+
+    const withAccessor = {
+      type: "editor-created",
+      authoredPPr: {},
+      context: EMPTY_CONTEXT,
+    };
+    Object.defineProperty(withAccessor.authoredPPr, "styleId", {
+      enumerable: true,
+      get: () => "must-not-run",
+    });
+    expect(() => readParagraphPropertyState(withAccessor)).toThrow(
+      ParagraphPropertySourceValidationError,
+    );
   });
 
   test("patches exact authored values without losing imported identity", () => {
@@ -443,10 +477,9 @@ describe("paragraph property projection proof", () => {
       "Non-governed paragraph mutation changed governed attr: alignment",
     );
     expect(() =>
-      assertParagraphPropertyInvariant(
-        { ...attrs, alignment: "right" } as ParagraphAttrs,
-        { type: "internal" },
-      ),
+      assertParagraphPropertyInvariant({ ...attrs, alignment: "right" } as ParagraphAttrs, {
+        type: "internal",
+      }),
     ).toThrow("Paragraph-property projection invariant failed for attr: alignment");
   });
 

--- a/packages/core/src/prosemirror/paragraphPropertyState.test.ts
+++ b/packages/core/src/prosemirror/paragraphPropertyState.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  ParagraphPropertySourceContract,
+  ParagraphPropertySourceToken,
+  ParagraphPropertyTransientTemplateHandle,
+} from "../docx/paragraphPropertySourceIdentity";
+import {
+  canonicalParagraphPropertySourceFingerprintJson,
+  PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR,
+  paragraphPropertySourceFingerprintFromFormatting,
+  paragraphPropertySourceFingerprintFromParts,
+  type AuthoredParagraphProperties,
+} from "../docx/paragraphPropertyDescriptor";
+import {
+  createEditorParagraphPropertyState,
+  createImportedParagraphPropertyState,
+  createTransientTemplateParagraphPropertyState,
+  joinParagraphPropertyStates,
+  readPersistableParagraphPropertyState,
+  readParagraphPropertyState,
+  serializeParagraphPropertyState,
+  serializePersistableParagraphPropertyState,
+  splitParagraphPropertyState,
+  transitionParagraphPropertyState,
+} from "./paragraphPropertyState";
+import {
+  assertParagraphPropertyInvariant,
+  createEditorParagraphProperties,
+  paragraphAttrsFromExternalDomImport,
+  preserveParagraphProperties,
+} from "./paragraphPropertyMutation";
+import type { ParagraphAttrs } from "./schema/nodes";
+
+const ALL_AUTHORED_PROPERTIES = {
+  alignment: "both",
+  bidi: false,
+  kinsoku: false,
+  overflowPunctuation: true,
+  spaceBefore: 0,
+  spaceAfter: 240,
+  lineSpacing: 360,
+  lineSpacingRule: "exact",
+  snapToGrid: false,
+  beforeAutospacing: false,
+  afterAutospacing: true,
+  spacingExplicit: { before: false, after: true },
+  indentLeft: 720,
+  indentRight: 0,
+  indentFirstLine: -360,
+  hangingIndent: true,
+  borders: {
+    bottom: { style: "single", size: 8, space: 1, shadow: false },
+  },
+  shading: { fill: { rgb: "00FF00" }, pattern: "clear" },
+  tabs: [{ position: 720, alignment: "left", leader: "dot" }],
+  keepNext: false,
+  keepLines: true,
+  widowControl: false,
+  pageBreakBefore: true,
+  contextualSpacing: false,
+  numPr: { ilvl: 2 },
+  outlineLevel: 1,
+  styleId: "BodyText",
+  frame: { hAnchor: "margin", xAlign: "inside", wrap: "around" },
+  suppressLineNumbers: false,
+  suppressAutoHyphens: true,
+} satisfies Required<AuthoredParagraphProperties>;
+
+const token = (): ParagraphPropertySourceToken =>
+  ParagraphPropertySourceToken.forOrdinal(
+    ParagraphPropertySourceContract.fromDigest("a".repeat(64)),
+    { type: "document" },
+    0,
+  );
+
+describe("mandatory paragraph property state", () => {
+  test("the exhaustive authored fixture covers every descriptor-owned pPr property", () => {
+    const descriptorKeys = Object.entries(PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR)
+      .filter(([, descriptor]) => descriptor.owner === "pPr-base")
+      .map(([key]) => key)
+      .toSorted();
+
+    expect(Object.keys(ALL_AUTHORED_PROPERTIES).toSorted()).toEqual(descriptorKeys);
+  });
+
+  test("raw source identity covers pPr base and paragraph-mark properties only", () => {
+    const parsed = paragraphPropertySourceFingerprintFromFormatting({
+      ...ALL_AUTHORED_PROPERTIES,
+      numberingLevelIndent: {
+        type: "latent",
+        numId: 9,
+        ilvl: 0,
+        baseline: { indentLeft: 720 },
+      },
+      numPrFromStyle: { numId: 9 },
+      runProperties: { bold: false },
+      runInWithNext: true,
+    });
+    const composed = paragraphPropertySourceFingerprintFromParts(ALL_AUTHORED_PROPERTIES, {
+      runProperties: { bold: false },
+      runInWithNext: true,
+    });
+
+    expect(parsed).toEqual(composed);
+    expect(parsed).toEqual({
+      pPrBase: ALL_AUTHORED_PROPERTIES,
+      paragraphMark: { runProperties: { bold: false }, runInWithNext: true },
+    });
+    expect(canonicalParagraphPropertySourceFingerprintJson(parsed)).not.toBe(
+      canonicalParagraphPropertySourceFingerprintJson(
+        paragraphPropertySourceFingerprintFromParts(ALL_AUTHORED_PROPERTIES, {
+          runProperties: { bold: true },
+          runInWithNext: true,
+        }),
+      ),
+    );
+  });
+
+  test("reifies wire state into nominal, deeply immutable trusted state", () => {
+    const serialized = {
+      type: "imported",
+      token: token().serialized,
+      authoredPPr: ALL_AUTHORED_PROPERTIES,
+    };
+
+    const result = readParagraphPropertyState(serialized);
+
+    expect(result.status).toBe("valid");
+    if (result.status !== "valid") {
+      throw new Error("Expected valid paragraph-property state");
+    }
+    expect(result.value.type).toBe("imported");
+    expect(Object.isFrozen(result.value)).toBe(true);
+    expect(Object.isFrozen(result.value.authoredPPr)).toBe(true);
+    expect(Object.isFrozen(result.value.authoredPPr.borders?.bottom)).toBe(true);
+    expect(result.value.authoredPPr.kinsoku).toBe(false);
+    expect(result.value.authoredPPr.numPr).toEqual({ ilvl: 2 });
+    expect(serializeParagraphPropertyState(result.value)).toEqual(serialized);
+  });
+
+  test("keeps empty authored pPr distinct from missing or invalid state", () => {
+    expect(readParagraphPropertyState(undefined)).toEqual({ status: "absent" });
+    expect(readParagraphPropertyState({ type: "editor-created" }).status).toBe("invalid");
+
+    const state = createEditorParagraphPropertyState({});
+    expect(serializePersistableParagraphPropertyState(state)).toEqual({
+      type: "editor-created",
+      authoredPPr: {},
+    });
+  });
+
+  test("rejects non-authored, malformed, and ambiguous wire payloads", () => {
+    for (const authoredPPr of [
+      { runProperties: { bold: true } },
+      { numberingLevelIndent: { type: "latent" } },
+      { numPrFromStyle: { numId: 1 } },
+      { numPr: { numId: -1 } },
+      { hangingIndent: true, indentFirstLine: 360 },
+      { tabs: [{ position: 720, alignment: "invented" }] },
+      { kinsoku: null },
+    ]) {
+      expect(readParagraphPropertyState({ type: "editor-created", authoredPPr }).status).toBe(
+        "invalid",
+      );
+    }
+    expect(
+      readParagraphPropertyState({
+        type: "editor-created",
+        authoredPPr: {},
+        token: token().serialized,
+      }).status,
+    ).toBe("invalid");
+  });
+
+  test("patches exact authored values without losing imported identity", () => {
+    const sourceToken = token();
+    const initial = createImportedParagraphPropertyState(sourceToken, {
+      kinsoku: false,
+      overflowPunctuation: true,
+      numPr: { ilvl: 4 },
+    });
+
+    const next = transitionParagraphPropertyState(initial, {
+      type: "mutate-authored",
+      mutations: [
+        { key: "kinsoku", mutation: { type: "set", value: true } },
+        { key: "overflowPunctuation", mutation: { type: "remove" } },
+        { key: "numPr", mutation: { type: "set", value: { numId: 8 } } },
+      ],
+    });
+
+    expect(next.type).toBe("imported");
+    if (next.type !== "imported") {
+      throw new Error("Expected imported paragraph-property state");
+    }
+    expect(next.token).toBe(sourceToken);
+    expect(next.authoredPPr).toEqual({ kinsoku: true, numPr: { numId: 8 } });
+    expect(() =>
+      transitionParagraphPropertyState(initial, {
+        type: "mutate-authored",
+        mutations: [
+          { key: "kinsoku", mutation: { type: "remove" } },
+          { key: "kinsoku", mutation: { type: "set", value: true } },
+        ],
+      }),
+    ).toThrow("Paragraph-property mutation batch contains duplicate key: kinsoku");
+  });
+
+  test("models split, copy, join, and transient persistence boundaries explicitly", () => {
+    const imported = createImportedParagraphPropertyState(token(), { keepNext: false });
+    const split = splitParagraphPropertyState(imported, {
+      type: "split-left-created-right-retains",
+    });
+    expect(split.type).toBe("split-left-created-right-retains");
+    expect(split.left.type).toBe("editor-created");
+    expect(split.left.authoredPPr).toEqual({ keepNext: false });
+    expect(split.right).toBe(imported);
+    expect(split.right.type).toBe("imported");
+    if (split.right.type !== "imported") {
+      throw new Error("Expected the right paragraph mark to retain source ownership");
+    }
+    expect(split.right.token).toBe(imported.token);
+
+    const copied = transitionParagraphPropertyState(imported, { type: "editor-copy" });
+    expect(copied.type).toBe("editor-created");
+    expect(
+      joinParagraphPropertyStates(imported, copied, {
+        type: "join-right-paragraph-mark-retains",
+      }),
+    ).toBe(copied);
+    expect(
+      joinParagraphPropertyStates(imported, copied, {
+        type: "join-left-paragraph-mark-retains",
+      }),
+    ).toBe(imported);
+
+    const transient = createTransientTemplateParagraphPropertyState(
+      ParagraphPropertyTransientTemplateHandle.forOrdinal(0),
+      {},
+    );
+    expect(serializeParagraphPropertyState(transient)).toEqual({
+      type: "transient-template",
+      handle: "folio-ppr-template-v1:0",
+      authoredPPr: {},
+    });
+    expect(() => serializePersistableParagraphPropertyState(transient)).toThrow(
+      "Transient paragraph-property state cannot cross a persistence boundary",
+    );
+    expect(
+      readPersistableParagraphPropertyState(serializeParagraphPropertyState(transient)).status,
+    ).toBe("invalid");
+  });
+});
+
+describe("paragraph property projection proof", () => {
+  test("keeps exact authored partial numbering separate from fieldwise effective numbering", () => {
+    const attrs = paragraphAttrsFromExternalDomImport({
+      effectiveAttrs: { numPr: { numId: 7, ilvl: 2 }, kinsoku: true },
+      authoredAttrs: { numPr: { ilvl: 2 }, kinsoku: false },
+      inheritedPPr: { numPr: { numId: 7, ilvl: 0 }, kinsoku: true },
+    });
+
+    const state = assertParagraphPropertyInvariant(attrs, { type: "persistence" });
+    expect(state.authoredPPr).toEqual({ numPr: { ilvl: 2 }, kinsoku: false });
+    expect(attrs.numPr).toEqual({ numId: 7, ilvl: 2 });
+    expect(attrs.kinsoku).toBe(false);
+  });
+
+  test("capsules expose no attrs and the preserve path rejects governed drift", () => {
+    const projection = createEditorParagraphProperties({
+      authoredPPr: { alignment: "center" },
+      context: { inheritedPPr: {}, numberingLevelIndent: null, numPrFromStyle: null },
+    });
+    expect(Object.keys(projection)).toEqual([]);
+
+    const attrs = paragraphAttrsFromExternalDomImport({
+      effectiveAttrs: { alignment: "center" },
+    });
+    expect(() => preserveParagraphProperties(attrs, { alignment: "right" })).toThrow(
+      "Non-governed paragraph mutation changed governed attr: alignment",
+    );
+    expect(() =>
+      assertParagraphPropertyInvariant(
+        { ...attrs, alignment: "right" } as ParagraphAttrs,
+        { type: "internal" },
+      ),
+    ).toThrow("Paragraph-property projection invariant failed for attr: alignment");
+  });
+});

--- a/packages/core/src/prosemirror/paragraphPropertyState.ts
+++ b/packages/core/src/prosemirror/paragraphPropertyState.ts
@@ -13,6 +13,7 @@ import {
 } from "@stll/docx-core/model";
 
 import {
+  ParagraphPropertySourceValidationError,
   ParagraphPropertyTransientTemplateHandle,
   type ParagraphPropertySourceAttribute,
 } from "../docx/paragraphPropertySourceIdentity";
@@ -74,13 +75,10 @@ type DeepReadonly<Value> = Value extends (...args: never[]) => unknown
       ? { readonly [Key in keyof Value]: DeepReadonly<Value[Key]> }
       : Value;
 
-export type ParagraphPropertyProjectionContext = DeepReadonly<
-  SerializedParagraphPropertyProjectionContext
->;
+export type ParagraphPropertyProjectionContext =
+  DeepReadonly<SerializedParagraphPropertyProjectionContext>;
 
-const TRUSTED_PARAGRAPH_PROPERTY_STATE: unique symbol = Symbol(
-  "trusted-paragraph-property-state",
-);
+const TRUSTED_PARAGRAPH_PROPERTY_STATE: unique symbol = Symbol("trusted-paragraph-property-state");
 
 type TrustedParagraphPropertyState = {
   readonly [TRUSTED_PARAGRAPH_PROPERTY_STATE]: true;
@@ -96,7 +94,8 @@ export type PersistableParagraphPropertyState = (
   | {
       readonly type: "editor-created";
     }
-  ) & TrustedParagraphPropertyState;
+) &
+  TrustedParagraphPropertyState;
 
 /** Trusted state used after the serialized PM/Yjs boundary has been validated. */
 export type ParagraphPropertyState =
@@ -170,6 +169,73 @@ type ValidationResult = { valid: true } | { valid: false };
 
 const INVALID: ValidationResult = { valid: false };
 const VALID: ValidationResult = { valid: true };
+
+const PARAGRAPH_PROPERTY_STATE_MAX_DEPTH = 16;
+const PARAGRAPH_PROPERTY_STATE_MAX_NODES = 4_096;
+const PARAGRAPH_PROPERTY_STATE_MAX_LIST_ENTRIES = 1_024;
+const PARAGRAPH_PROPERTY_STATE_MAX_STRING_CODE_UNITS = 16_384;
+
+const assertParagraphPropertyStateBudget = (raw: unknown): void => {
+  const pending: { depth: number; value: unknown }[] = [{ depth: 0, value: raw }];
+  const seen = new WeakSet<object>();
+  let nodeCount = 0;
+  while (pending.length > 0) {
+    const entry = pending.pop();
+    if (!entry) {
+      break;
+    }
+    nodeCount += 1;
+    if (
+      nodeCount > PARAGRAPH_PROPERTY_STATE_MAX_NODES ||
+      entry.depth > PARAGRAPH_PROPERTY_STATE_MAX_DEPTH
+    ) {
+      throw new ParagraphPropertySourceValidationError({
+        code: "state_capacity_exceeded",
+        message: "Paragraph-property state complexity capacity was exceeded.",
+      });
+    }
+    if (typeof entry.value === "string") {
+      if (entry.value.length > PARAGRAPH_PROPERTY_STATE_MAX_STRING_CODE_UNITS) {
+        throw new ParagraphPropertySourceValidationError({
+          code: "state_capacity_exceeded",
+          message: "Paragraph-property state string capacity was exceeded.",
+        });
+      }
+      continue;
+    }
+    if (typeof entry.value !== "object" || entry.value === null) {
+      continue;
+    }
+    if (seen.has(entry.value)) {
+      continue;
+    }
+    seen.add(entry.value);
+    const keys = Reflect.ownKeys(entry.value);
+    if (
+      keys.length > PARAGRAPH_PROPERTY_STATE_MAX_LIST_ENTRIES ||
+      keys.some((key) => typeof key !== "string")
+    ) {
+      throw new ParagraphPropertySourceValidationError({
+        code: "state_capacity_exceeded",
+        message: "Paragraph-property state collection capacity was exceeded.",
+      });
+    }
+    const descriptors = Object.getOwnPropertyDescriptors(entry.value);
+    for (const key of keys) {
+      if (typeof key !== "string") {
+        continue;
+      }
+      const descriptor = descriptors[key];
+      if (!descriptor || !("value" in descriptor)) {
+        throw new ParagraphPropertySourceValidationError({
+          code: "invalid_state",
+          message: "Paragraph-property state cannot contain accessors.",
+        });
+      }
+      pending.push({ depth: entry.depth + 1, value: descriptor.value });
+    }
+  }
+};
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
@@ -549,10 +615,7 @@ const validateTabs = (value: unknown): ValidationResult => {
       if (validation === "required-number" && !isFiniteNumber(property)) {
         return INVALID;
       }
-      if (
-        validation === "required-alignment" &&
-        !isOneOf(property, TAB_STOP_ALIGNMENT_VALUES)
-      ) {
+      if (validation === "required-alignment" && !isOneOf(property, TAB_STOP_ALIGNMENT_VALUES)) {
         return INVALID;
       }
       if (
@@ -635,16 +698,10 @@ const validateFrame = (value: unknown): ValidationResult => {
     if (validation === "drop-cap" && !isOneOf(property, ["none", "drop", "margin"])) {
       return INVALID;
     }
-    if (
-      validation === "horizontal-anchor" &&
-      !isOneOf(property, ["text", "margin", "page"])
-    ) {
+    if (validation === "horizontal-anchor" && !isOneOf(property, ["text", "margin", "page"])) {
       return INVALID;
     }
-    if (
-      validation === "vertical-anchor" &&
-      !isOneOf(property, ["text", "margin", "page"])
-    ) {
+    if (validation === "vertical-anchor" && !isOneOf(property, ["text", "margin", "page"])) {
       return INVALID;
     }
     if (validation === "horizontal-alignment" && !isOneOf(property, FRAME_X_ALIGN_VALUES)) {
@@ -832,9 +889,7 @@ const validateNumberingLevelIndentGeometry = (
   if (!isRecord(value) || !hasOnlyKeys(value, NUMBERING_LEVEL_INDENT_GEOMETRY_KEYS)) {
     return INVALID;
   }
-  for (const [key, validation] of Object.entries(
-    NUMBERING_LEVEL_INDENT_GEOMETRY_VALIDATION,
-  )) {
+  for (const [key, validation] of Object.entries(NUMBERING_LEVEL_INDENT_GEOMETRY_VALIDATION)) {
     const property = value[key];
     if (property === undefined) {
       continue;
@@ -917,10 +972,7 @@ const validateNumberingLevelIndent = (value: unknown): ValidationResult => {
 const PARAGRAPH_MARK_EFFECTIVE_VALIDATION = {
   defaultTextFormatting: "text-formatting",
   runInWithNext: "boolean",
-} as const satisfies Record<
-  keyof ParagraphMarkEffectiveProperties,
-  "boolean" | "text-formatting"
->;
+} as const satisfies Record<keyof ParagraphMarkEffectiveProperties, "boolean" | "text-formatting">;
 const PARAGRAPH_MARK_EFFECTIVE_KEYS = new Set<string>(
   Object.keys(PARAGRAPH_MARK_EFFECTIVE_VALIDATION),
 );
@@ -948,9 +1000,7 @@ const PARAGRAPH_MARK_CONTEXT_VALIDATION = {
   authored: "paragraph-mark",
   effective: "effective",
 } as const satisfies Record<keyof ParagraphMarkProjectionContext, "effective" | "paragraph-mark">;
-const PARAGRAPH_MARK_CONTEXT_KEYS = new Set<string>(
-  Object.keys(PARAGRAPH_MARK_CONTEXT_VALIDATION),
-);
+const PARAGRAPH_MARK_CONTEXT_KEYS = new Set<string>(Object.keys(PARAGRAPH_MARK_CONTEXT_VALIDATION));
 
 const validateParagraphMarkContext = (value: unknown): ValidationResult => {
   if (!isRecord(value) || !hasOnlyKeys(value, PARAGRAPH_MARK_CONTEXT_KEYS)) {
@@ -977,9 +1027,7 @@ const validateParagraphSpacingInheritance = (value: unknown): ValidationResult =
   if (!isRecord(value) || !hasOnlyKeys(value, PARAGRAPH_SPACING_INHERITANCE_KEYS)) {
     return INVALID;
   }
-  return Object.values(value).every((entry) =>
-    isOneOf(entry, PARAGRAPH_SPACING_INHERITANCE_VALUES),
-  )
+  return Object.values(value).every((entry) => isOneOf(entry, PARAGRAPH_SPACING_INHERITANCE_VALUES))
     ? VALID
     : INVALID;
 };
@@ -1007,10 +1055,7 @@ const validateParagraphPropertyProjectionContext = (value: unknown): ValidationR
     return INVALID;
   }
   const numberingLevelIndent = value["numberingLevelIndent"];
-  if (
-    numberingLevelIndent !== null &&
-    !validateNumberingLevelIndent(numberingLevelIndent).valid
-  ) {
+  if (numberingLevelIndent !== null && !validateNumberingLevelIndent(numberingLevelIndent).valid) {
     return INVALID;
   }
   const numPrFromStyle = value["numPrFromStyle"];
@@ -1089,7 +1134,7 @@ const trustedParagraphPropertyPayload = (
 type UntrustedStateBranch =
   | {
       type: "imported";
-      token: ParagraphPropertySourceToken;
+      token: string;
       authoredPPr: AuthoredParagraphProperties;
       context: ParagraphPropertyProjectionContext;
     }
@@ -1118,8 +1163,7 @@ const trustParagraphPropertyState = <Branch extends UntrustedStateBranch>(
     Object.defineProperty(state, "toJSON", {
       configurable: false,
       enumerable: false,
-      value: () =>
-        panic("Transient paragraph-property state cannot cross a persistence boundary"),
+      value: () => panic("Transient paragraph-property state cannot cross a persistence boundary"),
       writable: false,
     });
   }
@@ -1209,6 +1253,7 @@ export const readParagraphPropertyState = (
   if (isTrustedParagraphPropertyState(raw)) {
     return { status: "valid", value: raw };
   }
+  assertParagraphPropertyStateBudget(raw);
   if (!isRecord(raw) || typeof raw["type"] !== "string") {
     return { raw, status: "invalid" };
   }
@@ -1234,7 +1279,10 @@ export const readParagraphPropertyState = (
     case "imported": {
       const token = raw["token"];
       return typeof token === "string" && token.length > 0
-        ? { status: "valid", value: trustParagraphPropertyState({ type, token, authoredPPr, context }) }
+        ? {
+            status: "valid",
+            value: trustParagraphPropertyState({ type, token, authoredPPr, context }),
+          }
         : { raw, status: "invalid" };
     }
     case "editor-created":

--- a/packages/core/src/prosemirror/paragraphPropertyState.ts
+++ b/packages/core/src/prosemirror/paragraphPropertyState.ts
@@ -1,0 +1,744 @@
+import { panic } from "better-result";
+
+import {
+  ParagraphPropertySourceToken,
+  ParagraphPropertyTransientTemplateHandle,
+  type ParagraphPropertySourceAttribute,
+} from "../docx/paragraphPropertySourceIdentity";
+import {
+  FRAME_WRAP_VALUES,
+  FRAME_X_ALIGN_VALUES,
+  FRAME_Y_ALIGN_VALUES,
+  LINE_SPACING_RULE_VALUES,
+  PARAGRAPH_ALIGNMENT_VALUES,
+  SHADING_PATTERN_VALUES,
+  TAB_LEADER_VALUES,
+  TAB_STOP_ALIGNMENT_VALUES,
+  THEME_COLOR_SLOT_VALUES,
+} from "../types/documentEnumValues";
+import {
+  PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR,
+  selectAuthoredParagraphProperties,
+  type AuthoredParagraphProperties,
+  type AuthoredParagraphPropertyKey,
+} from "../docx/paragraphPropertyDescriptor";
+
+export type SerializedPersistableParagraphPropertyState =
+  | {
+      type: "imported";
+      token: string;
+      authoredPPr: AuthoredParagraphProperties;
+    }
+  | {
+      type: "editor-created";
+      authoredPPr: AuthoredParagraphProperties;
+    };
+
+/** Internal PM-only state; transient handles are forbidden at persistence boundaries. */
+export type SerializedParagraphPropertyState =
+  | SerializedPersistableParagraphPropertyState
+  | {
+      type: "transient-template";
+      handle: string;
+      authoredPPr: AuthoredParagraphProperties;
+    };
+
+const TRUSTED_PARAGRAPH_PROPERTY_STATE: unique symbol = Symbol(
+  "trusted-paragraph-property-state",
+);
+
+type TrustedParagraphPropertyState = {
+  readonly [TRUSTED_PARAGRAPH_PROPERTY_STATE]: true;
+};
+
+export type PersistableParagraphPropertyState = (
+  | {
+      readonly type: "imported";
+      readonly token: ParagraphPropertySourceToken;
+      readonly authoredPPr: Readonly<AuthoredParagraphProperties>;
+    }
+  | {
+      readonly type: "editor-created";
+      readonly authoredPPr: Readonly<AuthoredParagraphProperties>;
+    }
+  ) & TrustedParagraphPropertyState;
+
+/** Trusted state used after the serialized PM/Yjs boundary has been validated. */
+export type ParagraphPropertyState =
+  | PersistableParagraphPropertyState
+  | ({
+      readonly type: "transient-template";
+      readonly handle: ParagraphPropertyTransientTemplateHandle;
+      readonly authoredPPr: Readonly<AuthoredParagraphProperties>;
+    } & TrustedParagraphPropertyState);
+
+export type ParagraphPropertyMutation = {
+  [Key in AuthoredParagraphPropertyKey]:
+    | { key: Key; mutation: { type: "remove" } }
+    | {
+        key: Key;
+        mutation: {
+          type: "set";
+          value: Exclude<AuthoredParagraphProperties[Key], undefined>;
+        };
+      };
+}[AuthoredParagraphPropertyKey];
+
+export type ParagraphPropertyStateTransition =
+  | { type: "mutate-authored"; mutations: readonly ParagraphPropertyMutation[] }
+  | { type: "replace-authored"; authoredPPr: AuthoredParagraphProperties }
+  | { type: "editor-copy" };
+
+export type ParagraphPropertySplitTransition = {
+  type: "split-left-created-right-retains";
+};
+
+export type ParagraphPropertyJoinTransition =
+  | { type: "join-left-paragraph-mark-retains" }
+  | { type: "join-right-paragraph-mark-retains" };
+
+type ValidationResult = { valid: true } | { valid: false };
+
+const INVALID: ValidationResult = { valid: false };
+const VALID: ValidationResult = { valid: true };
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const hasOnlyKeys = (value: Record<string, unknown>, allowed: ReadonlySet<string>): boolean =>
+  Object.keys(value).every((key) => allowed.has(key));
+
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value);
+
+const isNonNegativeSafeInteger = (value: unknown): value is number =>
+  Number.isSafeInteger(value) && typeof value === "number" && value >= 0;
+
+const isOneOf = <Value extends string>(value: unknown, allowed: readonly Value[]): value is Value =>
+  typeof value === "string" && allowed.includes(value as Value);
+
+const validateOptionalBooleanRecord = (
+  value: unknown,
+  keys: readonly string[],
+): ValidationResult => {
+  if (!isRecord(value) || !hasOnlyKeys(value, new Set(keys))) {
+    return INVALID;
+  }
+  return Object.values(value).every((entry) => typeof entry === "boolean") ? VALID : INVALID;
+};
+
+const COLOR_VALUE_KEYS = new Set(["rgb", "auto", "themeColor", "themeTint", "themeShade"]);
+
+const validateColorValue = (value: unknown): ValidationResult => {
+  if (!isRecord(value) || !hasOnlyKeys(value, COLOR_VALUE_KEYS)) {
+    return INVALID;
+  }
+  if (value["rgb"] !== undefined && typeof value["rgb"] !== "string") {
+    return INVALID;
+  }
+  if (value["auto"] !== undefined && typeof value["auto"] !== "boolean") {
+    return INVALID;
+  }
+  if (
+    value["themeColor"] !== undefined &&
+    !isOneOf(value["themeColor"], THEME_COLOR_SLOT_VALUES)
+  ) {
+    return INVALID;
+  }
+  if (value["themeTint"] !== undefined && typeof value["themeTint"] !== "string") {
+    return INVALID;
+  }
+  if (value["themeShade"] !== undefined && typeof value["themeShade"] !== "string") {
+    return INVALID;
+  }
+  return VALID;
+};
+
+const BORDER_KEYS = new Set(["style", "size", "space", "color", "shadow", "frame"]);
+
+const validateBorder = (value: unknown): ValidationResult => {
+  if (!isRecord(value) || !hasOnlyKeys(value, BORDER_KEYS)) {
+    return INVALID;
+  }
+  if (value["style"] !== undefined && typeof value["style"] !== "string") {
+    return INVALID;
+  }
+  if (value["size"] !== undefined && !isFiniteNumber(value["size"])) {
+    return INVALID;
+  }
+  if (value["space"] !== undefined && !isFiniteNumber(value["space"])) {
+    return INVALID;
+  }
+  if (value["shadow"] !== undefined && typeof value["shadow"] !== "boolean") {
+    return INVALID;
+  }
+  if (value["frame"] !== undefined && typeof value["frame"] !== "boolean") {
+    return INVALID;
+  }
+  if (value["color"] !== undefined && !validateColorValue(value["color"]).valid) {
+    return INVALID;
+  }
+  return VALID;
+};
+
+const PARAGRAPH_BORDER_KEYS = new Set(["top", "bottom", "left", "right", "between", "bar"]);
+
+const validateBorders = (value: unknown): ValidationResult => {
+  if (!isRecord(value) || !hasOnlyKeys(value, PARAGRAPH_BORDER_KEYS)) {
+    return INVALID;
+  }
+  return Object.values(value).every((entry) => validateBorder(entry).valid) ? VALID : INVALID;
+};
+
+const SHADING_KEYS = new Set(["color", "fill", "pattern"]);
+
+const validateShading = (value: unknown): ValidationResult => {
+  if (!isRecord(value) || !hasOnlyKeys(value, SHADING_KEYS)) {
+    return INVALID;
+  }
+  if (value["color"] !== undefined && !validateColorValue(value["color"]).valid) {
+    return INVALID;
+  }
+  if (value["fill"] !== undefined && !validateColorValue(value["fill"]).valid) {
+    return INVALID;
+  }
+  if (value["pattern"] !== undefined && !isOneOf(value["pattern"], SHADING_PATTERN_VALUES)) {
+    return INVALID;
+  }
+  return VALID;
+};
+
+const TAB_KEYS = new Set(["position", "alignment", "leader"]);
+
+const validateTabs = (value: unknown): ValidationResult => {
+  if (!Array.isArray(value)) {
+    return INVALID;
+  }
+  for (const tab of value) {
+    if (!isRecord(tab) || !hasOnlyKeys(tab, TAB_KEYS)) {
+      return INVALID;
+    }
+    if (!isFiniteNumber(tab["position"])) {
+      return INVALID;
+    }
+    if (!isOneOf(tab["alignment"], TAB_STOP_ALIGNMENT_VALUES)) {
+      return INVALID;
+    }
+    if (tab["leader"] !== undefined && !isOneOf(tab["leader"], TAB_LEADER_VALUES)) {
+      return INVALID;
+    }
+  }
+  return VALID;
+};
+
+const NUM_PR_KEYS = new Set(["numId", "ilvl"]);
+
+const validateNumPr = (value: unknown): ValidationResult => {
+  if (!isRecord(value) || !hasOnlyKeys(value, NUM_PR_KEYS)) {
+    return INVALID;
+  }
+  if (value["numId"] !== undefined && !isNonNegativeSafeInteger(value["numId"])) {
+    return INVALID;
+  }
+  if (value["ilvl"] !== undefined && !isNonNegativeSafeInteger(value["ilvl"])) {
+    return INVALID;
+  }
+  return VALID;
+};
+
+const FRAME_KEYS = new Set([
+  "dropCap",
+  "lines",
+  "width",
+  "height",
+  "hSpace",
+  "vSpace",
+  "hAnchor",
+  "vAnchor",
+  "x",
+  "y",
+  "xAlign",
+  "yAlign",
+  "wrap",
+]);
+
+const validateFrame = (value: unknown): ValidationResult => {
+  if (!isRecord(value) || !hasOnlyKeys(value, FRAME_KEYS)) {
+    return INVALID;
+  }
+  if (value["dropCap"] !== undefined && !isOneOf(value["dropCap"], ["none", "drop", "margin"])) {
+    return INVALID;
+  }
+  if (value["hAnchor"] !== undefined && !isOneOf(value["hAnchor"], ["text", "margin", "page"])) {
+    return INVALID;
+  }
+  if (value["vAnchor"] !== undefined && !isOneOf(value["vAnchor"], ["text", "margin", "page"])) {
+    return INVALID;
+  }
+  if (value["xAlign"] !== undefined && !isOneOf(value["xAlign"], FRAME_X_ALIGN_VALUES)) {
+    return INVALID;
+  }
+  if (value["yAlign"] !== undefined && !isOneOf(value["yAlign"], FRAME_Y_ALIGN_VALUES)) {
+    return INVALID;
+  }
+  if (value["wrap"] !== undefined && !isOneOf(value["wrap"], FRAME_WRAP_VALUES)) {
+    return INVALID;
+  }
+  for (const key of ["lines", "width", "height", "hSpace", "vSpace", "x", "y"] as const) {
+    if (value[key] !== undefined && !isFiniteNumber(value[key])) {
+      return INVALID;
+    }
+  }
+  return VALID;
+};
+
+const validateAuthoredProperty = (
+  key: AuthoredParagraphPropertyKey,
+  value: unknown,
+): ValidationResult => {
+  switch (key) {
+    case "bidi":
+    case "kinsoku":
+    case "overflowPunctuation":
+    case "snapToGrid":
+    case "beforeAutospacing":
+    case "afterAutospacing":
+    case "hangingIndent":
+    case "keepNext":
+    case "keepLines":
+    case "widowControl":
+    case "pageBreakBefore":
+    case "contextualSpacing":
+    case "suppressLineNumbers":
+    case "suppressAutoHyphens":
+      return typeof value === "boolean" ? VALID : INVALID;
+    case "spaceBefore":
+    case "spaceAfter":
+    case "lineSpacing":
+    case "indentLeft":
+    case "indentRight":
+    case "indentFirstLine":
+    case "outlineLevel":
+      return isFiniteNumber(value) ? VALID : INVALID;
+    case "alignment":
+      return isOneOf(value, PARAGRAPH_ALIGNMENT_VALUES) ? VALID : INVALID;
+    case "lineSpacingRule":
+      return isOneOf(value, LINE_SPACING_RULE_VALUES) ? VALID : INVALID;
+    case "spacingExplicit":
+      return validateOptionalBooleanRecord(value, ["before", "after"]);
+    case "borders":
+      return validateBorders(value);
+    case "shading":
+      return validateShading(value);
+    case "tabs":
+      return validateTabs(value);
+    case "numPr":
+      return validateNumPr(value);
+    case "styleId":
+      return typeof value === "string" ? VALID : INVALID;
+    case "frame":
+      return validateFrame(value);
+    default: {
+      const exhaustive: never = key;
+      return exhaustive;
+    }
+  }
+};
+
+const isAuthoredParagraphPropertyKey = (key: string): key is AuthoredParagraphPropertyKey => {
+  const descriptor = Reflect.get(PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR, key) as
+    | { owner?: unknown }
+    | undefined;
+  return descriptor?.owner === "pPr-base";
+};
+
+const validateAuthoredParagraphProperties = (value: unknown): ValidationResult => {
+  if (!isRecord(value)) {
+    return INVALID;
+  }
+  for (const [key, propertyValue] of Object.entries(value)) {
+    if (!isAuthoredParagraphPropertyKey(key) || propertyValue === undefined) {
+      return INVALID;
+    }
+    if (!validateAuthoredProperty(key, propertyValue).valid) {
+      return INVALID;
+    }
+  }
+  if (
+    value["hangingIndent"] === true &&
+    (!isFiniteNumber(value["indentFirstLine"]) || value["indentFirstLine"] >= 0)
+  ) {
+    return INVALID;
+  }
+  if (
+    isFiniteNumber(value["indentFirstLine"]) &&
+    value["indentFirstLine"] < 0 &&
+    value["hangingIndent"] !== true
+  ) {
+    return INVALID;
+  }
+  return VALID;
+};
+
+export const readAuthoredParagraphProperties = (
+  raw: unknown,
+): ParagraphPropertySourceAttribute<AuthoredParagraphProperties> => {
+  if (raw === null || raw === undefined) {
+    return { status: "absent" };
+  }
+  if (!validateAuthoredParagraphProperties(raw).valid) {
+    return { raw, status: "invalid" };
+  }
+  // SAFETY: validation established the descriptor-owned property shapes.
+  return {
+    status: "valid",
+    value: cloneJsonValue(raw) as AuthoredParagraphProperties,
+  };
+};
+
+const cloneJsonValue = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(cloneJsonValue);
+  }
+  if (isRecord(value)) {
+    const clone: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      clone[key] = cloneJsonValue(entry);
+    }
+    return clone;
+  }
+  return value;
+};
+
+const deepFreezeJsonValue = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      deepFreezeJsonValue(entry);
+    }
+    return Object.freeze(value);
+  }
+  if (isRecord(value)) {
+    for (const entry of Object.values(value)) {
+      deepFreezeJsonValue(entry);
+    }
+    return Object.freeze(value);
+  }
+  return value;
+};
+
+const cloneAuthoredParagraphProperties = (
+  authoredPPr: AuthoredParagraphProperties,
+): AuthoredParagraphProperties => {
+  if (!validateAuthoredParagraphProperties(authoredPPr).valid) {
+    panic("Invalid authored paragraph properties");
+  }
+  // SAFETY: the exhaustive validator above proves the clone contains only
+  // descriptor-owned fields with their exact ParagraphFormatting value shapes.
+  return deepFreezeJsonValue(cloneJsonValue(authoredPPr)) as AuthoredParagraphProperties;
+};
+
+type UntrustedStateBranch =
+  | {
+      type: "imported";
+      token: ParagraphPropertySourceToken;
+      authoredPPr: AuthoredParagraphProperties;
+    }
+  | {
+      type: "editor-created";
+      authoredPPr: AuthoredParagraphProperties;
+    }
+  | {
+      type: "transient-template";
+      handle: ParagraphPropertyTransientTemplateHandle;
+      authoredPPr: AuthoredParagraphProperties;
+    };
+
+const trustParagraphPropertyState = <Branch extends UntrustedStateBranch>(
+  state: Branch,
+): Branch & TrustedParagraphPropertyState => {
+  Object.defineProperty(state, TRUSTED_PARAGRAPH_PROPERTY_STATE, {
+    configurable: false,
+    enumerable: false,
+    value: true,
+    writable: false,
+  });
+  Object.freeze(state);
+  // SAFETY: this function alone installs the private runtime brand after all
+  // payloads have passed validation and deep freezing.
+  return state as Branch & TrustedParagraphPropertyState;
+};
+
+const stateKeysAreValid = (value: Record<string, unknown>, type: string): boolean => {
+  switch (type) {
+    case "imported":
+      return hasOnlyKeys(value, new Set(["type", "token", "authoredPPr"]));
+    case "editor-created":
+      return hasOnlyKeys(value, new Set(["type", "authoredPPr"]));
+    case "transient-template":
+      return hasOnlyKeys(value, new Set(["type", "handle", "authoredPPr"]));
+    default:
+      return false;
+  }
+};
+
+export const createImportedParagraphPropertyState = (
+  token: ParagraphPropertySourceToken,
+  authoredPPr: AuthoredParagraphProperties,
+): PersistableParagraphPropertyState =>
+  trustParagraphPropertyState({
+    type: "imported",
+    token,
+    authoredPPr: cloneAuthoredParagraphProperties(authoredPPr),
+  });
+
+export const createEditorParagraphPropertyState = (
+  authoredPPr: AuthoredParagraphProperties = {},
+): PersistableParagraphPropertyState =>
+  trustParagraphPropertyState({
+    type: "editor-created",
+    authoredPPr: cloneAuthoredParagraphProperties(authoredPPr),
+  });
+
+/** Validate and freeze the model-level authored selector at the PM trust boundary. */
+export const authoredParagraphPropertiesFromFormatting = (
+  formatting: Parameters<typeof selectAuthoredParagraphProperties>[0],
+): AuthoredParagraphProperties =>
+  cloneAuthoredParagraphProperties(selectAuthoredParagraphProperties(formatting));
+
+export const createTransientTemplateParagraphPropertyState = (
+  handle: ParagraphPropertyTransientTemplateHandle,
+  authoredPPr: AuthoredParagraphProperties,
+): ParagraphPropertyState =>
+  trustParagraphPropertyState({
+    type: "transient-template",
+    handle,
+    authoredPPr: cloneAuthoredParagraphProperties(authoredPPr),
+  });
+
+export const readParagraphPropertyState = (
+  raw: unknown,
+): ParagraphPropertySourceAttribute<ParagraphPropertyState> => {
+  if (raw === null || raw === undefined) {
+    return { status: "absent" };
+  }
+  if (!isRecord(raw) || typeof raw["type"] !== "string") {
+    return { raw, status: "invalid" };
+  }
+  const type = raw["type"];
+  if (!stateKeysAreValid(raw, type) || !validateAuthoredParagraphProperties(raw["authoredPPr"]).valid) {
+    return { raw, status: "invalid" };
+  }
+  // SAFETY: the validation above established the complete descriptor-owned shape.
+  const authoredPPr = cloneAuthoredParagraphProperties(
+    raw["authoredPPr"] as AuthoredParagraphProperties,
+  );
+  switch (type) {
+    case "imported": {
+      const token = ParagraphPropertySourceToken.read(raw["token"]);
+      return token.status === "valid"
+        ? {
+            status: "valid",
+            value: trustParagraphPropertyState({ type, token: token.value, authoredPPr }),
+          }
+        : { raw, status: "invalid" };
+    }
+    case "editor-created":
+      return {
+        status: "valid",
+        value: trustParagraphPropertyState({ type, authoredPPr }),
+      };
+    case "transient-template": {
+      const handle = ParagraphPropertyTransientTemplateHandle.read(raw["handle"]);
+      return handle.status === "valid"
+        ? {
+            status: "valid",
+            value: trustParagraphPropertyState({ type, handle: handle.value, authoredPPr }),
+          }
+        : { raw, status: "invalid" };
+    }
+    default:
+      return { raw, status: "invalid" };
+  }
+};
+
+/** Reify state at a PM/Yjs persistence boundary, where template handles are invalid. */
+export const readPersistableParagraphPropertyState = (
+  raw: unknown,
+): ParagraphPropertySourceAttribute<PersistableParagraphPropertyState> => {
+  const result = readParagraphPropertyState(raw);
+  if (result.status !== "valid") {
+    return result;
+  }
+  if (result.value.type === "transient-template") {
+    return { raw, status: "invalid" };
+  }
+  return result;
+};
+
+export const expectParagraphPropertyState = (raw: unknown): ParagraphPropertyState => {
+  const result = readParagraphPropertyState(raw);
+  if (result.status !== "valid") {
+    panic("Paragraphs require a valid paragraph-property state");
+  }
+  return result.value;
+};
+
+export const serializeParagraphPropertyState = (
+  state: ParagraphPropertyState,
+): SerializedParagraphPropertyState => {
+  switch (state.type) {
+    case "imported":
+      return {
+        type: "imported",
+        token: state.token.serialized,
+        authoredPPr: cloneAuthoredParagraphProperties(state.authoredPPr),
+      };
+    case "editor-created":
+      return {
+        type: "editor-created",
+        authoredPPr: cloneAuthoredParagraphProperties(state.authoredPPr),
+      };
+    case "transient-template":
+      return {
+        type: "transient-template",
+        handle: state.handle.serialized,
+        authoredPPr: cloneAuthoredParagraphProperties(state.authoredPPr),
+      };
+    default: {
+      const exhaustive: never = state;
+      return exhaustive;
+    }
+  }
+};
+
+/** Serialize only state safe to store in Yjs or another persistent document. */
+export const serializePersistableParagraphPropertyState = (
+  state: ParagraphPropertyState,
+): SerializedPersistableParagraphPropertyState => {
+  switch (state.type) {
+    case "imported":
+      return {
+        type: "imported",
+        token: state.token.serialized,
+        authoredPPr: cloneAuthoredParagraphProperties(state.authoredPPr),
+      };
+    case "editor-created":
+      return {
+        type: "editor-created",
+        authoredPPr: cloneAuthoredParagraphProperties(state.authoredPPr),
+      };
+    case "transient-template":
+      return panic("Transient paragraph-property state cannot cross a persistence boundary");
+    default: {
+      const exhaustive: never = state;
+      return exhaustive;
+    }
+  }
+};
+
+export const transitionParagraphPropertyState = (
+  state: ParagraphPropertyState,
+  transition: ParagraphPropertyStateTransition,
+): ParagraphPropertyState => {
+  if (transition.type === "editor-copy") {
+    return createEditorParagraphPropertyState(state.authoredPPr);
+  }
+  const authoredPPr =
+    transition.type === "replace-authored"
+      ? cloneAuthoredParagraphProperties(transition.authoredPPr)
+      : applyParagraphPropertyMutations(state.authoredPPr, transition.mutations);
+  switch (state.type) {
+    case "imported":
+      return trustParagraphPropertyState({ type: "imported", token: state.token, authoredPPr });
+    case "editor-created":
+      return trustParagraphPropertyState({ type: "editor-created", authoredPPr });
+    case "transient-template":
+      return trustParagraphPropertyState({
+        type: "transient-template",
+        handle: state.handle,
+        authoredPPr,
+      });
+    default: {
+      const exhaustive: never = state;
+      return exhaustive;
+    }
+  }
+};
+
+export const applyParagraphPropertyMutations = (
+  authoredPPr: AuthoredParagraphProperties,
+  mutations: readonly ParagraphPropertyMutation[],
+): AuthoredParagraphProperties => {
+  if (!validateAuthoredParagraphProperties(authoredPPr).valid) {
+    panic("Invalid authored paragraph properties");
+  }
+  // SAFETY: the source passed the exhaustive authored-property validator.
+  const next = cloneJsonValue(authoredPPr) as AuthoredParagraphProperties;
+  const seen = new Set<AuthoredParagraphPropertyKey>();
+  for (const { key, mutation } of mutations) {
+    if (!isAuthoredParagraphPropertyKey(key)) {
+      panic(`Cannot mutate non-authored paragraph property: ${key}`);
+    }
+    if (seen.has(key)) {
+      panic(`Paragraph-property mutation batch contains duplicate key: ${key}`);
+    }
+    seen.add(key);
+    switch (mutation.type) {
+      case "remove":
+        Reflect.deleteProperty(next, key);
+        break;
+      case "set":
+        Reflect.set(next, key, cloneJsonValue(mutation.value));
+        break;
+      default: {
+        const exhaustive: never = mutation;
+        return exhaustive;
+      }
+    }
+  }
+  return cloneAuthoredParagraphProperties(next);
+};
+
+export const splitParagraphPropertyState = (
+  state: ParagraphPropertyState,
+  transition: ParagraphPropertySplitTransition,
+): {
+  type: ParagraphPropertySplitTransition["type"];
+  left: PersistableParagraphPropertyState;
+  right: ParagraphPropertyState;
+} => {
+  switch (transition.type) {
+    case "split-left-created-right-retains":
+      return {
+        type: transition.type,
+        left: createEditorParagraphPropertyState(state.authoredPPr),
+        right: state,
+      };
+    default: {
+      const exhaustive: never = transition;
+      return exhaustive;
+    }
+  }
+};
+
+export const joinParagraphPropertyStates = (
+  left: ParagraphPropertyState,
+  right: ParagraphPropertyState,
+  transition: ParagraphPropertyJoinTransition,
+): ParagraphPropertyState => {
+  switch (transition.type) {
+    case "join-left-paragraph-mark-retains":
+      return left;
+    case "join-right-paragraph-mark-retains":
+      return right;
+    default: {
+      const exhaustive: never = transition;
+      return exhaustive;
+    }
+  }
+};
+
+export const EMPTY_EDITOR_PARAGRAPH_PROPERTY_STATE = Object.freeze({
+  type: "editor-created",
+  authoredPPr: Object.freeze({}),
+}) satisfies SerializedPersistableParagraphPropertyState;

--- a/packages/core/src/prosemirror/paragraphPropertyState.ts
+++ b/packages/core/src/prosemirror/paragraphPropertyState.ts
@@ -1,12 +1,18 @@
 import { panic } from "better-result";
 import type {
+  AuthoredParagraphProperties,
+  AuthoredParagraphPropertyKey,
   NonEmptyNumberingLevelIndentGeometry,
   NumberingLevelIndentGeometry,
   NumberingLevelIndentProvenance,
+  ParagraphMarkProperties,
+} from "@stll/docx-core/model";
+import {
+  PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR,
+  selectAuthoredParagraphProperties,
 } from "@stll/docx-core/model";
 
 import {
-  ParagraphPropertySourceToken,
   ParagraphPropertyTransientTemplateHandle,
   type ParagraphPropertySourceAttribute,
 } from "../docx/paragraphPropertySourceIdentity";
@@ -27,13 +33,6 @@ import {
   THEME_COLOR_SLOT_VALUES,
   UNDERLINE_STYLE_VALUES,
 } from "../types/documentEnumValues";
-import {
-  PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR,
-  selectAuthoredParagraphProperties,
-  type AuthoredParagraphProperties,
-  type AuthoredParagraphPropertyKey,
-  type ParagraphMarkProperties,
-} from "../docx/paragraphPropertyDescriptor";
 import type {
   BorderSpec,
   ColorValue,
@@ -92,7 +91,7 @@ type TrustedParagraphPropertyState = {
 export type PersistableParagraphPropertyState = (
   | {
       readonly type: "imported";
-      readonly token: ParagraphPropertySourceToken;
+      readonly token: string;
     }
   | {
       readonly type: "editor-created";
@@ -153,13 +152,11 @@ export type ParagraphMarkEffectivePropertyMutation =
       mutation: { type: "remove" } | { type: "set"; value: boolean };
     };
 
-export type ParagraphPropertyStateTransition =
-  | {
-      type: "update";
-      authored: ParagraphPropertyAuthoredTransition;
-      context: ParagraphPropertyContextTransition;
-    }
-  | { type: "editor-copy" };
+export type ParagraphPropertyStateTransition = {
+  type: "update";
+  authored: ParagraphPropertyAuthoredTransition;
+  context: ParagraphPropertyContextTransition;
+};
 
 export type ParagraphPropertySplitTransition = {
   type: "split-left-created-right-retains";
@@ -1147,7 +1144,7 @@ const IMPORTED_STATE_KEYS = new Set<string>(["type", "token", "authoredPPr", "co
 const EDITOR_STATE_KEYS = new Set<string>(["type", "authoredPPr", "context"]);
 
 type CreateImportedParagraphPropertyStateOptions = {
-  token: ParagraphPropertySourceToken;
+  token: string;
   authoredPPr: AuthoredParagraphProperties;
   context: SerializedParagraphPropertyProjectionContext;
 };
@@ -1235,12 +1232,9 @@ export const readParagraphPropertyState = (
   }
   switch (type) {
     case "imported": {
-      const token = ParagraphPropertySourceToken.read(raw["token"]);
-      return token.status === "valid"
-        ? {
-            status: "valid",
-            value: trustParagraphPropertyState({ type, token: token.value, authoredPPr, context }),
-          }
+      const token = raw["token"];
+      return typeof token === "string" && token.length > 0
+        ? { status: "valid", value: trustParagraphPropertyState({ type, token, authoredPPr, context }) }
         : { raw, status: "invalid" };
     }
     case "editor-created":
@@ -1283,7 +1277,7 @@ export const serializePersistableParagraphPropertyState = (
     case "imported":
       return {
         type: "imported",
-        token: state.token.serialized,
+        token: state.token,
         authoredPPr: cloneAuthoredParagraphProperties(state.authoredPPr),
         context: cloneJsonValue(state.context) as SerializedParagraphPropertyProjectionContext,
       };
@@ -1316,12 +1310,6 @@ export const transitionParagraphPropertyState = (
   state: ParagraphPropertyState,
   transition: ParagraphPropertyStateTransition,
 ): ParagraphPropertyState => {
-  if (transition.type === "editor-copy") {
-    return createEditorParagraphPropertyState({
-      authoredPPr: state.authoredPPr,
-      context: state.context,
-    });
-  }
   const authoredPPr = applyAuthoredTransition(state.authoredPPr, transition.authored);
   const context = applyContextTransition(state.context, transition.context);
   assertParagraphPropertyStatePayload(authoredPPr, context);

--- a/packages/core/src/prosemirror/paragraphPropertyState.ts
+++ b/packages/core/src/prosemirror/paragraphPropertyState.ts
@@ -1,4 +1,9 @@
 import { panic } from "better-result";
+import type {
+  NonEmptyNumberingLevelIndentGeometry,
+  NumberingLevelIndentGeometry,
+  NumberingLevelIndentProvenance,
+} from "@stll/docx-core/model";
 
 import {
   ParagraphPropertySourceToken,
@@ -9,39 +14,70 @@ import {
   FRAME_WRAP_VALUES,
   FRAME_X_ALIGN_VALUES,
   FRAME_Y_ALIGN_VALUES,
+  EMPHASIS_MARK_VALUES,
+  FONT_HINT_VALUES,
+  FONT_THEME_VALUES,
+  HIGHLIGHT_COLOR_VALUES,
   LINE_SPACING_RULE_VALUES,
   PARAGRAPH_ALIGNMENT_VALUES,
   SHADING_PATTERN_VALUES,
   TAB_LEADER_VALUES,
   TAB_STOP_ALIGNMENT_VALUES,
+  TEXT_EFFECT_VALUES,
   THEME_COLOR_SLOT_VALUES,
+  UNDERLINE_STYLE_VALUES,
 } from "../types/documentEnumValues";
 import {
   PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR,
   selectAuthoredParagraphProperties,
   type AuthoredParagraphProperties,
   type AuthoredParagraphPropertyKey,
+  type ParagraphMarkProperties,
 } from "../docx/paragraphPropertyDescriptor";
+import type {
+  BorderSpec,
+  ColorValue,
+  ParagraphFormatting,
+  ShadingProperties,
+  TabStop,
+  TextFormatting,
+} from "../types/document";
+import {
+  PARAGRAPH_SPACING_INHERITANCE_SOURCE,
+  type ParagraphMarkEffectiveProperties,
+  type ParagraphMarkProjectionContext,
+  type ParagraphSpacingInheritance,
+  type SerializedParagraphPropertyProjectionContext,
+} from "./paragraphPropertyContext";
+
+type SerializedParagraphPropertyStateCommon = {
+  authoredPPr: AuthoredParagraphProperties;
+  context: SerializedParagraphPropertyProjectionContext;
+};
 
 export type SerializedPersistableParagraphPropertyState =
-  | {
+  | (SerializedParagraphPropertyStateCommon & {
       type: "imported";
       token: string;
-      authoredPPr: AuthoredParagraphProperties;
-    }
-  | {
+    })
+  | (SerializedParagraphPropertyStateCommon & {
       type: "editor-created";
-      authoredPPr: AuthoredParagraphProperties;
-    };
+    });
 
-/** Internal PM-only state; transient handles are forbidden at persistence boundaries. */
-export type SerializedParagraphPropertyState =
-  | SerializedPersistableParagraphPropertyState
-  | {
-      type: "transient-template";
-      handle: string;
-      authoredPPr: AuthoredParagraphProperties;
-    };
+/** PM/Yjs wire data is persistable by construction; transient handles have no wire branch. */
+export type SerializedParagraphPropertyState = SerializedPersistableParagraphPropertyState;
+
+type DeepReadonly<Value> = Value extends (...args: never[]) => unknown
+  ? Value
+  : Value extends readonly (infer Entry)[]
+    ? readonly DeepReadonly<Entry>[]
+    : Value extends object
+      ? { readonly [Key in keyof Value]: DeepReadonly<Value[Key]> }
+      : Value;
+
+export type ParagraphPropertyProjectionContext = DeepReadonly<
+  SerializedParagraphPropertyProjectionContext
+>;
 
 const TRUSTED_PARAGRAPH_PROPERTY_STATE: unique symbol = Symbol(
   "trusted-paragraph-property-state",
@@ -49,17 +85,17 @@ const TRUSTED_PARAGRAPH_PROPERTY_STATE: unique symbol = Symbol(
 
 type TrustedParagraphPropertyState = {
   readonly [TRUSTED_PARAGRAPH_PROPERTY_STATE]: true;
+  readonly authoredPPr: DeepReadonly<AuthoredParagraphProperties>;
+  readonly context: ParagraphPropertyProjectionContext;
 };
 
 export type PersistableParagraphPropertyState = (
   | {
       readonly type: "imported";
       readonly token: ParagraphPropertySourceToken;
-      readonly authoredPPr: Readonly<AuthoredParagraphProperties>;
     }
   | {
       readonly type: "editor-created";
-      readonly authoredPPr: Readonly<AuthoredParagraphProperties>;
     }
   ) & TrustedParagraphPropertyState;
 
@@ -69,7 +105,6 @@ export type ParagraphPropertyState =
   | ({
       readonly type: "transient-template";
       readonly handle: ParagraphPropertyTransientTemplateHandle;
-      readonly authoredPPr: Readonly<AuthoredParagraphProperties>;
     } & TrustedParagraphPropertyState);
 
 export type ParagraphPropertyMutation = {
@@ -84,9 +119,46 @@ export type ParagraphPropertyMutation = {
       };
 }[AuthoredParagraphPropertyKey];
 
+export type ParagraphMarkPropertyMutation =
+  | {
+      key: "runProperties";
+      mutation: { type: "remove" } | { type: "set"; value: TextFormatting };
+    }
+  | {
+      key: "runInWithNext";
+      mutation: { type: "remove" } | { type: "set"; value: boolean };
+    };
+
+export type ParagraphPropertyAuthoredTransition =
+  | { type: "preserve" }
+  | { type: "mutate"; mutations: readonly ParagraphPropertyMutation[] }
+  | { type: "replace"; authoredPPr: AuthoredParagraphProperties };
+
+export type ParagraphPropertyContextTransition =
+  | { type: "preserve" }
+  | { type: "replace"; context: SerializedParagraphPropertyProjectionContext }
+  | {
+      type: "mutate-paragraph-mark";
+      authored: readonly ParagraphMarkPropertyMutation[];
+      effective: readonly ParagraphMarkEffectivePropertyMutation[];
+    };
+
+export type ParagraphMarkEffectivePropertyMutation =
+  | {
+      key: "defaultTextFormatting";
+      mutation: { type: "remove" } | { type: "set"; value: TextFormatting };
+    }
+  | {
+      key: "runInWithNext";
+      mutation: { type: "remove" } | { type: "set"; value: boolean };
+    };
+
 export type ParagraphPropertyStateTransition =
-  | { type: "mutate-authored"; mutations: readonly ParagraphPropertyMutation[] }
-  | { type: "replace-authored"; authoredPPr: AuthoredParagraphProperties }
+  | {
+      type: "update";
+      authored: ParagraphPropertyAuthoredTransition;
+      context: ParagraphPropertyContextTransition;
+    }
   | { type: "editor-copy" };
 
 export type ParagraphPropertySplitTransition = {
@@ -127,61 +199,92 @@ const validateOptionalBooleanRecord = (
   return Object.values(value).every((entry) => typeof entry === "boolean") ? VALID : INVALID;
 };
 
-const COLOR_VALUE_KEYS = new Set(["rgb", "auto", "themeColor", "themeTint", "themeShade"]);
+const COLOR_VALUE_VALIDATION = {
+  rgb: "string",
+  auto: "boolean",
+  themeColor: "theme-color",
+  themeTint: "string",
+  themeShade: "string",
+} as const satisfies Record<keyof ColorValue, "boolean" | "string" | "theme-color">;
+const COLOR_VALUE_KEYS = new Set<string>(Object.keys(COLOR_VALUE_VALIDATION));
 
 const validateColorValue = (value: unknown): ValidationResult => {
   if (!isRecord(value) || !hasOnlyKeys(value, COLOR_VALUE_KEYS)) {
     return INVALID;
   }
-  if (value["rgb"] !== undefined && typeof value["rgb"] !== "string") {
-    return INVALID;
-  }
-  if (value["auto"] !== undefined && typeof value["auto"] !== "boolean") {
-    return INVALID;
-  }
-  if (
-    value["themeColor"] !== undefined &&
-    !isOneOf(value["themeColor"], THEME_COLOR_SLOT_VALUES)
-  ) {
-    return INVALID;
-  }
-  if (value["themeTint"] !== undefined && typeof value["themeTint"] !== "string") {
-    return INVALID;
-  }
-  if (value["themeShade"] !== undefined && typeof value["themeShade"] !== "string") {
-    return INVALID;
+  for (const [key, validation] of Object.entries(COLOR_VALUE_VALIDATION)) {
+    const property = value[key];
+    if (property === undefined) {
+      continue;
+    }
+    if (validation === "boolean" && typeof property !== "boolean") {
+      return INVALID;
+    }
+    if (validation === "string" && typeof property !== "string") {
+      return INVALID;
+    }
+    if (validation === "theme-color" && !isOneOf(property, THEME_COLOR_SLOT_VALUES)) {
+      return INVALID;
+    }
   }
   return VALID;
 };
 
-const BORDER_KEYS = new Set(["style", "size", "space", "color", "shadow", "frame"]);
+const BORDER_VALIDATION = {
+  style: "required-string",
+  size: "number",
+  space: "number",
+  color: "color",
+  shadow: "boolean",
+  frame: "boolean",
+  artRelationshipId: "string",
+  topLeftArtRelationshipId: "string",
+  topRightArtRelationshipId: "string",
+  bottomLeftArtRelationshipId: "string",
+  bottomRightArtRelationshipId: "string",
+} as const satisfies Record<
+  keyof BorderSpec,
+  "boolean" | "color" | "number" | "required-string" | "string"
+>;
+const BORDER_KEYS = new Set<string>(Object.keys(BORDER_VALIDATION));
 
 const validateBorder = (value: unknown): ValidationResult => {
   if (!isRecord(value) || !hasOnlyKeys(value, BORDER_KEYS)) {
     return INVALID;
   }
-  if (value["style"] !== undefined && typeof value["style"] !== "string") {
-    return INVALID;
-  }
-  if (value["size"] !== undefined && !isFiniteNumber(value["size"])) {
-    return INVALID;
-  }
-  if (value["space"] !== undefined && !isFiniteNumber(value["space"])) {
-    return INVALID;
-  }
-  if (value["shadow"] !== undefined && typeof value["shadow"] !== "boolean") {
-    return INVALID;
-  }
-  if (value["frame"] !== undefined && typeof value["frame"] !== "boolean") {
-    return INVALID;
-  }
-  if (value["color"] !== undefined && !validateColorValue(value["color"]).valid) {
-    return INVALID;
+  for (const [key, validation] of Object.entries(BORDER_VALIDATION)) {
+    const property = value[key];
+    if (validation === "required-string") {
+      if (typeof property !== "string") {
+        return INVALID;
+      }
+      continue;
+    }
+    if (property === undefined) {
+      continue;
+    }
+    if (
+      (validation === "string" && typeof property !== "string") ||
+      (validation === "number" && !isFiniteNumber(property)) ||
+      (validation === "boolean" && typeof property !== "boolean") ||
+      (validation === "color" && !validateColorValue(property).valid)
+    ) {
+      return INVALID;
+    }
   }
   return VALID;
 };
 
-const PARAGRAPH_BORDER_KEYS = new Set(["top", "bottom", "left", "right", "between", "bar"]);
+type ParagraphBorders = NonNullable<AuthoredParagraphProperties["borders"]>;
+const PARAGRAPH_BORDER_VALIDATION = {
+  top: "border",
+  bottom: "border",
+  left: "border",
+  right: "border",
+  between: "border",
+  bar: "border",
+} as const satisfies Record<keyof ParagraphBorders, "border">;
+const PARAGRAPH_BORDER_KEYS = new Set<string>(Object.keys(PARAGRAPH_BORDER_VALIDATION));
 
 const validateBorders = (value: unknown): ValidationResult => {
   if (!isRecord(value) || !hasOnlyKeys(value, PARAGRAPH_BORDER_KEYS)) {
@@ -190,25 +293,251 @@ const validateBorders = (value: unknown): ValidationResult => {
   return Object.values(value).every((entry) => validateBorder(entry).valid) ? VALID : INVALID;
 };
 
-const SHADING_KEYS = new Set(["color", "fill", "pattern"]);
+const SHADING_VALIDATION = {
+  color: "color",
+  fill: "color",
+  pattern: "pattern",
+} as const satisfies Record<keyof ShadingProperties, "color" | "pattern">;
+const SHADING_KEYS = new Set<string>(Object.keys(SHADING_VALIDATION));
 
 const validateShading = (value: unknown): ValidationResult => {
   if (!isRecord(value) || !hasOnlyKeys(value, SHADING_KEYS)) {
     return INVALID;
   }
-  if (value["color"] !== undefined && !validateColorValue(value["color"]).valid) {
-    return INVALID;
-  }
-  if (value["fill"] !== undefined && !validateColorValue(value["fill"]).valid) {
-    return INVALID;
-  }
-  if (value["pattern"] !== undefined && !isOneOf(value["pattern"], SHADING_PATTERN_VALUES)) {
-    return INVALID;
+  for (const [key, validation] of Object.entries(SHADING_VALIDATION)) {
+    const property = value[key];
+    if (property === undefined) {
+      continue;
+    }
+    if (
+      (validation === "color" && !validateColorValue(property).valid) ||
+      (validation === "pattern" && !isOneOf(property, SHADING_PATTERN_VALUES))
+    ) {
+      return INVALID;
+    }
   }
   return VALID;
 };
 
-const TAB_KEYS = new Set(["position", "alignment", "leader"]);
+const TEXT_FORMATTING_VALIDATION = {
+  bold: "boolean",
+  boldCs: "boolean",
+  italic: "boolean",
+  italicCs: "boolean",
+  underline: "underline",
+  strike: "boolean",
+  doubleStrike: "boolean",
+  vertAlign: "vertical-alignment",
+  smallCaps: "boolean",
+  allCaps: "boolean",
+  hidden: "boolean",
+  color: "color",
+  highlight: "highlight",
+  shading: "shading",
+  fontSize: "number",
+  fontSizeCs: "number",
+  fontFamily: "font-family",
+  language: "language",
+  spacing: "number",
+  position: "number",
+  scale: "number",
+  kerning: "number",
+  effect: "effect",
+  emphasisMark: "emphasis-mark",
+  emboss: "boolean",
+  imprint: "boolean",
+  outline: "boolean",
+  shadow: "boolean",
+  rtl: "boolean",
+  cs: "boolean",
+  styleId: "string",
+} as const satisfies Record<
+  keyof TextFormatting,
+  | "boolean"
+  | "color"
+  | "effect"
+  | "emphasis-mark"
+  | "font-family"
+  | "highlight"
+  | "language"
+  | "number"
+  | "shading"
+  | "string"
+  | "underline"
+  | "vertical-alignment"
+>;
+const TEXT_FORMATTING_KEYS = new Set<string>(Object.keys(TEXT_FORMATTING_VALIDATION));
+
+type TextUnderline = NonNullable<TextFormatting["underline"]>;
+const TEXT_UNDERLINE_VALIDATION = {
+  style: "required-style",
+  color: "color",
+} as const satisfies Record<keyof TextUnderline, "color" | "required-style">;
+const TEXT_UNDERLINE_KEYS = new Set<string>(Object.keys(TEXT_UNDERLINE_VALIDATION));
+
+type TextFontFamily = NonNullable<TextFormatting["fontFamily"]>;
+const TEXT_FONT_FAMILY_VALIDATION = {
+  ascii: "string",
+  hAnsi: "string",
+  eastAsia: "string",
+  cs: "string",
+  hint: "font-hint",
+  asciiTheme: "font-theme",
+  hAnsiTheme: "string",
+  eastAsiaTheme: "string",
+  csTheme: "string",
+} as const satisfies Record<keyof TextFontFamily, "font-hint" | "font-theme" | "string">;
+const TEXT_FONT_FAMILY_KEYS = new Set<string>(Object.keys(TEXT_FONT_FAMILY_VALIDATION));
+
+type TextLanguage = NonNullable<TextFormatting["language"]>;
+const TEXT_LANGUAGE_VALIDATION = {
+  val: "string",
+  eastAsia: "string",
+  bidi: "string",
+} as const satisfies Record<keyof TextLanguage, "string">;
+const TEXT_LANGUAGE_KEYS = new Set<string>(Object.keys(TEXT_LANGUAGE_VALIDATION));
+
+const validateTextFormatting = (value: unknown): ValidationResult => {
+  if (!isRecord(value) || !hasOnlyKeys(value, TEXT_FORMATTING_KEYS)) {
+    return INVALID;
+  }
+  for (const [key, validation] of Object.entries(TEXT_FORMATTING_VALIDATION)) {
+    const property = value[key];
+    if (property === undefined) {
+      continue;
+    }
+    switch (validation) {
+      case "boolean":
+        if (typeof property !== "boolean") return INVALID;
+        break;
+      case "number":
+        if (!isFiniteNumber(property)) return INVALID;
+        break;
+      case "string":
+        if (typeof property !== "string") return INVALID;
+        break;
+      case "vertical-alignment":
+        if (!isOneOf(property, ["baseline", "superscript", "subscript"])) return INVALID;
+        break;
+      case "effect":
+        if (!isOneOf(property, TEXT_EFFECT_VALUES)) return INVALID;
+        break;
+      case "emphasis-mark":
+        if (!isOneOf(property, EMPHASIS_MARK_VALUES)) return INVALID;
+        break;
+      case "highlight":
+        if (!isOneOf(property, HIGHLIGHT_COLOR_VALUES)) return INVALID;
+        break;
+      case "color":
+        if (!validateColorValue(property).valid) return INVALID;
+        break;
+      case "shading":
+        if (!validateShading(property).valid) return INVALID;
+        break;
+      case "underline": {
+        if (!isRecord(property) || !hasOnlyKeys(property, TEXT_UNDERLINE_KEYS)) return INVALID;
+        for (const [underlineKey, underlineValidation] of Object.entries(
+          TEXT_UNDERLINE_VALIDATION,
+        )) {
+          const underlineProperty = property[underlineKey];
+          if (
+            (underlineValidation === "required-style" &&
+              !isOneOf(underlineProperty, UNDERLINE_STYLE_VALUES)) ||
+            (underlineValidation === "color" &&
+              underlineProperty !== undefined &&
+              !validateColorValue(underlineProperty).valid)
+          ) {
+            return INVALID;
+          }
+        }
+        break;
+      }
+      case "font-family": {
+        if (!isRecord(property) || !hasOnlyKeys(property, TEXT_FONT_FAMILY_KEYS)) return INVALID;
+        for (const [fontKey, fontValidation] of Object.entries(TEXT_FONT_FAMILY_VALIDATION)) {
+          const fontProperty = property[fontKey];
+          if (fontProperty === undefined) continue;
+          if (
+            (fontValidation === "string" && typeof fontProperty !== "string") ||
+            (fontValidation === "font-hint" && !isOneOf(fontProperty, FONT_HINT_VALUES)) ||
+            (fontValidation === "font-theme" && !isOneOf(fontProperty, FONT_THEME_VALUES))
+          ) {
+            return INVALID;
+          }
+        }
+        break;
+      }
+      case "language": {
+        if (!isRecord(property) || !hasOnlyKeys(property, TEXT_LANGUAGE_KEYS)) return INVALID;
+        for (const [languageKey] of Object.entries(TEXT_LANGUAGE_VALIDATION)) {
+          const languageProperty = property[languageKey];
+          if (languageProperty !== undefined && typeof languageProperty !== "string") {
+            return INVALID;
+          }
+        }
+        break;
+      }
+      default: {
+        const exhaustive: never = validation;
+        return exhaustive;
+      }
+    }
+  }
+  return VALID;
+};
+
+export const readTextFormatting = (
+  raw: unknown,
+): ParagraphPropertySourceAttribute<TextFormatting> => {
+  if (raw === null || raw === undefined) {
+    return { status: "absent" };
+  }
+  if (!validateTextFormatting(raw).valid) {
+    return { raw, status: "invalid" };
+  }
+  // SAFETY: the total validator established every TextFormatting field.
+  return { status: "valid", value: cloneJsonValue(raw) as TextFormatting };
+};
+
+const PARAGRAPH_MARK_PROPERTY_VALIDATION = {
+  runProperties: "text-formatting",
+  runInWithNext: "boolean",
+} as const satisfies Record<keyof ParagraphMarkProperties, "boolean" | "text-formatting">;
+const PARAGRAPH_MARK_PROPERTY_KEYS = new Set<string>(
+  Object.keys(PARAGRAPH_MARK_PROPERTY_VALIDATION),
+);
+
+export const readParagraphMarkProperties = (
+  raw: unknown,
+): ParagraphPropertySourceAttribute<ParagraphMarkProperties> => {
+  if (raw === null || raw === undefined) {
+    return { status: "absent" };
+  }
+  if (!isRecord(raw) || !hasOnlyKeys(raw, PARAGRAPH_MARK_PROPERTY_KEYS)) {
+    return { raw, status: "invalid" };
+  }
+  for (const [key, validation] of Object.entries(PARAGRAPH_MARK_PROPERTY_VALIDATION)) {
+    const value = raw[key];
+    if (value === undefined) {
+      continue;
+    }
+    if (
+      (validation === "boolean" && typeof value !== "boolean") ||
+      (validation === "text-formatting" && !validateTextFormatting(value).valid)
+    ) {
+      return { raw, status: "invalid" };
+    }
+  }
+  // SAFETY: the exact-key checks and nested validator established the mark shape.
+  return { status: "valid", value: cloneJsonValue(raw) as ParagraphMarkProperties };
+};
+
+const TAB_VALIDATION = {
+  position: "required-number",
+  alignment: "required-alignment",
+  leader: "leader",
+} as const satisfies Record<keyof TabStop, "leader" | "required-alignment" | "required-number">;
+const TAB_KEYS = new Set<string>(Object.keys(TAB_VALIDATION));
 
 const validateTabs = (value: unknown): ValidationResult => {
   if (!Array.isArray(value)) {
@@ -218,74 +547,116 @@ const validateTabs = (value: unknown): ValidationResult => {
     if (!isRecord(tab) || !hasOnlyKeys(tab, TAB_KEYS)) {
       return INVALID;
     }
-    if (!isFiniteNumber(tab["position"])) {
-      return INVALID;
-    }
-    if (!isOneOf(tab["alignment"], TAB_STOP_ALIGNMENT_VALUES)) {
-      return INVALID;
-    }
-    if (tab["leader"] !== undefined && !isOneOf(tab["leader"], TAB_LEADER_VALUES)) {
-      return INVALID;
+    for (const [key, validation] of Object.entries(TAB_VALIDATION)) {
+      const property = tab[key];
+      if (validation === "required-number" && !isFiniteNumber(property)) {
+        return INVALID;
+      }
+      if (
+        validation === "required-alignment" &&
+        !isOneOf(property, TAB_STOP_ALIGNMENT_VALUES)
+      ) {
+        return INVALID;
+      }
+      if (
+        validation === "leader" &&
+        property !== undefined &&
+        !isOneOf(property, TAB_LEADER_VALUES)
+      ) {
+        return INVALID;
+      }
     }
   }
   return VALID;
 };
 
-const NUM_PR_KEYS = new Set(["numId", "ilvl"]);
+type ParagraphNumberingProperties = NonNullable<AuthoredParagraphProperties["numPr"]>;
+const NUM_PR_VALIDATION = {
+  numId: "non-negative-integer",
+  ilvl: "non-negative-integer",
+} as const satisfies Record<keyof ParagraphNumberingProperties, "non-negative-integer">;
+const NUM_PR_KEYS = new Set<string>(Object.keys(NUM_PR_VALIDATION));
+
+type ParagraphSpacingExplicit = NonNullable<AuthoredParagraphProperties["spacingExplicit"]>;
+const SPACING_EXPLICIT_VALIDATION = {
+  before: "boolean",
+  after: "boolean",
+} as const satisfies Record<keyof ParagraphSpacingExplicit, "boolean">;
+const SPACING_EXPLICIT_KEY_LIST = Object.keys(SPACING_EXPLICIT_VALIDATION);
 
 const validateNumPr = (value: unknown): ValidationResult => {
   if (!isRecord(value) || !hasOnlyKeys(value, NUM_PR_KEYS)) {
     return INVALID;
   }
-  if (value["numId"] !== undefined && !isNonNegativeSafeInteger(value["numId"])) {
-    return INVALID;
-  }
-  if (value["ilvl"] !== undefined && !isNonNegativeSafeInteger(value["ilvl"])) {
-    return INVALID;
+  for (const key of Object.keys(NUM_PR_VALIDATION)) {
+    if (value[key] !== undefined && !isNonNegativeSafeInteger(value[key])) {
+      return INVALID;
+    }
   }
   return VALID;
 };
 
-const FRAME_KEYS = new Set([
-  "dropCap",
-  "lines",
-  "width",
-  "height",
-  "hSpace",
-  "vSpace",
-  "hAnchor",
-  "vAnchor",
-  "x",
-  "y",
-  "xAlign",
-  "yAlign",
-  "wrap",
-]);
+type ParagraphFrameProperties = NonNullable<ParagraphFormatting["frame"]>;
+const FRAME_VALIDATION = {
+  dropCap: "drop-cap",
+  lines: "number",
+  width: "number",
+  height: "number",
+  hSpace: "number",
+  vSpace: "number",
+  hAnchor: "horizontal-anchor",
+  vAnchor: "vertical-anchor",
+  x: "number",
+  y: "number",
+  xAlign: "horizontal-alignment",
+  yAlign: "vertical-alignment",
+  wrap: "wrap",
+} as const satisfies Record<
+  keyof ParagraphFrameProperties,
+  | "drop-cap"
+  | "horizontal-alignment"
+  | "horizontal-anchor"
+  | "number"
+  | "vertical-alignment"
+  | "vertical-anchor"
+  | "wrap"
+>;
+const FRAME_KEYS = new Set<string>(Object.keys(FRAME_VALIDATION));
 
 const validateFrame = (value: unknown): ValidationResult => {
   if (!isRecord(value) || !hasOnlyKeys(value, FRAME_KEYS)) {
     return INVALID;
   }
-  if (value["dropCap"] !== undefined && !isOneOf(value["dropCap"], ["none", "drop", "margin"])) {
-    return INVALID;
-  }
-  if (value["hAnchor"] !== undefined && !isOneOf(value["hAnchor"], ["text", "margin", "page"])) {
-    return INVALID;
-  }
-  if (value["vAnchor"] !== undefined && !isOneOf(value["vAnchor"], ["text", "margin", "page"])) {
-    return INVALID;
-  }
-  if (value["xAlign"] !== undefined && !isOneOf(value["xAlign"], FRAME_X_ALIGN_VALUES)) {
-    return INVALID;
-  }
-  if (value["yAlign"] !== undefined && !isOneOf(value["yAlign"], FRAME_Y_ALIGN_VALUES)) {
-    return INVALID;
-  }
-  if (value["wrap"] !== undefined && !isOneOf(value["wrap"], FRAME_WRAP_VALUES)) {
-    return INVALID;
-  }
-  for (const key of ["lines", "width", "height", "hSpace", "vSpace", "x", "y"] as const) {
-    if (value[key] !== undefined && !isFiniteNumber(value[key])) {
+  for (const [key, validation] of Object.entries(FRAME_VALIDATION)) {
+    const property = value[key];
+    if (property === undefined) {
+      continue;
+    }
+    if (validation === "number" && !isFiniteNumber(property)) {
+      return INVALID;
+    }
+    if (validation === "drop-cap" && !isOneOf(property, ["none", "drop", "margin"])) {
+      return INVALID;
+    }
+    if (
+      validation === "horizontal-anchor" &&
+      !isOneOf(property, ["text", "margin", "page"])
+    ) {
+      return INVALID;
+    }
+    if (
+      validation === "vertical-anchor" &&
+      !isOneOf(property, ["text", "margin", "page"])
+    ) {
+      return INVALID;
+    }
+    if (validation === "horizontal-alignment" && !isOneOf(property, FRAME_X_ALIGN_VALUES)) {
+      return INVALID;
+    }
+    if (validation === "vertical-alignment" && !isOneOf(property, FRAME_Y_ALIGN_VALUES)) {
+      return INVALID;
+    }
+    if (validation === "wrap" && !isOneOf(property, FRAME_WRAP_VALUES)) {
       return INVALID;
     }
   }
@@ -325,7 +696,7 @@ const validateAuthoredProperty = (
     case "lineSpacingRule":
       return isOneOf(value, LINE_SPACING_RULE_VALUES) ? VALID : INVALID;
     case "spacingExplicit":
-      return validateOptionalBooleanRecord(value, ["before", "after"]);
+      return validateOptionalBooleanRecord(value, SPACING_EXPLICIT_KEY_LIST);
     case "borders":
       return validateBorders(value);
     case "shading":
@@ -437,20 +808,304 @@ const cloneAuthoredParagraphProperties = (
   return deepFreezeJsonValue(cloneJsonValue(authoredPPr)) as AuthoredParagraphProperties;
 };
 
+type NumberingLevelIndentGeometryKey = keyof NumberingLevelIndentGeometry;
+const NUMBERING_LEVEL_INDENT_GEOMETRY_VALIDATION = {
+  indentLeft: "number",
+  indentRight: "number",
+  indentFirstLine: "number",
+  hangingIndent: "boolean",
+} as const satisfies Record<NumberingLevelIndentGeometryKey, "boolean" | "number">;
+const NUMBERING_LEVEL_INDENT_GEOMETRY_KEYS = new Set<string>(
+  Object.keys(NUMBERING_LEVEL_INDENT_GEOMETRY_VALIDATION),
+);
+
+const validateFirstLineIndent = (value: Record<string, unknown>): ValidationResult => {
+  const firstLine = value["indentFirstLine"];
+  const hanging = value["hangingIndent"];
+  if (hanging === true && (!isFiniteNumber(firstLine) || firstLine >= 0)) {
+    return INVALID;
+  }
+  return isFiniteNumber(firstLine) && firstLine < 0 && hanging !== true ? INVALID : VALID;
+};
+
+const validateNumberingLevelIndentGeometry = (
+  value: unknown,
+  requireNonEmpty: boolean,
+): ValidationResult => {
+  if (!isRecord(value) || !hasOnlyKeys(value, NUMBERING_LEVEL_INDENT_GEOMETRY_KEYS)) {
+    return INVALID;
+  }
+  for (const [key, validation] of Object.entries(
+    NUMBERING_LEVEL_INDENT_GEOMETRY_VALIDATION,
+  )) {
+    const property = value[key];
+    if (property === undefined) {
+      continue;
+    }
+    if (
+      (validation === "number" && !isFiniteNumber(property)) ||
+      (validation === "boolean" && typeof property !== "boolean")
+    ) {
+      return INVALID;
+    }
+  }
+  if (
+    requireNonEmpty &&
+    value["indentLeft"] === undefined &&
+    value["indentRight"] === undefined &&
+    value["indentFirstLine"] === undefined
+  ) {
+    return INVALID;
+  }
+  return validateFirstLineIndent(value);
+};
+
+type LatentNumberingLevelIndent = Extract<NumberingLevelIndentProvenance, { type: "latent" }>;
+type OwnedNumberingLevelIndent = Extract<NumberingLevelIndentProvenance, { type: "owned" }>;
+const LATENT_NUMBERING_LEVEL_INDENT_VALIDATION = {
+  type: "latent",
+  numId: "identity",
+  ilvl: "identity",
+  baseline: "geometry",
+} as const satisfies Record<keyof LatentNumberingLevelIndent, string>;
+const OWNED_NUMBERING_LEVEL_INDENT_VALIDATION = {
+  type: "owned",
+  numId: "identity",
+  ilvl: "identity",
+  baseline: "geometry",
+  owned: "geometry",
+} as const satisfies Record<keyof OwnedNumberingLevelIndent, string>;
+const LATENT_NUMBERING_LEVEL_INDENT_KEYS = new Set<string>(
+  Object.keys(LATENT_NUMBERING_LEVEL_INDENT_VALIDATION),
+);
+const OWNED_NUMBERING_LEVEL_INDENT_KEYS = new Set<string>(
+  Object.keys(OWNED_NUMBERING_LEVEL_INDENT_VALIDATION),
+);
+
+const validateNumberingLevelIndent = (value: unknown): ValidationResult => {
+  if (!isRecord(value) || (value["type"] !== "latent" && value["type"] !== "owned")) {
+    return INVALID;
+  }
+  const keys =
+    value["type"] === "latent"
+      ? LATENT_NUMBERING_LEVEL_INDENT_KEYS
+      : OWNED_NUMBERING_LEVEL_INDENT_KEYS;
+  if (
+    !hasOnlyKeys(value, keys) ||
+    !isNonNegativeSafeInteger(value["numId"]) ||
+    value["numId"] === 0 ||
+    !isNonNegativeSafeInteger(value["ilvl"]) ||
+    !validateNumberingLevelIndentGeometry(value["baseline"], true).valid
+  ) {
+    return INVALID;
+  }
+  if (value["type"] === "latent") {
+    return VALID;
+  }
+  if (!validateNumberingLevelIndentGeometry(value["owned"], true).valid) {
+    return INVALID;
+  }
+  const baseline = value["baseline"] as NonEmptyNumberingLevelIndentGeometry;
+  const owned = value["owned"] as NonEmptyNumberingLevelIndentGeometry;
+  for (const key of Object.keys(
+    NUMBERING_LEVEL_INDENT_GEOMETRY_VALIDATION,
+  ) as NumberingLevelIndentGeometryKey[]) {
+    if (owned[key] !== undefined && owned[key] !== baseline[key]) {
+      return INVALID;
+    }
+  }
+  return VALID;
+};
+
+const PARAGRAPH_MARK_EFFECTIVE_VALIDATION = {
+  defaultTextFormatting: "text-formatting",
+  runInWithNext: "boolean",
+} as const satisfies Record<
+  keyof ParagraphMarkEffectiveProperties,
+  "boolean" | "text-formatting"
+>;
+const PARAGRAPH_MARK_EFFECTIVE_KEYS = new Set<string>(
+  Object.keys(PARAGRAPH_MARK_EFFECTIVE_VALIDATION),
+);
+
+const validateParagraphMarkEffectiveProperties = (value: unknown): ValidationResult => {
+  if (!isRecord(value) || !hasOnlyKeys(value, PARAGRAPH_MARK_EFFECTIVE_KEYS)) {
+    return INVALID;
+  }
+  for (const [key, validation] of Object.entries(PARAGRAPH_MARK_EFFECTIVE_VALIDATION)) {
+    const property = value[key];
+    if (property === undefined) {
+      continue;
+    }
+    if (
+      (validation === "boolean" && typeof property !== "boolean") ||
+      (validation === "text-formatting" && !validateTextFormatting(property).valid)
+    ) {
+      return INVALID;
+    }
+  }
+  return VALID;
+};
+
+const PARAGRAPH_MARK_CONTEXT_VALIDATION = {
+  authored: "paragraph-mark",
+  effective: "effective",
+} as const satisfies Record<keyof ParagraphMarkProjectionContext, "effective" | "paragraph-mark">;
+const PARAGRAPH_MARK_CONTEXT_KEYS = new Set<string>(
+  Object.keys(PARAGRAPH_MARK_CONTEXT_VALIDATION),
+);
+
+const validateParagraphMarkContext = (value: unknown): ValidationResult => {
+  if (!isRecord(value) || !hasOnlyKeys(value, PARAGRAPH_MARK_CONTEXT_KEYS)) {
+    return INVALID;
+  }
+  return readParagraphMarkProperties(value["authored"]).status === "valid" &&
+    validateParagraphMarkEffectiveProperties(value["effective"]).valid
+    ? VALID
+    : INVALID;
+};
+
+const PARAGRAPH_SPACING_INHERITANCE_VALIDATION = {
+  before: "spacing-source",
+  after: "spacing-source",
+} as const satisfies Record<keyof ParagraphSpacingInheritance, "spacing-source">;
+const PARAGRAPH_SPACING_INHERITANCE_KEYS = new Set<string>(
+  Object.keys(PARAGRAPH_SPACING_INHERITANCE_VALIDATION),
+);
+const PARAGRAPH_SPACING_INHERITANCE_VALUES = Object.freeze(
+  Object.values(PARAGRAPH_SPACING_INHERITANCE_SOURCE),
+);
+
+const validateParagraphSpacingInheritance = (value: unknown): ValidationResult => {
+  if (!isRecord(value) || !hasOnlyKeys(value, PARAGRAPH_SPACING_INHERITANCE_KEYS)) {
+    return INVALID;
+  }
+  return Object.values(value).every((entry) =>
+    isOneOf(entry, PARAGRAPH_SPACING_INHERITANCE_VALUES),
+  )
+    ? VALID
+    : INVALID;
+};
+
+const PARAGRAPH_PROPERTY_CONTEXT_VALIDATION = {
+  inheritedPPr: "authored-ppr",
+  numberingLevelIndent: "numbering-indent",
+  numPrFromStyle: "num-pr",
+  paragraphMark: "paragraph-mark",
+  spacingInheritance: "spacing-inheritance",
+} as const satisfies Record<keyof SerializedParagraphPropertyProjectionContext, string>;
+const PARAGRAPH_PROPERTY_CONTEXT_KEYS = new Set<string>(
+  Object.keys(PARAGRAPH_PROPERTY_CONTEXT_VALIDATION),
+);
+
+const validateParagraphPropertyProjectionContext = (value: unknown): ValidationResult => {
+  if (!isRecord(value) || !hasOnlyKeys(value, PARAGRAPH_PROPERTY_CONTEXT_KEYS)) {
+    return INVALID;
+  }
+  if (
+    readAuthoredParagraphProperties(value["inheritedPPr"]).status !== "valid" ||
+    !validateParagraphMarkContext(value["paragraphMark"]).valid ||
+    !validateParagraphSpacingInheritance(value["spacingInheritance"]).valid
+  ) {
+    return INVALID;
+  }
+  const numberingLevelIndent = value["numberingLevelIndent"];
+  if (
+    numberingLevelIndent !== null &&
+    !validateNumberingLevelIndent(numberingLevelIndent).valid
+  ) {
+    return INVALID;
+  }
+  const numPrFromStyle = value["numPrFromStyle"];
+  if (numPrFromStyle !== null && !validateNumPr(numPrFromStyle).valid) {
+    return INVALID;
+  }
+  const inheritedPPr = value["inheritedPPr"] as AuthoredParagraphProperties;
+  const spacingInheritance = value["spacingInheritance"] as ParagraphSpacingInheritance;
+  if (
+    (spacingInheritance.before !== undefined && inheritedPPr.spaceBefore === undefined) ||
+    (spacingInheritance.after !== undefined && inheritedPPr.spaceAfter === undefined)
+  ) {
+    return INVALID;
+  }
+  return VALID;
+};
+
+const cloneParagraphPropertyProjectionContext = (
+  context: SerializedParagraphPropertyProjectionContext,
+): ParagraphPropertyProjectionContext => {
+  if (!validateParagraphPropertyProjectionContext(context).valid) {
+    panic("Invalid paragraph-property projection context");
+  }
+  // SAFETY: the total context and nested validators establish the complete shape.
+  return deepFreezeJsonValue(cloneJsonValue(context)) as ParagraphPropertyProjectionContext;
+};
+
+const effectiveNumberingIdentity = (
+  authoredPPr: DeepReadonly<AuthoredParagraphProperties>,
+  context: ParagraphPropertyProjectionContext,
+): ParagraphFormatting["numPr"] | undefined => {
+  const inherited = context.inheritedPPr.numPr;
+  const authored = authoredPPr.numPr;
+  if (inherited === undefined && authored === undefined) {
+    return undefined;
+  }
+  return { ...inherited, ...authored };
+};
+
+const paragraphPropertyStatePayloadIsValid = (
+  authoredPPr: AuthoredParagraphProperties,
+  context: ParagraphPropertyProjectionContext,
+): boolean => {
+  const provenance = context.numberingLevelIndent;
+  if (provenance === null) {
+    return true;
+  }
+  const numbering = effectiveNumberingIdentity(authoredPPr, context);
+  return !(
+    numbering?.numId === undefined ||
+    numbering.numId === 0 ||
+    numbering.numId !== provenance.numId ||
+    (numbering.ilvl ?? 0) !== provenance.ilvl
+  );
+};
+
+const assertParagraphPropertyStatePayload = (
+  authoredPPr: AuthoredParagraphProperties,
+  context: ParagraphPropertyProjectionContext,
+): void => {
+  if (!paragraphPropertyStatePayloadIsValid(authoredPPr, context)) {
+    panic("Numbering indentation provenance must match effective paragraph numbering");
+  }
+};
+
+const trustedParagraphPropertyPayload = (
+  authoredPPr: AuthoredParagraphProperties,
+  context: SerializedParagraphPropertyProjectionContext,
+): Pick<TrustedParagraphPropertyState, "authoredPPr" | "context"> => {
+  const trustedAuthored = cloneAuthoredParagraphProperties(authoredPPr);
+  const trustedContext = cloneParagraphPropertyProjectionContext(context);
+  assertParagraphPropertyStatePayload(trustedAuthored, trustedContext);
+  return { authoredPPr: trustedAuthored, context: trustedContext };
+};
+
 type UntrustedStateBranch =
   | {
       type: "imported";
       token: ParagraphPropertySourceToken;
       authoredPPr: AuthoredParagraphProperties;
+      context: ParagraphPropertyProjectionContext;
     }
   | {
       type: "editor-created";
       authoredPPr: AuthoredParagraphProperties;
+      context: ParagraphPropertyProjectionContext;
     }
   | {
       type: "transient-template";
       handle: ParagraphPropertyTransientTemplateHandle;
       authoredPPr: AuthoredParagraphProperties;
+      context: ParagraphPropertyProjectionContext;
     };
 
 const trustParagraphPropertyState = <Branch extends UntrustedStateBranch>(
@@ -462,6 +1117,15 @@ const trustParagraphPropertyState = <Branch extends UntrustedStateBranch>(
     value: true,
     writable: false,
   });
+  if (state.type === "transient-template") {
+    Object.defineProperty(state, "toJSON", {
+      configurable: false,
+      enumerable: false,
+      value: () =>
+        panic("Transient paragraph-property state cannot cross a persistence boundary"),
+      writable: false,
+    });
+  }
   Object.freeze(state);
   // SAFETY: this function alone installs the private runtime brand after all
   // payloads have passed validation and deep freezing.
@@ -471,32 +1135,46 @@ const trustParagraphPropertyState = <Branch extends UntrustedStateBranch>(
 const stateKeysAreValid = (value: Record<string, unknown>, type: string): boolean => {
   switch (type) {
     case "imported":
-      return hasOnlyKeys(value, new Set(["type", "token", "authoredPPr"]));
+      return hasOnlyKeys(value, IMPORTED_STATE_KEYS);
     case "editor-created":
-      return hasOnlyKeys(value, new Set(["type", "authoredPPr"]));
-    case "transient-template":
-      return hasOnlyKeys(value, new Set(["type", "handle", "authoredPPr"]));
+      return hasOnlyKeys(value, EDITOR_STATE_KEYS);
     default:
       return false;
   }
 };
 
-export const createImportedParagraphPropertyState = (
-  token: ParagraphPropertySourceToken,
-  authoredPPr: AuthoredParagraphProperties,
-): PersistableParagraphPropertyState =>
+const IMPORTED_STATE_KEYS = new Set<string>(["type", "token", "authoredPPr", "context"]);
+const EDITOR_STATE_KEYS = new Set<string>(["type", "authoredPPr", "context"]);
+
+type CreateImportedParagraphPropertyStateOptions = {
+  token: ParagraphPropertySourceToken;
+  authoredPPr: AuthoredParagraphProperties;
+  context: SerializedParagraphPropertyProjectionContext;
+};
+
+export const createImportedParagraphPropertyState = ({
+  token,
+  authoredPPr,
+  context,
+}: CreateImportedParagraphPropertyStateOptions): PersistableParagraphPropertyState =>
   trustParagraphPropertyState({
     type: "imported",
     token,
-    authoredPPr: cloneAuthoredParagraphProperties(authoredPPr),
+    ...trustedParagraphPropertyPayload(authoredPPr, context),
   });
 
-export const createEditorParagraphPropertyState = (
-  authoredPPr: AuthoredParagraphProperties = {},
-): PersistableParagraphPropertyState =>
+type CreateEditorParagraphPropertyStateOptions = {
+  authoredPPr?: AuthoredParagraphProperties;
+  context?: SerializedParagraphPropertyProjectionContext;
+};
+
+export const createEditorParagraphPropertyState = ({
+  authoredPPr = {},
+  context = EMPTY_PARAGRAPH_PROPERTY_CONTEXT,
+}: CreateEditorParagraphPropertyStateOptions = {}): PersistableParagraphPropertyState =>
   trustParagraphPropertyState({
     type: "editor-created",
-    authoredPPr: cloneAuthoredParagraphProperties(authoredPPr),
+    ...trustedParagraphPropertyPayload(authoredPPr, context),
   });
 
 /** Validate and freeze the model-level authored selector at the PM trust boundary. */
@@ -505,15 +1183,25 @@ export const authoredParagraphPropertiesFromFormatting = (
 ): AuthoredParagraphProperties =>
   cloneAuthoredParagraphProperties(selectAuthoredParagraphProperties(formatting));
 
-export const createTransientTemplateParagraphPropertyState = (
-  handle: ParagraphPropertyTransientTemplateHandle,
-  authoredPPr: AuthoredParagraphProperties,
-): ParagraphPropertyState =>
+type CreateTransientTemplateParagraphPropertyStateOptions = {
+  handle: ParagraphPropertyTransientTemplateHandle;
+  authoredPPr: AuthoredParagraphProperties;
+  context: SerializedParagraphPropertyProjectionContext;
+};
+
+export const createTransientTemplateParagraphPropertyState = ({
+  handle,
+  authoredPPr,
+  context,
+}: CreateTransientTemplateParagraphPropertyStateOptions): ParagraphPropertyState =>
   trustParagraphPropertyState({
     type: "transient-template",
     handle,
-    authoredPPr: cloneAuthoredParagraphProperties(authoredPPr),
+    ...trustedParagraphPropertyPayload(authoredPPr, context),
   });
+
+const isTrustedParagraphPropertyState = (raw: unknown): raw is ParagraphPropertyState =>
+  isRecord(raw) && Reflect.get(raw, TRUSTED_PARAGRAPH_PROPERTY_STATE) === true;
 
 export const readParagraphPropertyState = (
   raw: unknown,
@@ -521,41 +1209,45 @@ export const readParagraphPropertyState = (
   if (raw === null || raw === undefined) {
     return { status: "absent" };
   }
+  if (isTrustedParagraphPropertyState(raw)) {
+    return { status: "valid", value: raw };
+  }
   if (!isRecord(raw) || typeof raw["type"] !== "string") {
     return { raw, status: "invalid" };
   }
   const type = raw["type"];
-  if (!stateKeysAreValid(raw, type) || !validateAuthoredParagraphProperties(raw["authoredPPr"]).valid) {
+  if (
+    !stateKeysAreValid(raw, type) ||
+    !validateAuthoredParagraphProperties(raw["authoredPPr"]).valid ||
+    !validateParagraphPropertyProjectionContext(raw["context"]).valid
+  ) {
     return { raw, status: "invalid" };
   }
   // SAFETY: the validation above established the complete descriptor-owned shape.
   const authoredPPr = cloneAuthoredParagraphProperties(
     raw["authoredPPr"] as AuthoredParagraphProperties,
   );
+  const context = cloneParagraphPropertyProjectionContext(
+    raw["context"] as SerializedParagraphPropertyProjectionContext,
+  );
+  if (!paragraphPropertyStatePayloadIsValid(authoredPPr, context)) {
+    return { raw, status: "invalid" };
+  }
   switch (type) {
     case "imported": {
       const token = ParagraphPropertySourceToken.read(raw["token"]);
       return token.status === "valid"
         ? {
             status: "valid",
-            value: trustParagraphPropertyState({ type, token: token.value, authoredPPr }),
+            value: trustParagraphPropertyState({ type, token: token.value, authoredPPr, context }),
           }
         : { raw, status: "invalid" };
     }
     case "editor-created":
       return {
         status: "valid",
-        value: trustParagraphPropertyState({ type, authoredPPr }),
+        value: trustParagraphPropertyState({ type, authoredPPr, context }),
       };
-    case "transient-template": {
-      const handle = ParagraphPropertyTransientTemplateHandle.read(raw["handle"]);
-      return handle.status === "valid"
-        ? {
-            status: "valid",
-            value: trustParagraphPropertyState({ type, handle: handle.value, authoredPPr }),
-          }
-        : { raw, status: "invalid" };
-    }
     default:
       return { raw, status: "invalid" };
   }
@@ -583,34 +1275,6 @@ export const expectParagraphPropertyState = (raw: unknown): ParagraphPropertySta
   return result.value;
 };
 
-export const serializeParagraphPropertyState = (
-  state: ParagraphPropertyState,
-): SerializedParagraphPropertyState => {
-  switch (state.type) {
-    case "imported":
-      return {
-        type: "imported",
-        token: state.token.serialized,
-        authoredPPr: cloneAuthoredParagraphProperties(state.authoredPPr),
-      };
-    case "editor-created":
-      return {
-        type: "editor-created",
-        authoredPPr: cloneAuthoredParagraphProperties(state.authoredPPr),
-      };
-    case "transient-template":
-      return {
-        type: "transient-template",
-        handle: state.handle.serialized,
-        authoredPPr: cloneAuthoredParagraphProperties(state.authoredPPr),
-      };
-    default: {
-      const exhaustive: never = state;
-      return exhaustive;
-    }
-  }
-};
-
 /** Serialize only state safe to store in Yjs or another persistent document. */
 export const serializePersistableParagraphPropertyState = (
   state: ParagraphPropertyState,
@@ -621,11 +1285,13 @@ export const serializePersistableParagraphPropertyState = (
         type: "imported",
         token: state.token.serialized,
         authoredPPr: cloneAuthoredParagraphProperties(state.authoredPPr),
+        context: cloneJsonValue(state.context) as SerializedParagraphPropertyProjectionContext,
       };
     case "editor-created":
       return {
         type: "editor-created",
         authoredPPr: cloneAuthoredParagraphProperties(state.authoredPPr),
+        context: cloneJsonValue(state.context) as SerializedParagraphPropertyProjectionContext,
       };
     case "transient-template":
       return panic("Transient paragraph-property state cannot cross a persistence boundary");
@@ -636,27 +1302,45 @@ export const serializePersistableParagraphPropertyState = (
   }
 };
 
+/** PM attrs carry wire-safe state, except a conversion-scoped nominal transient capsule. */
+export type ParagraphPropertyStateAttribute =
+  | SerializedParagraphPropertyState
+  | Extract<ParagraphPropertyState, { type: "transient-template" }>;
+
+export const paragraphPropertyStateAttribute = (
+  state: ParagraphPropertyState,
+): ParagraphPropertyStateAttribute =>
+  state.type === "transient-template" ? state : serializePersistableParagraphPropertyState(state);
+
 export const transitionParagraphPropertyState = (
   state: ParagraphPropertyState,
   transition: ParagraphPropertyStateTransition,
 ): ParagraphPropertyState => {
   if (transition.type === "editor-copy") {
-    return createEditorParagraphPropertyState(state.authoredPPr);
+    return createEditorParagraphPropertyState({
+      authoredPPr: state.authoredPPr,
+      context: state.context,
+    });
   }
-  const authoredPPr =
-    transition.type === "replace-authored"
-      ? cloneAuthoredParagraphProperties(transition.authoredPPr)
-      : applyParagraphPropertyMutations(state.authoredPPr, transition.mutations);
+  const authoredPPr = applyAuthoredTransition(state.authoredPPr, transition.authored);
+  const context = applyContextTransition(state.context, transition.context);
+  assertParagraphPropertyStatePayload(authoredPPr, context);
   switch (state.type) {
     case "imported":
-      return trustParagraphPropertyState({ type: "imported", token: state.token, authoredPPr });
+      return trustParagraphPropertyState({
+        type: "imported",
+        token: state.token,
+        authoredPPr,
+        context,
+      });
     case "editor-created":
-      return trustParagraphPropertyState({ type: "editor-created", authoredPPr });
+      return trustParagraphPropertyState({ type: "editor-created", authoredPPr, context });
     case "transient-template":
       return trustParagraphPropertyState({
         type: "transient-template",
         handle: state.handle,
         authoredPPr,
+        context,
       });
     default: {
       const exhaustive: never = state;
@@ -665,8 +1349,103 @@ export const transitionParagraphPropertyState = (
   }
 };
 
+const applyAuthoredTransition = (
+  authoredPPr: DeepReadonly<AuthoredParagraphProperties>,
+  transition: ParagraphPropertyAuthoredTransition,
+): AuthoredParagraphProperties => {
+  switch (transition.type) {
+    case "preserve":
+      return cloneAuthoredParagraphProperties(authoredPPr);
+    case "mutate":
+      return applyParagraphPropertyMutations(authoredPPr, transition.mutations);
+    case "replace":
+      return cloneAuthoredParagraphProperties(transition.authoredPPr);
+    default: {
+      const exhaustive: never = transition;
+      return exhaustive;
+    }
+  }
+};
+
+const applyParagraphMarkMutations = (
+  mark: ParagraphMarkProperties,
+  mutations: readonly ParagraphMarkPropertyMutation[],
+): ParagraphMarkProperties => {
+  const next = cloneJsonValue(mark) as ParagraphMarkProperties;
+  const seen = new Set<ParagraphMarkPropertyMutation["key"]>();
+  for (const { key, mutation } of mutations) {
+    if (seen.has(key)) {
+      panic(`Paragraph-mark mutation batch contains duplicate key: ${key}`);
+    }
+    seen.add(key);
+    if (mutation.type === "remove") {
+      Reflect.deleteProperty(next, key);
+    } else {
+      Reflect.set(next, key, cloneJsonValue(mutation.value));
+    }
+  }
+  const validated = readParagraphMarkProperties(next);
+  if (validated.status !== "valid") {
+    panic("Invalid paragraph-mark mutation result");
+  }
+  return validated.value;
+};
+
+const applyParagraphMarkEffectiveMutations = (
+  mark: ParagraphMarkEffectiveProperties,
+  mutations: readonly ParagraphMarkEffectivePropertyMutation[],
+): ParagraphMarkEffectiveProperties => {
+  const next = cloneJsonValue(mark) as ParagraphMarkEffectiveProperties;
+  const seen = new Set<ParagraphMarkEffectivePropertyMutation["key"]>();
+  for (const { key, mutation } of mutations) {
+    if (seen.has(key)) {
+      panic(`Effective paragraph-mark mutation batch contains duplicate key: ${key}`);
+    }
+    seen.add(key);
+    if (mutation.type === "remove") {
+      Reflect.deleteProperty(next, key);
+    } else {
+      Reflect.set(next, key, cloneJsonValue(mutation.value));
+    }
+  }
+  if (!validateParagraphMarkEffectiveProperties(next).valid) {
+    panic("Invalid effective paragraph-mark mutation result");
+  }
+  return next;
+};
+
+const applyContextTransition = (
+  context: ParagraphPropertyProjectionContext,
+  transition: ParagraphPropertyContextTransition,
+): ParagraphPropertyProjectionContext => {
+  switch (transition.type) {
+    case "preserve":
+      return cloneParagraphPropertyProjectionContext(context);
+    case "replace":
+      return cloneParagraphPropertyProjectionContext(transition.context);
+    case "mutate-paragraph-mark":
+      return cloneParagraphPropertyProjectionContext({
+        ...context,
+        paragraphMark: {
+          authored: applyParagraphMarkMutations(
+            context.paragraphMark.authored,
+            transition.authored,
+          ),
+          effective: applyParagraphMarkEffectiveMutations(
+            context.paragraphMark.effective,
+            transition.effective,
+          ),
+        },
+      });
+    default: {
+      const exhaustive: never = transition;
+      return exhaustive;
+    }
+  }
+};
+
 export const applyParagraphPropertyMutations = (
-  authoredPPr: AuthoredParagraphProperties,
+  authoredPPr: DeepReadonly<AuthoredParagraphProperties>,
   mutations: readonly ParagraphPropertyMutation[],
 ): AuthoredParagraphProperties => {
   if (!validateAuthoredParagraphProperties(authoredPPr).valid) {
@@ -711,7 +1490,10 @@ export const splitParagraphPropertyState = (
     case "split-left-created-right-retains":
       return {
         type: transition.type,
-        left: createEditorParagraphPropertyState(state.authoredPPr),
+        left: createEditorParagraphPropertyState({
+          authoredPPr: state.authoredPPr,
+          context: state.context,
+        }),
         right: state,
       };
     default: {
@@ -738,7 +1520,19 @@ export const joinParagraphPropertyStates = (
   }
 };
 
+export const EMPTY_PARAGRAPH_PROPERTY_CONTEXT = Object.freeze({
+  inheritedPPr: Object.freeze({}),
+  numberingLevelIndent: null,
+  numPrFromStyle: null,
+  paragraphMark: Object.freeze({
+    authored: Object.freeze({}),
+    effective: Object.freeze({}),
+  }),
+  spacingInheritance: Object.freeze({}),
+}) satisfies SerializedParagraphPropertyProjectionContext;
+
 export const EMPTY_EDITOR_PARAGRAPH_PROPERTY_STATE = Object.freeze({
   type: "editor-created",
   authoredPPr: Object.freeze({}),
+  context: EMPTY_PARAGRAPH_PROPERTY_CONTEXT,
 }) satisfies SerializedPersistableParagraphPropertyState;

--- a/packages/core/src/prosemirror/paragraphSpacing.ts
+++ b/packages/core/src/prosemirror/paragraphSpacing.ts
@@ -1,10 +1,8 @@
 import type { ParagraphFormatting } from "../types/document";
 import type { FolioAIParagraphSpacing } from "../ai-edits/types";
-import {
-  autospacingMatchesBase,
-  hasAutospacingBaseSide,
-  setAutospacingBaseValue,
-} from "./autospacingBase";
+import { setAutospacingBaseValue } from "./autospacingBase";
+import type { ParagraphSpacingInheritance } from "./paragraphPropertyContext";
+import { expectParagraphPropertyState } from "./paragraphPropertyState";
 import type { ParagraphAttrs } from "./schema/nodes";
 
 /** The complete modeled attribute set of one direct `w:pPr/w:spacing`. */
@@ -38,22 +36,6 @@ export const lineSpacingProvenanceFromSpacing = (
   return hasRule ? "rule" : undefined;
 };
 
-/** Resolve exact provenance, including editor states written with the former boolean marker. */
-const lineSpacingProvenance = (attrs: ParagraphAttrs): ExactLineSpacingProvenance | undefined => {
-  if (typeof attrs.lineSpacingExplicit === "string") {
-    return attrs.lineSpacingExplicit;
-  }
-  const original = paragraphSpacingFromFormatting(attrs._originalFormatting);
-  const originalProvenance = lineSpacingProvenanceFromSpacing(original);
-  if (originalProvenance !== undefined || attrs.lineSpacingExplicit !== true) {
-    return originalProvenance;
-  }
-  return lineSpacingProvenanceFromSpacing({
-    ...(typeof attrs.lineSpacing === "number" ? { lineSpacing: attrs.lineSpacing } : {}),
-    ...(attrs.lineSpacingRule !== undefined ? { lineSpacingRule: attrs.lineSpacingRule } : {}),
-  });
-};
-
 /** Project only authored `w:spacing` attributes, preserving explicit zero and false. */
 export const paragraphSpacingFromFormatting = (
   formatting: DirectParagraphSpacing | null | undefined,
@@ -80,75 +62,15 @@ export const paragraphSpacingFromFormatting = (
 
 /**
  * Read direct spacing independently of the effective values used for layout.
- * Imported and command-authored paragraphs keep their source in
- * `_originalFormatting`; explicit PM attrs cover newly created content.
+ * Mandatory authored state is the sole source. Effective spacing and its
+ * auto-spacing baseline are projections, never fallback provenance.
  */
 export const directParagraphSpacing = (
   attrs: ParagraphAttrs,
-): DirectParagraphSpacing | undefined => {
-  const spacing = paragraphSpacingFromFormatting(attrs._originalFormatting) ?? {};
-  const lineProvenance = lineSpacingProvenance(attrs);
-  const spaceBefore: unknown = attrs.spaceBefore;
-  const spaceAfter: unknown = attrs.spaceAfter;
-  const beforeHasBase = hasAutospacingBaseSide(attrs._autospacingBase, "before");
-  const afterHasBase = hasAutospacingBaseSide(attrs._autospacingBase, "after");
-  const beforeAutospacingEdited = beforeHasBase
-    ? !autospacingMatchesBase(attrs._autospacingBase, "before", spaceBefore)
-    : spacing.beforeAutospacing === true && attrs._autospacingBase == null;
-  const afterAutospacingEdited = afterHasBase
-    ? !autospacingMatchesBase(attrs._autospacingBase, "after", spaceAfter)
-    : spacing.afterAutospacing === true && attrs._autospacingBase == null;
-
-  if (beforeAutospacingEdited) {
-    spacing.beforeAutospacing = false;
-    if (typeof spaceBefore === "number") {
-      spacing.spaceBefore = spaceBefore;
-    } else {
-      Reflect.deleteProperty(spacing, "spaceBefore");
-    }
-  }
-  if (afterAutospacingEdited) {
-    spacing.afterAutospacing = false;
-    if (typeof spaceAfter === "number") {
-      spacing.spaceAfter = spaceAfter;
-    } else {
-      Reflect.deleteProperty(spacing, "spaceAfter");
-    }
-  }
-  if (spacing.spaceBefore !== undefined || attrs.spacingExplicit?.before === true) {
-    if (typeof spaceBefore === "number") {
-      spacing.spaceBefore = spaceBefore;
-    } else {
-      Reflect.deleteProperty(spacing, "spaceBefore");
-    }
-  }
-  if (spacing.spaceAfter !== undefined || attrs.spacingExplicit?.after === true) {
-    if (typeof spaceAfter === "number") {
-      spacing.spaceAfter = spaceAfter;
-    } else {
-      Reflect.deleteProperty(spacing, "spaceAfter");
-    }
-  }
-  if (lineProvenance === "value" || lineProvenance === "both") {
-    if (typeof attrs.lineSpacing === "number") {
-      spacing.lineSpacing = attrs.lineSpacing;
-    } else {
-      Reflect.deleteProperty(spacing, "lineSpacing");
-    }
-  } else {
-    Reflect.deleteProperty(spacing, "lineSpacing");
-  }
-  if (lineProvenance === "rule" || lineProvenance === "both") {
-    if (attrs.lineSpacingRule !== undefined) {
-      spacing.lineSpacingRule = attrs.lineSpacingRule;
-    } else {
-      Reflect.deleteProperty(spacing, "lineSpacingRule");
-    }
-  } else {
-    Reflect.deleteProperty(spacing, "lineSpacingRule");
-  }
-  return Object.keys(spacing).length > 0 ? spacing : undefined;
-};
+): DirectParagraphSpacing | undefined =>
+  paragraphSpacingFromFormatting(
+    expectParagraphPropertyState(attrs._paragraphPropertyState).authoredPPr,
+  );
 
 /** Structural equality for the canonical, fixed-order spacing projection. */
 export const paragraphSpacingEqual = (
@@ -188,23 +110,33 @@ export const withDirectParagraphSpacing = (
 type ParagraphSpacingAttrPatchOptions = {
   direct: DirectParagraphSpacing | null | undefined;
   inherited: DirectParagraphSpacing | null | undefined;
+  inheritance: ParagraphSpacingInheritance;
 };
 
 /** Project direct-over-inherited spacing into the attrs consumed by layout. */
 export const paragraphSpacingAttrPatch = ({
   direct,
   inherited,
+  inheritance,
 }: ParagraphSpacingAttrPatchOptions): Record<string, unknown> => {
   const effective = { ...inherited, ...direct };
   const spacingExplicit = {
     ...(direct?.spaceBefore !== undefined ? { before: true } : {}),
     ...(direct?.spaceAfter !== undefined ? { after: true } : {}),
   };
-  const spacingFromStyle = {
-    ...(direct?.spaceBefore === undefined && inherited?.spaceBefore !== undefined
+  const spacingFromDocDefaults = {
+    ...(direct?.spaceBefore === undefined && inheritance.before === "document-default"
       ? { before: true }
       : {}),
-    ...(direct?.spaceAfter === undefined && inherited?.spaceAfter !== undefined
+    ...(direct?.spaceAfter === undefined && inheritance.after === "document-default"
+      ? { after: true }
+      : {}),
+  };
+  const spacingFromImplicitDefaultStyle = {
+    ...(direct?.spaceBefore === undefined && inheritance.before === "implicit-default-style"
+      ? { before: true }
+      : {}),
+    ...(direct?.spaceAfter === undefined && inheritance.after === "implicit-default-style"
       ? { after: true }
       : {}),
   };
@@ -222,8 +154,12 @@ export const paragraphSpacingAttrPatch = ({
     lineSpacingRule: effective.lineSpacingRule ?? null,
     lineSpacingExplicit: lineSpacingProvenanceFromSpacing(direct) ?? null,
     spacingExplicit: Object.keys(spacingExplicit).length > 0 ? spacingExplicit : null,
+    spacingFromDocDefaults:
+      Object.keys(spacingFromDocDefaults).length > 0 ? spacingFromDocDefaults : null,
     spacingFromImplicitDefaultStyle:
-      Object.keys(spacingFromStyle).length > 0 ? spacingFromStyle : null,
+      Object.keys(spacingFromImplicitDefaultStyle).length > 0
+        ? spacingFromImplicitDefaultStyle
+        : null,
     _autospacingBase: Object.keys(autospacingBase).length > 0 ? autospacingBase : null,
   };
 };

--- a/packages/core/src/prosemirror/plugins/suggestionMode.ts
+++ b/packages/core/src/prosemirror/plugins/suggestionMode.ts
@@ -18,7 +18,13 @@ import type { EditorState, Transaction } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
 
 import type { TrackedChangeInfo } from "../../types/document";
+import { expectParagraphAttrs } from "../attrs";
 import { splitBlockClearBorders } from "../extensions/features/BaseKeymapExtension";
+import {
+  applyParagraphPropertyProjection,
+  joinParagraphsWithProperties,
+  preserveParagraphProperties,
+} from "../paragraphPropertyMutation";
 import { canCarryTrackedRunMark } from "../trackedRunInlineAtoms";
 import { mintRevisionId, seedRevisionIdsFromDoc } from "./revisionIds";
 
@@ -434,8 +440,21 @@ function applyPPrDel(
     tr.setMeta(SUGGESTION_META, true);
     const joinPos = targetParagraphPos + targetNode.nodeSize;
     try {
-      tr.join(joinPos);
-      tr.setNodeAttribute(targetParagraphPos, "pPrMark", null);
+      joinParagraphsWithProperties({
+        transaction: tr,
+        joinPos,
+        transition: { type: "join-right-paragraph-mark-retains" },
+      });
+      const joined = tr.doc.nodeAt(targetParagraphPos);
+      if (joined?.type.name !== "paragraph") {
+        return false;
+      }
+      applyParagraphPropertyProjection({
+        transaction: tr,
+        pos: targetParagraphPos,
+        projection: preserveParagraphProperties(expectParagraphAttrs(joined), { pPrMark: null }),
+        source: { type: "preserve" },
+      });
       view.dispatch(tr.scrollIntoView());
     } catch {
       return true;

--- a/packages/core/src/prosemirror/rebaseParagraphRunFormatting.ts
+++ b/packages/core/src/prosemirror/rebaseParagraphRunFormatting.ts
@@ -1,7 +1,8 @@
-import { Mark } from "prosemirror-model";
+import { Mark, type Schema } from "prosemirror-model";
 import type { Transaction } from "prosemirror-state";
 import { panic } from "better-result";
 
+import type { TextFormatting } from "../types/document";
 import {
   expandRunFormattingCarrier,
   type RunFormattingCarrierRepresentation,
@@ -12,22 +13,88 @@ import {
   reconcileRunFormattingMarks,
 } from "./runFormattingReconciliation";
 import { paragraphRunStyleContext, type RunStyleResolver } from "./runStyleFormatting";
+import {
+  applyNonParagraphMarkup,
+  applyParagraphPropertyProjection,
+  createParagraphNodeFromProjection,
+  type ParagraphPropertyProjection,
+} from "./paragraphPropertyMutation";
 
 type RebaseParagraphRunFormattingOptions = {
-  nextAttrs: Record<string, unknown>;
   paragraphPosition: number;
-  styleResolver: RunStyleResolver;
+  projection: ParagraphPropertyProjection;
+  previousTableRunFormatting?: TextFormatting | null;
+  styleResolver?: RunStyleResolver | null;
+  tableRunFormatting?: TextFormatting | null;
   tr: Transaction;
+};
+
+type InheritedParagraphRunFormattingOptions = {
+  paragraph: Parameters<typeof paragraphRunStyleContext>[0];
+  styleResolver?: RunStyleResolver | null;
+  tableRunFormatting?: TextFormatting | null;
+};
+
+const markInheritedFormattingAsKnownEmpty = (
+  marks: readonly Mark[],
+  schema: Schema,
+): readonly Mark[] => {
+  const override = schema.marks["runFormattingOverride"];
+  if (!override || marks.length === 0) {
+    return marks;
+  }
+  return override.create({ _authoredOn: [] }).addToSet(marks);
+};
+
+/** Build physical inherited marks with an explicit known-empty direct baseline. */
+export const inheritedRunFormattingMarks = (
+  formatting: TextFormatting,
+  schema: Schema,
+): readonly Mark[] => {
+  const carrier = schema.text("projection");
+  const marks = reconcileRunFormattingMarks({
+    authoredFormatting: {},
+    context: {
+      baseParagraphFormatting: formatting,
+      paragraphFormatting: formatting,
+      paragraphMarkFormatting: undefined,
+      paragraphMarkPrecedesStyle: false,
+    },
+    node: carrier,
+  }).filter(({ type }) => RUN_FORMATTING_MARK_NAMES.has(type.name));
+  return markInheritedFormattingAsKnownEmpty(marks, schema);
+};
+
+/** Resolve inherited-only live marks/defaults for an existing or empty paragraph. */
+export const inheritedParagraphRunFormatting = ({
+  paragraph,
+  styleResolver,
+  tableRunFormatting,
+}: InheritedParagraphRunFormattingOptions) => {
+  const context = paragraphRunStyleContext(paragraph, styleResolver, tableRunFormatting);
+  const carrier = paragraph.type.schema.text("projection");
+  const marks = reconcileRunFormattingMarks({
+    authoredFormatting: {},
+    context,
+    node: carrier,
+    styleResolver,
+  }).filter(({ type }) => RUN_FORMATTING_MARK_NAMES.has(type.name));
+  return {
+    formatting: context.paragraphFormatting,
+    marks: markInheritedFormattingAsKnownEmpty(marks, paragraph.type.schema),
+  };
 };
 
 /**
  * Change paragraph attrs and re-resolve inherited run marks in the new style
  * context without turning the old rendered style into direct run formatting.
  */
-export const setParagraphAttrsWithRebasedRunFormatting = ({
-  nextAttrs,
+export const setParagraphPropertiesWithRebasedRunFormatting = ({
   paragraphPosition,
+  projection,
+  previousTableRunFormatting,
   styleResolver,
+  tableRunFormatting,
   tr,
 }: RebaseParagraphRunFormattingOptions): Transaction => {
   const paragraph = tr.doc.nodeAt(paragraphPosition);
@@ -38,9 +105,24 @@ export const setParagraphAttrsWithRebasedRunFormatting = ({
     });
   }
 
-  const previousContext = paragraphRunStyleContext(paragraph, styleResolver);
-  const nextParagraph = paragraph.type.create(nextAttrs, paragraph.content, paragraph.marks);
-  const nextContext = paragraphRunStyleContext(nextParagraph, styleResolver);
+  const previousContext = paragraphRunStyleContext(
+    paragraph,
+    styleResolver,
+    previousTableRunFormatting === undefined
+      ? tableRunFormatting
+      : previousTableRunFormatting,
+  );
+  const nextParagraph = createParagraphNodeFromProjection({
+    type: paragraph.type,
+    projection,
+    content: paragraph.content,
+    marks: paragraph.marks,
+  });
+  const nextContext = paragraphRunStyleContext(
+    nextParagraph,
+    styleResolver,
+    tableRunFormatting,
+  );
   const changes: {
     attrs: Readonly<Record<string, unknown>>;
     currentFormattingMarks: readonly Mark[];
@@ -94,10 +176,15 @@ export const setParagraphAttrsWithRebasedRunFormatting = ({
     return false;
   });
 
-  tr = tr.setNodeMarkup(paragraphPosition, undefined, nextAttrs);
+  applyParagraphPropertyProjection({
+    transaction: tr,
+    pos: paragraphPosition,
+    projection,
+    source: { type: "preserve" },
+  });
   for (const { attrs, currentFormattingMarks, from, isText, marks, to } of changes) {
     if (!isText) {
-      tr = tr.setNodeMarkup(from, undefined, attrs, marks);
+      applyNonParagraphMarkup({ transaction: tr, pos: from, attrs, marks });
       continue;
     }
     for (const mark of currentFormattingMarks) {

--- a/packages/core/src/prosemirror/recreateNode.ts
+++ b/packages/core/src/prosemirror/recreateNode.ts
@@ -1,0 +1,18 @@
+import type { Fragment, Mark, Node as PMNode } from "prosemirror-model";
+
+type RecreateProseNodeOptions = {
+  attrs?: PMNode["attrs"];
+  content?: Fragment | PMNode | readonly PMNode[] | null;
+  marks?: readonly Mark[];
+};
+
+/** Immutable ProseMirror rebuild with no hidden ownership side channel. */
+export const recreateProseNode = (
+  source: PMNode,
+  options: RecreateProseNodeOptions = {},
+): PMNode =>
+  source.type.create(
+    options.attrs ?? source.attrs,
+    options.content === undefined ? source.content : options.content,
+    options.marks ?? source.marks,
+  );

--- a/packages/core/src/prosemirror/runStyleFormatting.ts
+++ b/packages/core/src/prosemirror/runStyleFormatting.ts
@@ -1,9 +1,15 @@
 import type { Mark, Node as PMNode } from "prosemirror-model";
+import type { ParagraphMarkProperties } from "@stll/docx-core/model";
 
 import type { StyleEngine } from "../style-engine";
 import type { TextFormatting } from "../types/document";
-import { mergeTextFormatting, STYLE_TOGGLE_KEYS } from "../utils/textFormattingMerge";
+import {
+  mergeStyleTextFormatting,
+  mergeTextFormatting,
+  STYLE_TOGGLE_KEYS,
+} from "../utils/textFormattingMerge";
 import { expectCharacterStyleMarkAttrs, expectParagraphAttrs } from "./attrs";
+import { expectParagraphPropertyState } from "./paragraphPropertyState";
 import {
   cascadeStyleFromResolvedBase,
   cascadeStyleTextFormatting,
@@ -152,17 +158,171 @@ export type ParagraphRunStyleContext = {
 export type RunStyleResolver = Pick<
   StyleEngine,
   | "getDefaultCharacterStyle"
+  | "getDefaultParagraphStyle"
   | "getDocDefaults"
+  | "getStyle"
   | "getRunStyleOwnProperties"
   | "resolveParagraphStyle"
 >;
 
+export const resolveRunFormattingWithoutDefaults = (
+  formatting: TextFormatting | undefined,
+  styleResolver: Pick<StyleEngine, "getRunStyleOwnProperties"> | null,
+): TextFormatting | undefined => {
+  if (!formatting || !styleResolver) {
+    return formatting;
+  }
+  const characterStyleFormatting = formatting.styleId
+    ? styleResolver.getRunStyleOwnProperties(formatting.styleId)
+    : undefined;
+  return cascadeStyleTextFormatting([
+    { formatting: characterStyleFormatting, type: "style" },
+    { formatting, type: "direct" },
+  ]).formatting;
+};
+
+const resolveParagraphStyleRunFormatting = (
+  styleId: string | undefined,
+  styleResolver: RunStyleResolver,
+): TextFormatting | undefined => {
+  let style = styleId ? styleResolver.getStyle(styleId) : styleResolver.getDefaultParagraphStyle();
+  const visited = new Set<string>();
+  const chain: TextFormatting[] = [];
+  while (style?.type === "paragraph" && !visited.has(style.styleId)) {
+    visited.add(style.styleId);
+    if (style.rPr) {
+      chain.push(style.rPr);
+    }
+    style = style.basedOn ? styleResolver.getStyle(style.basedOn) : undefined;
+  }
+  let formatting: TextFormatting | undefined;
+  for (const inherited of chain.reverse()) {
+    formatting = mergeStyleTextFormatting(formatting, inherited);
+  }
+  return formatting;
+};
+
+export const resolveParagraphRunStyleBase = (
+  styleId: string | undefined,
+  styleResolver: RunStyleResolver | null | undefined,
+  tableRunFormatting?: TextFormatting,
+): ReturnType<typeof cascadeStyleTextFormatting> => {
+  const paragraphStyleRunFormatting = styleResolver
+    ? resolveParagraphStyleRunFormatting(styleId, styleResolver)
+    : undefined;
+  const styleRunFormatting = cascadeStyleTextFormatting([
+    { formatting: styleResolver?.getDocDefaults()?.rPr, type: "defaults" },
+    { formatting: paragraphStyleRunFormatting, type: "style" },
+  ]).formatting;
+  const ordinaryStyleFormatting =
+    styleId === undefined
+      ? mergeTextFormatting(styleRunFormatting, tableRunFormatting)
+      : mergeTextFormatting(tableRunFormatting, styleRunFormatting);
+  const cascade = cascadeStyleTextFormatting(
+    [
+      { formatting: styleResolver?.getDocDefaults()?.rPr, type: "defaults" },
+      { formatting: tableRunFormatting, type: "style" },
+      { formatting: paragraphStyleRunFormatting, type: "style" },
+    ],
+    { ordinaryFormatting: ordinaryStyleFormatting },
+  );
+  const paragraphStyleFontFamily = paragraphStyleRunFormatting?.fontFamily;
+  if (!paragraphStyleFontFamily) {
+    return cascade;
+  }
+  return {
+    ...cascade,
+    formatting: mergeTextFormatting(cascade.formatting, {
+      fontFamily: paragraphStyleFontFamily,
+    }),
+  };
+};
+
+type ResolveParagraphRunStyleFormattingOptions = {
+  styleId: string | undefined;
+  styleResolver: RunStyleResolver | null | undefined;
+  tableRunFormatting: TextFormatting | undefined;
+  inheritableParagraphMarkFormatting: TextFormatting | undefined;
+};
+
+export const resolveParagraphRunStyleFormatting = ({
+  styleId,
+  styleResolver,
+  tableRunFormatting,
+  inheritableParagraphMarkFormatting,
+}: ResolveParagraphRunStyleFormattingOptions) => {
+  const baseStyleCascade = resolveParagraphRunStyleBase(styleId, styleResolver, tableRunFormatting);
+  const defaultCharacterFormatting = styleResolver?.getDefaultCharacterStyle()?.rPr;
+  const baseWithDefaultCharacter = mergeTextFormatting(
+    defaultCharacterFormatting,
+    baseStyleCascade.formatting,
+  );
+  const defaultCharacterStyleCascade = cascadeStyleTextFormatting(
+    [
+      { cascade: baseStyleCascade, type: "carried" },
+      { formatting: defaultCharacterFormatting, type: "style" },
+    ],
+    { ordinaryFormatting: baseWithDefaultCharacter },
+  );
+  const defaultRunFormatting = mergeTextFormatting(
+    baseWithDefaultCharacter,
+    inheritableParagraphMarkFormatting,
+  );
+  const defaultRunCascade = cascadeStyleTextFormatting(
+    [
+      { cascade: defaultCharacterStyleCascade, type: "carried" },
+      { formatting: inheritableParagraphMarkFormatting, type: "direct" },
+    ],
+    { ordinaryFormatting: defaultRunFormatting },
+  );
+  return {
+    baseStyleCascade,
+    baseWithDefaultCharacter,
+    defaultCharacterStyleCascade,
+    defaultRunCascade,
+  };
+};
+
+type ResolveEffectiveParagraphMarkFormattingOptions = {
+  authored: ParagraphMarkProperties;
+  styleId: string | undefined;
+  styleResolver: RunStyleResolver | null | undefined;
+  tableRunFormatting: TextFormatting | undefined;
+};
+
+/** Resolve authored paragraph-mark rPr over the complete inherited run cascade. */
+export const resolveEffectiveParagraphMarkFormatting = ({
+  authored,
+  styleId,
+  styleResolver,
+  tableRunFormatting,
+}: ResolveEffectiveParagraphMarkFormattingOptions): TextFormatting | undefined => {
+  const characterStyleFormatting = authored.runProperties?.styleId
+    ? styleResolver?.getRunStyleOwnProperties(authored.runProperties.styleId)
+    : undefined;
+  const resolvedParagraphMarkFormatting = cascadeStyleTextFormatting([
+    { formatting: characterStyleFormatting, type: "style" },
+    { formatting: authored.runProperties, type: "direct" },
+  ]).formatting;
+  const inheritableParagraphMarkFormatting = resolvedParagraphMarkFormatting
+    ? stripParagraphMarkFormattingForBodyRuns(resolvedParagraphMarkFormatting)
+    : undefined;
+  return resolveParagraphRunStyleFormatting({
+    styleId,
+    styleResolver,
+    tableRunFormatting,
+    inheritableParagraphMarkFormatting,
+  }).defaultRunCascade.formatting;
+};
+
 export const paragraphRunStyleContext = (
   paragraph: PMNode,
   styleResolver?: RunStyleResolver | null,
+  tableRunFormatting?: TextFormatting | null,
 ): ParagraphRunStyleContext => {
   const attrs = expectParagraphAttrs(paragraph);
-  const paragraphMarkFormatting = attrs._originalFormatting?.runProperties;
+  const propertyState = expectParagraphPropertyState(attrs._paragraphPropertyState);
+  const paragraphMarkFormatting = propertyState.context.paragraphMark.authored.runProperties;
   const characterStyleFormatting = paragraphMarkFormatting?.styleId
     ? styleResolver?.getRunStyleOwnProperties(paragraphMarkFormatting.styleId)
     : undefined;
@@ -173,9 +333,25 @@ export const paragraphRunStyleContext = (
   const inheritableParagraphMarkFormatting = resolvedParagraphMarkFormatting
     ? stripParagraphMarkFormattingForBodyRuns(resolvedParagraphMarkFormatting)
     : undefined;
+  const tableStyleContext =
+    tableRunFormatting === undefined
+      ? undefined
+      : resolveParagraphRunStyleFormatting({
+          styleId: attrs.styleId,
+          styleResolver,
+          tableRunFormatting: tableRunFormatting ?? undefined,
+          inheritableParagraphMarkFormatting:
+            attrs.styleId === undefined && attrs._tableOfContentsLevel === undefined
+              ? inheritableParagraphMarkFormatting
+              : undefined,
+        });
   return {
-    baseParagraphFormatting: styleResolver?.resolveParagraphStyle(attrs.styleId).runFormatting,
-    paragraphFormatting: attrs.defaultTextFormatting ?? undefined,
+    baseParagraphFormatting:
+      tableStyleContext === undefined
+        ? resolveParagraphRunStyleBase(attrs.styleId, styleResolver).formatting
+        : tableStyleContext.baseStyleCascade.formatting,
+    paragraphFormatting:
+      propertyState.context.paragraphMark.effective.defaultTextFormatting ?? undefined,
     paragraphMarkFormatting: inheritableParagraphMarkFormatting,
     paragraphMarkPrecedesStyle: attrs.styleId !== undefined,
   };

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -45,7 +45,12 @@ import type {
 } from "../../types/document";
 import type { OutlineStyleAttr } from "../../types/documentEnumValues";
 import type { SpacingExplicit } from "../../types/formatting";
+import type {
+  AuthoredParagraphProperties,
+  ParagraphMarkProperties,
+} from "../../docx/paragraphPropertyDescriptor";
 import type { ParagraphDirection } from "../paragraphDirection";
+import type { SerializedParagraphPropertyState } from "../paragraphPropertyState";
 import type { TrackedChangeProvenance } from "./marks";
 
 export type HardBreakAttrs = {
@@ -101,6 +106,8 @@ export type ParagraphAttrs = {
   overflowPunctuation?: boolean;
   /** Effective paragraph opt-out from document automatic hyphenation. */
   suppressAutoHyphens?: boolean;
+  /** Effective paragraph opt-out from section line numbering. */
+  suppressLineNumbers?: boolean;
 
   // Spacing (in twips)
   spaceBefore?: number;
@@ -241,6 +248,9 @@ export type ParagraphAttrs = {
   // Outline level for TOC (0-9)
   outlineLevel?: number;
 
+  /** Effective frame properties after inherited and authored resolution. */
+  frame?: ParagraphFormatting["frame"];
+
   // Bookmarks on this paragraph (for TOC anchors, cross-references)
   bookmarks?: { id: number; name: string }[];
 
@@ -264,9 +274,17 @@ export type ParagraphAttrs = {
    */
   runInWithNext?: boolean;
 
-  /** Original inline paragraph formatting from DOCX (pre-style-resolution).
-   *  Used by fromProseDoc for lossless round-trip serialization. */
-  _originalFormatting?: ParagraphFormatting;
+  /** Mandatory authored CT_PPrBase state; effective/layout attrs stay separate. */
+  _paragraphPropertyState: SerializedParagraphPropertyState;
+
+  /** Effective style/table/default pPr layer beneath the authored payload. */
+  _paragraphPropertyInheritance: AuthoredParagraphProperties;
+
+  /** Paragraph-mark properties (`w:pPr/w:rPr`), outside CT_PPrBase provenance. */
+  _paragraphMarkFormatting: ParagraphMarkProperties;
+
+  /** Numbering indentation provenance, derived from the active numbering level. */
+  _numberingLevelIndent?: ParagraphFormatting["numberingLevelIndent"];
 
   /** Import-effective spacing baseline for HTML auto-spacing detection.
    *  PM-only; never serialized back into DOCX formatting. */

--- a/packages/core/src/prosemirror/schema/nodes.ts
+++ b/packages/core/src/prosemirror/schema/nodes.ts
@@ -45,12 +45,8 @@ import type {
 } from "../../types/document";
 import type { OutlineStyleAttr } from "../../types/documentEnumValues";
 import type { SpacingExplicit } from "../../types/formatting";
-import type {
-  AuthoredParagraphProperties,
-  ParagraphMarkProperties,
-} from "../../docx/paragraphPropertyDescriptor";
 import type { ParagraphDirection } from "../paragraphDirection";
-import type { SerializedParagraphPropertyState } from "../paragraphPropertyState";
+import type { ParagraphPropertyStateAttribute } from "../paragraphPropertyState";
 import type { TrackedChangeProvenance } from "./marks";
 
 export type HardBreakAttrs = {
@@ -274,17 +270,8 @@ export type ParagraphAttrs = {
    */
   runInWithNext?: boolean;
 
-  /** Mandatory authored CT_PPrBase state; effective/layout attrs stay separate. */
-  _paragraphPropertyState: SerializedParagraphPropertyState;
-
-  /** Effective style/table/default pPr layer beneath the authored payload. */
-  _paragraphPropertyInheritance: AuthoredParagraphProperties;
-
-  /** Paragraph-mark properties (`w:pPr/w:rPr`), outside CT_PPrBase provenance. */
-  _paragraphMarkFormatting: ParagraphMarkProperties;
-
-  /** Numbering indentation provenance, derived from the active numbering level. */
-  _numberingLevelIndent?: ParagraphFormatting["numberingLevelIndent"];
+  /** Mandatory validated source, authored, inheritance, numbering, and mark state. */
+  _paragraphPropertyState: ParagraphPropertyStateAttribute;
 
   /** Import-effective spacing baseline for HTML auto-spacing detection.
    *  PM-only; never serialized back into DOCX formatting. */

--- a/packages/core/src/prosemirror/styles/resolvedStyleAttrs.ts
+++ b/packages/core/src/prosemirror/styles/resolvedStyleAttrs.ts
@@ -1,146 +1,350 @@
-/**
- * Shared helper for projecting a resolved paragraph style onto ProseMirror
- * paragraph node attrs.
- *
- * Both `applyStyle` (toolbar style picker) and the Enter handler's
- * next-style switch need to write the same set of style-controlled attrs.
- * Keeping the projection in one place ensures the two paths stay in sync —
- * a style applied via the picker and a style applied on Enter produce
- * identical paragraph attrs.
- */
+/** Canonical paragraph style and numbering transitions. */
+
+import {
+  PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR,
+  PARAGRAPH_FORMATTING_PROPERTY_KEY_LIST,
+  selectParagraphMarkProperties,
+  type AuthoredParagraphProperties,
+  type NumberingLevelIndentGeometry,
+} from "@stll/docx-core/model";
 
 import {
   computeListRendering,
   numberingLevelHasMarkerSlot,
   type NumberingMap,
 } from "../../docx/numberingParser";
+import { createNumberingLevelIndentProvenance } from "../../docx/numberingProvenance";
+import type { ParagraphFormatting, TextFormatting } from "../../types/document";
 import { tableOfContentsStyleLevel } from "../../utils/tableOfContentsStyle";
-import { setAutospacingBaseValue } from "../autospacingBase";
+import { mergeTextFormatting } from "../../utils/textFormattingMerge";
 import { CLEARED_LIST_RENDERING_ATTRS } from "../listMarker";
+import {
+  transitionParagraphProperties,
+  type ParagraphPropertyProjection,
+} from "../paragraphPropertyMutation";
+import {
+  applyParagraphPropertyMutations,
+  authoredParagraphPropertiesFromFormatting,
+  expectParagraphPropertyState,
+  type ParagraphPropertyMutation,
+  type ParagraphPropertyProjectionContext,
+} from "../paragraphPropertyState";
 import type { ParagraphAttrs } from "../schema/nodes";
+import {
+  resolveEffectiveParagraphMarkFormatting,
+  type RunStyleResolver,
+} from "../runStyleFormatting";
 import type { ResolvedParagraphStyle } from "./styleResolver";
 
 type ResolvedStyleIdentity = {
-  styleId: string;
+  styleId: string | null;
   styleName?: string;
 };
 
-/**
- * The paragraph attrs a style definition controls. Applying a style resets
- * every one of these to the style's value (or `null` to clear), so a prior
- * style's properties (e.g. a heading's spacing) never leak through. Returns
- * a partial attrs object to merge over the paragraph's existing attrs.
- */
-export function paragraphAttrsFromResolvedStyle(
-  resolved: ResolvedParagraphStyle,
-  identity: ResolvedStyleIdentity,
-): Record<string, unknown> {
-  const ppr = resolved.paragraphFormatting;
-  const runFormatting = resolved.runFormatting;
-  const hasRunFormatting = !!runFormatting && Object.keys(runFormatting).length > 0;
-
-  return {
-    alignment: ppr?.alignment ?? null,
-    alignmentFromStyle: ppr?.alignment,
-    spaceBefore: ppr?.spaceBefore ?? null,
-    spaceAfter: ppr?.spaceAfter ?? null,
-    lineSpacing: ppr?.lineSpacing ?? null,
-    lineSpacingRule: ppr?.lineSpacingRule ?? null,
-    lineSpacingExplicit: null,
-    snapToGrid: ppr?.snapToGrid ?? null,
-    indentLeft: ppr?.indentLeft ?? null,
-    indentRight: ppr?.indentRight ?? null,
-    indentFirstLine: ppr?.indentFirstLine ?? null,
-    hangingIndent: ppr?.hangingIndent ?? null,
-    contextualSpacing: ppr?.contextualSpacing ?? null,
-    keepNext: ppr?.keepNext ?? null,
-    keepLines: ppr?.keepLines ?? null,
-    pageBreakBefore: ppr?.pageBreakBefore ?? null,
-    outlineLevel: ppr?.outlineLevel ?? null,
-    // Custom paragraph styles (callouts, bordered headings) carry their own
-    // `w:pBdr`; the picker and the Enter-into-w:next path both need to apply
-    // them, while clearing any source paragraph's leftover borders when the
-    // new style has none.
-    borders: ppr?.borders ?? null,
-    // The style's run defaults drive the caret height in an empty paragraph
-    // and the formatting typed text inherits (see EmptyParagraphFormatExtension).
-    defaultTextFormatting: hasRunFormatting ? runFormatting : null,
-    _autospacingBase: autospacingBaseFromResolvedParagraphFormatting(ppr),
-    _tableOfContentsLevel: tableOfContentsStyleLevel(identity) ?? null,
-  };
-}
-
-function autospacingBaseFromResolvedParagraphFormatting(
-  ppr: ResolvedParagraphStyle["paragraphFormatting"],
-): ParagraphAttrs["_autospacingBase"] | null {
-  const base: NonNullable<ParagraphAttrs["_autospacingBase"]> = {};
-  if (ppr?.beforeAutospacing) {
-    setAutospacingBaseValue(base, "before", ppr.spaceBefore);
-  }
-  if (ppr?.afterAutospacing) {
-    setAutospacingBaseValue(base, "after", ppr.spaceAfter);
-  }
-
-  return Object.keys(base).length > 0 ? base : null;
-}
-
-/**
- * The list attrs a style's `w:pPr/w:numPr` controls (numbering reference plus
- * the baked marker-rendering attrs that `toProseDoc` normally derives from
- * `listRendering` at load time). Returns null when the style defines no
- * numbering — applying such a style leaves any existing list attrs alone, so
- * directly-applied (toolbar) lists survive a style switch the way they do in
- * Word, where numbering is not cleared by applying an unnumbered style.
- *
- * When the style does define numbering, the full attr group is reset so a
- * previous list's marker attrs never leak into the new one. Without the
- * numbering definitions the marker template can't be resolved and the painter
- * falls back to a plain decimal marker.
- *
- * The content-derived marker attrs (`listImplicitChildLevelAdvances`,
- * `listMarkerSecondSlotOffsetTwips`) are nulled — they depend on the
- * paragraph's inline LISTNUM fields, which the picker has no view of. A
- * subsequent save + reload re-derives them from the document content.
- */
-export function listAttrsFromResolvedStyle(
-  resolved: ResolvedParagraphStyle,
-  numbering: NumberingMap | null | undefined,
-): Record<string, unknown> | null {
-  const numPr = resolved.paragraphFormatting?.numPr;
-  if (!numPr || numPr.numId === undefined || numPr.numId === 0) {
+const effectiveNumbering = (
+  authored: AuthoredParagraphProperties,
+  inherited: AuthoredParagraphProperties,
+): NonNullable<ParagraphFormatting["numPr"]> | null => {
+  if (authored.numPr === undefined && inherited.numPr === undefined) {
     return null;
   }
+  return { ...inherited.numPr, ...authored.numPr };
+};
 
-  const attrs = listAttrsFromNumbering({ numId: numPr.numId, ilvl: numPr.ilvl ?? 0 }, numbering);
-  const level = numbering?.getLevel(numPr.numId, numPr.ilvl ?? 0);
-  // The numbering belongs to the style — mark it so a save doesn't
-  // materialize a direct <w:numPr> (see ParagraphAttrs.numPrFromStyle).
-  attrs["numPrFromStyle"] = { numId: numPr.numId, ilvl: numPr.ilvl ?? 0 };
+const numberingLevelGeometry = (
+  formatting: ParagraphFormatting | undefined,
+  hasMarkerSlot: boolean,
+): NumberingLevelIndentGeometry => ({
+  ...(formatting?.indentLeft !== undefined ? { indentLeft: formatting.indentLeft } : {}),
+  ...(formatting?.indentRight !== undefined ? { indentRight: formatting.indentRight } : {}),
+  ...(hasMarkerSlot && formatting?.indentFirstLine !== undefined
+    ? { indentFirstLine: formatting.indentFirstLine }
+    : {}),
+  ...(hasMarkerSlot && formatting?.hangingIndent !== undefined
+    ? { hangingIndent: formatting.hangingIndent }
+    : {}),
+});
 
-  // The numbering level's own indents apply beneath the style's (ECMA-376
-  // numbering pPr sits below the style in the cascade) — use them only where
-  // the style doesn't specify its own indentation.
-  const ppr = resolved.paragraphFormatting;
-  if (level?.pPr) {
-    if (ppr?.indentLeft === undefined && level.pPr.indentLeft !== undefined) {
-      attrs["indentLeft"] = level.pPr.indentLeft;
+const numberingIndentContext = (
+  authored: AuthoredParagraphProperties,
+  inherited: AuthoredParagraphProperties,
+  numbering: NumberingMap | null | undefined,
+): ParagraphFormatting["numberingLevelIndent"] | null => {
+  const numPr = effectiveNumbering(authored, inherited);
+  if (numPr?.numId === undefined || numPr.numId === 0) {
+    return null;
+  }
+  const ilvl = numPr.ilvl ?? 0;
+  const level = numbering?.getLevel(numPr.numId, ilvl);
+  if (!level) {
+    return null;
+  }
+  const hasMarkerSlot = numberingLevelHasMarkerSlot(level);
+  const baseline = numberingLevelGeometry(level.pPr, hasMarkerSlot);
+  const owned: NumberingLevelIndentGeometry = {};
+  if (
+    baseline.indentLeft !== undefined &&
+    authored.indentLeft === undefined &&
+    inherited.indentLeft === undefined
+  ) {
+    owned.indentLeft = baseline.indentLeft;
+  }
+  if (
+    baseline.indentRight !== undefined &&
+    authored.indentRight === undefined &&
+    inherited.indentRight === undefined
+  ) {
+    owned.indentRight = baseline.indentRight;
+  }
+  const ownsFirstLine =
+    authored.indentFirstLine === undefined &&
+    authored.hangingIndent === undefined &&
+    inherited.indentFirstLine === undefined &&
+    inherited.hangingIndent === undefined;
+  if (ownsFirstLine) {
+    if (baseline.indentFirstLine !== undefined) {
+      owned.indentFirstLine = baseline.indentFirstLine;
     }
-    const styleHasFirstLine =
-      ppr?.indentFirstLine !== undefined || ppr?.hangingIndent !== undefined;
-    if (!styleHasFirstLine && numberingLevelHasMarkerSlot(level)) {
-      if (level.pPr.indentFirstLine !== undefined) {
-        attrs["indentFirstLine"] = level.pPr.indentFirstLine;
-      }
-      if (level.pPr.hangingIndent !== undefined) {
-        attrs["hangingIndent"] = level.pPr.hangingIndent;
+    if (baseline.hangingIndent !== undefined) {
+      owned.hangingIndent = baseline.hangingIndent;
+    }
+  }
+  return (
+    createNumberingLevelIndentProvenance({
+      numId: numPr.numId,
+      ilvl,
+      baseline,
+      owned,
+    }) ?? null
+  );
+};
+
+const paragraphMarkContext = (
+  attrs: ParagraphAttrs,
+  resolved: ResolvedParagraphStyle,
+  styleId: string | undefined,
+  styleResolver: RunStyleResolver | null | undefined,
+  tableRunFormatting: TextFormatting | undefined,
+): ParagraphPropertyProjectionContext["paragraphMark"] => {
+  const current = expectParagraphPropertyState(attrs._paragraphPropertyState);
+  const authored = current.context.paragraphMark.authored;
+  const inherited = selectParagraphMarkProperties(resolved.paragraphFormatting);
+  const defaultTextFormatting = resolveEffectiveParagraphMarkFormatting({
+    authored: {
+      ...authored,
+      runProperties: mergeTextFormatting(inherited.runProperties, authored.runProperties),
+    },
+    styleId,
+    styleResolver,
+    tableRunFormatting,
+  });
+  return {
+    authored,
+    effective: {
+      ...(defaultTextFormatting === undefined ? {} : { defaultTextFormatting }),
+      ...(authored.runInWithNext !== undefined
+        ? { runInWithNext: authored.runInWithNext }
+        : inherited.runInWithNext !== undefined
+          ? { runInWithNext: inherited.runInWithNext }
+          : {}),
+    },
+  };
+};
+
+const paragraphPropertyContext = (
+  attrs: ParagraphAttrs,
+  authoredPPr: AuthoredParagraphProperties,
+  resolved: ResolvedParagraphStyle,
+  numbering: NumberingMap | null | undefined,
+  styleResolver: RunStyleResolver | null | undefined,
+  tableRunFormatting: TextFormatting | undefined,
+): ParagraphPropertyProjectionContext => {
+  const inheritedPPr = authoredParagraphPropertiesFromFormatting(
+    resolved.paragraphFormatting,
+  );
+  return {
+    inheritedPPr,
+    numberingLevelIndent: numberingIndentContext(authoredPPr, inheritedPPr, numbering),
+    numPrFromStyle: inheritedPPr.numPr ?? null,
+    paragraphMark: paragraphMarkContext(
+      attrs,
+      resolved,
+      authoredPPr.styleId,
+      styleResolver,
+      tableRunFormatting,
+    ),
+    spacingInheritance: resolved.spacingInheritance ?? {},
+  };
+};
+
+const authoredForStyleTransition = (
+  attrs: ParagraphAttrs,
+  identity: ResolvedStyleIdentity,
+  transition:
+    | { type: "preserve-direct" }
+    | { type: "replace-style" }
+    | { type: "restore-authored"; formatting: ParagraphFormatting | null | undefined },
+): AuthoredParagraphProperties => {
+  const current = expectParagraphPropertyState(attrs._paragraphPropertyState);
+  const authored =
+    transition.type === "restore-authored"
+      ? authoredParagraphPropertiesFromFormatting(transition.formatting)
+      : structuredClone(current.authoredPPr);
+  if (transition.type === "replace-style") {
+    for (const key of PARAGRAPH_FORMATTING_PROPERTY_KEY_LIST) {
+      if (PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR[key].styleTransition === "replace") {
+        Reflect.deleteProperty(authored, key);
       }
     }
   }
+  if (identity.styleId === null) {
+    Reflect.deleteProperty(authored, "styleId");
+  } else {
+    authored.styleId = identity.styleId;
+  }
+  return authored;
+};
 
-  return attrs;
-}
+const listRenderingAttrs = (
+  authored: AuthoredParagraphProperties,
+  inherited: AuthoredParagraphProperties,
+  numbering: NumberingMap | null | undefined,
+): Record<string, unknown> => {
+  const numPr = effectiveNumbering(authored, inherited);
+  return numPr?.numId === undefined || numPr.numId === 0
+    ? CLEARED_LIST_RENDERING_ATTRS
+    : listAttrsFromNumbering({ numId: numPr.numId, ilvl: numPr.ilvl ?? 0 }, numbering);
+};
 
-/** Project one resolved numbering level into the complete editor attr group. */
+type ParagraphPropertiesForStyleTransitionOptions = {
+  attrs: ParagraphAttrs;
+  identity: ResolvedStyleIdentity;
+  numbering: NumberingMap | null | undefined;
+  resolved: ResolvedParagraphStyle;
+  styleResolver?: RunStyleResolver | null;
+  tableRunFormatting?: TextFormatting;
+  transition:
+    | { type: "preserve-direct" }
+    | { type: "replace-style" }
+    | { type: "restore-authored"; formatting: ParagraphFormatting | null | undefined };
+};
+
+/** Project one style transition and all dependent paragraph caches atomically. */
+export const paragraphPropertiesForStyleTransition = ({
+  attrs,
+  identity,
+  numbering,
+  resolved,
+  styleResolver,
+  tableRunFormatting,
+  transition,
+}: ParagraphPropertiesForStyleTransitionOptions): ParagraphPropertyProjection => {
+  const authoredPPr = authoredForStyleTransition(attrs, identity, transition);
+  const context = paragraphPropertyContext(
+    attrs,
+    authoredPPr,
+    resolved,
+    numbering,
+    styleResolver,
+    tableRunFormatting,
+  );
+  const nonPropertyAttrs = {
+    ...attrs,
+    ...listRenderingAttrs(authoredPPr, context.inheritedPPr, numbering),
+    _tableOfContentsLevel:
+      identity.styleId === null
+        ? null
+        : tableOfContentsStyleLevel({
+            styleId: identity.styleId,
+            ...(identity.styleName ? { styleName: identity.styleName } : {}),
+          }) ?? null,
+  };
+  return transitionParagraphProperties({
+    attrs: nonPropertyAttrs,
+    state: {
+      type: "update",
+      authored: { type: "replace", authoredPPr },
+      context: { type: "replace", context },
+    },
+  });
+};
+
+/** Direct numbering value that keeps inherited numbering disabled after reload. */
+export const numPrAfterListRemoval = (attrs: ParagraphAttrs): ParagraphAttrs["numPr"] | null => {
+  const state = expectParagraphPropertyState(attrs._paragraphPropertyState);
+  const styleNumPr = state.context.numPrFromStyle;
+  return styleNumPr?.numId !== undefined && styleNumPr.numId !== 0
+    ? { numId: 0, ilvl: attrs.numPr?.ilvl ?? styleNumPr.ilvl ?? 0 }
+    : null;
+};
+
+/** Remove direct numbering and its level geometry through the canonical state owner. */
+export const paragraphPropertiesForListRemoval = (
+  attrs: ParagraphAttrs,
+): ParagraphPropertyProjection => {
+  const numPr = numPrAfterListRemoval(attrs);
+  const mutation: ParagraphPropertyMutation =
+    numPr === null
+      ? { key: "numPr", mutation: { type: "remove" } }
+      : { key: "numPr", mutation: { type: "set", value: numPr } };
+  const state = expectParagraphPropertyState(attrs._paragraphPropertyState);
+  return transitionParagraphProperties({
+    attrs: { ...attrs, ...CLEARED_LIST_RENDERING_ATTRS },
+    state: {
+      type: "update",
+      authored: { type: "mutate", mutations: [mutation] },
+      context: {
+        type: "replace",
+        context: { ...state.context, numberingLevelIndent: null },
+      },
+    },
+  });
+};
+
+type ParagraphPropertiesForListLevelTransitionOptions = {
+  attrs: ParagraphAttrs;
+  numPr: NonNullable<ParagraphFormatting["numPr"]>;
+  numbering: NumberingMap | null | undefined;
+};
+
+/** Apply direct list identity and recompute level provenance atomically. */
+export const paragraphPropertiesForListLevelTransition = ({
+  attrs,
+  numPr,
+  numbering,
+}: ParagraphPropertiesForListLevelTransitionOptions): ParagraphPropertyProjection => {
+  const state = expectParagraphPropertyState(attrs._paragraphPropertyState);
+  const authoredPPr = applyParagraphPropertyMutations(state.authoredPPr, [
+    { key: "numPr", mutation: { type: "set", value: numPr } },
+  ]);
+  const context = {
+    ...state.context,
+    numberingLevelIndent: numberingIndentContext(
+      authoredPPr,
+      state.context.inheritedPPr,
+      numbering,
+    ),
+  };
+  return transitionParagraphProperties({
+    attrs: {
+      ...attrs,
+      ...(numPr.numId === undefined
+        ? CLEARED_LIST_RENDERING_ATTRS
+        : listAttrsFromNumbering(
+            { numId: numPr.numId, ilvl: numPr.ilvl ?? 0 },
+            numbering,
+          )),
+      listImplicitChildLevelAdvances: attrs.listImplicitChildLevelAdvances ?? null,
+    },
+    state: {
+      type: "update",
+      authored: { type: "replace", authoredPPr },
+      context: { type: "replace", context },
+    },
+  });
+};
+
+/** Project one resolved numbering level into non-property list-rendering attrs. */
 export function listAttrsFromNumbering(
   numPr: { numId: number; ilvl: number },
   numbering: NumberingMap | null | undefined,
@@ -149,7 +353,6 @@ export function listAttrsFromNumbering(
   const rendering = numbering ? computeListRendering(targetNumPr, numbering) : null;
   return {
     ...CLEARED_LIST_RENDERING_ATTRS,
-    numPr: targetNumPr,
     listNumFmt: rendering?.numFmt ?? null,
     listIsBullet: rendering?.isBullet ?? null,
     listIsLegal: rendering?.isLegal ?? null,
@@ -164,24 +367,5 @@ export function listAttrsFromNumbering(
     listLevelStarts: rendering?.levelStarts ?? null,
     listAbstractNumId: rendering?.abstractNumId ?? null,
     listStartOverride: rendering?.startOverride ?? null,
-  };
-}
-
-/** Recompute every level-dependent attr when a paragraph changes list level. */
-export function listLevelAttrPatch(
-  attrs: { listImplicitChildLevelAdvances?: number | null },
-  numPr: { numId: number; ilvl: number },
-  numbering: NumberingMap | null | undefined,
-): Record<string, unknown> {
-  const level = numbering?.getLevel(numPr.numId, numPr.ilvl);
-  const hasMarkerSlot = level ? numberingLevelHasMarkerSlot(level) : false;
-  return {
-    ...listAttrsFromNumbering(numPr, numbering),
-    // Inline LISTNUM fields still belong to this paragraph after a level
-    // change; their relative child-level advance moves with it.
-    listImplicitChildLevelAdvances: attrs.listImplicitChildLevelAdvances ?? null,
-    indentLeft: level?.pPr?.indentLeft ?? null,
-    indentFirstLine: hasMarkerSlot ? (level?.pPr?.indentFirstLine ?? null) : null,
-    hangingIndent: hasMarkerSlot ? (level?.pPr?.hangingIndent ?? null) : null,
   };
 }

--- a/packages/core/src/prosemirror/styles/styleResolver.ts
+++ b/packages/core/src/prosemirror/styles/styleResolver.ts
@@ -25,6 +25,11 @@ import type {
 } from "../../types/document";
 import { mergeParagraphFormatting } from "../../utils/paragraphFormattingMerge";
 import { cascadeStyleTextFormatting } from "./styleToggleCascade";
+import {
+  PARAGRAPH_SPACING_INHERITANCE_SOURCE,
+  type ParagraphSpacingInheritance,
+  type ParagraphSpacingInheritanceSource,
+} from "../paragraphPropertyContext";
 
 /**
  * Resolved style properties ready for rendering
@@ -34,6 +39,23 @@ export type ResolvedParagraphStyle = {
   paragraphFormatting?: ParagraphFormatting;
   /** Default run formatting from the style */
   runFormatting?: TextFormatting;
+  /** Exact source tier for inherited before/after spacing. */
+  spacingInheritance?: ParagraphSpacingInheritance;
+};
+
+const recordSpacingInheritance = (
+  result: ResolvedParagraphStyle,
+  formatting: ParagraphFormatting | undefined,
+  source: ParagraphSpacingInheritanceSource,
+): void => {
+  if (formatting?.spaceBefore === undefined && formatting?.spaceAfter === undefined) {
+    return;
+  }
+  result.spacingInheritance = {
+    ...result.spacingInheritance,
+    ...(formatting.spaceBefore === undefined ? {} : { before: source }),
+    ...(formatting.spaceAfter === undefined ? {} : { after: source }),
+  };
 };
 
 /**
@@ -185,6 +207,11 @@ export class StyleResolver {
     // Layer 1: document defaults
     if (this.docDefaults?.pPr) {
       result.paragraphFormatting = { ...this.docDefaults.pPr };
+      recordSpacingInheritance(
+        result,
+        this.docDefaults.pPr,
+        PARAGRAPH_SPACING_INHERITANCE_SOURCE.documentDefault,
+      );
     }
     // Layer 2: modeled enclosing-table paragraph fields (cell paragraphs only;
     // undefined for everything else, a no-op here).
@@ -193,6 +220,11 @@ export class StyleResolver {
       if (merged !== undefined) {
         result.paragraphFormatting = merged;
       }
+      recordSpacingInheritance(
+        result,
+        tableParagraphOverlay,
+        PARAGRAPH_SPACING_INHERITANCE_SOURCE.style,
+      );
     }
 
     // Layer 3: the paragraph's own style chain (Normal when absent or unknown).
@@ -204,6 +236,13 @@ export class StyleResolver {
       if (merged) {
         result.paragraphFormatting = merged;
       }
+      recordSpacingInheritance(
+        result,
+        style.pPr,
+        styleId
+          ? PARAGRAPH_SPACING_INHERITANCE_SOURCE.style
+          : PARAGRAPH_SPACING_INHERITANCE_SOURCE.implicitDefaultStyle,
+      );
     }
     const runFormatting = cascadeStyleTextFormatting([
       { formatting: this.docDefaults?.rPr, type: "defaults" },

--- a/packages/core/src/prosemirror/tableConditionalFormatting.test.ts
+++ b/packages/core/src/prosemirror/tableConditionalFormatting.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  resolveTableCellConditionalStyle,
+  type TableConditionalStyles,
+} from "./tableConditionalFormatting";
+
+const styles = {
+  wholeTable: { rPr: { color: { rgb: "111111" } } },
+  nwCell: { rPr: { bold: true } },
+  lastCol: { rPr: { strike: true } },
+  band1Vert: { rPr: { italic: true } },
+  band2Vert: { rPr: { smallCaps: true } },
+} satisfies TableConditionalStyles;
+
+const resolve = (
+  overrides: Partial<Parameters<typeof resolveTableCellConditionalStyle>[0]> = {},
+) =>
+  resolveTableCellConditionalStyle({
+    styles,
+    look: { firstRow: true, firstColumn: true, lastColumn: true },
+    rowIndex: 0,
+    totalRows: 2,
+    columnIndex: 0,
+    columnSpan: 1,
+    totalColumns: 4,
+    rowFormatting: undefined,
+    cellFormatting: undefined,
+    ...overrides,
+  })?.rPr;
+
+describe("table conditional formatting coordinates", () => {
+  test("explicit corner flags override coordinate-derived corners", () => {
+    expect(resolve()?.bold).toBe(true);
+    expect(resolve({ cellFormatting: { conditionalFormat: { nwCell: false } } })?.bold).toBeUndefined();
+    expect(
+      resolve({
+        rowIndex: 1,
+        columnIndex: 2,
+        cellFormatting: { conditionalFormat: { nwCell: true } },
+      })?.bold,
+    ).toBe(true);
+  });
+
+  test("grid omissions and colspan keep band and last-column coordinates distinct", () => {
+    const formatting = resolve({
+      look: { lastColumn: true },
+      rowIndex: 1,
+      columnIndex: 1,
+      columnSpan: 2,
+      totalColumns: 4,
+    });
+    expect(formatting?.strike).toBeUndefined();
+    expect(formatting?.smallCaps).toBe(true);
+
+    expect(
+      resolve({
+        look: { lastColumn: true },
+        rowIndex: 1,
+        columnIndex: 1,
+        columnSpan: 3,
+        totalColumns: 4,
+      })?.strike,
+    ).toBe(true);
+  });
+});

--- a/packages/core/src/prosemirror/tableConditionalFormatting.ts
+++ b/packages/core/src/prosemirror/tableConditionalFormatting.ts
@@ -1,0 +1,508 @@
+import { panic } from "better-result";
+import type { Node as PMNode } from "prosemirror-model";
+
+import type { StyleEngine, TableCellParagraphSpacingOverlay } from "../style-engine";
+import type {
+  ParagraphFormatting,
+  TableCellFormatting,
+  TableLook,
+  TableRowFormatting,
+  TextFormatting,
+} from "../types/document";
+import { mergeParagraphFormatting } from "../utils/paragraphFormattingMerge";
+import { mergeTextFormatting } from "../utils/textFormattingMerge";
+import { expectTableAttrs, expectTableCellAttrs, expectTableRowAttrs } from "./attrs";
+import { resolveRunFormattingWithoutDefaults } from "./runStyleFormatting";
+
+type TableConditionalStyleResolver = Pick<
+  StyleEngine,
+  "getDefaultTableStyle" | "getRunStyleOwnProperties" | "getStyle"
+>;
+
+const TABLE_CONDITIONAL_STYLE_TYPES = [
+  "wholeTable",
+  "firstRow",
+  "lastRow",
+  "firstCol",
+  "lastCol",
+  "band1Horz",
+  "band2Horz",
+  "band1Vert",
+  "band2Vert",
+  "nwCell",
+  "neCell",
+  "swCell",
+  "seCell",
+] as const;
+
+type TableConditionalStyleType = (typeof TABLE_CONDITIONAL_STYLE_TYPES)[number];
+
+export type TableConditionalStyle = {
+  tcPr?: TableCellFormatting;
+  rPr?: TextFormatting;
+  pPr?: TableCellParagraphSpacingOverlay;
+};
+
+export type TableConditionalStyles = Partial<
+  Record<TableConditionalStyleType, TableConditionalStyle>
+>;
+
+const extractTableParagraphOverlay = (
+  pPr: ParagraphFormatting | undefined,
+): TableCellParagraphSpacingOverlay | undefined => {
+  if (!pPr) {
+    return undefined;
+  }
+  const overlay: TableCellParagraphSpacingOverlay = {};
+  for (const key of [
+    "spaceBefore",
+    "spaceAfter",
+    "lineSpacing",
+    "lineSpacingRule",
+    "contextualSpacing",
+    "frame",
+  ] as const) {
+    const value = pPr[key];
+    if (value !== undefined) {
+      Object.assign(overlay, { [key]: value });
+    }
+  }
+  return Object.keys(overlay).length > 0 ? overlay : undefined;
+};
+
+const resolveTableStyleConditional = (
+  styleResolver: TableConditionalStyleResolver,
+  tableStyleId: string,
+  conditionType: TableConditionalStyleType,
+): TableConditionalStyle | undefined => {
+  const conditional = styleResolver
+    .getStyle(tableStyleId)
+    ?.tblStylePr?.find(({ type }) => type === conditionType);
+  if (!conditional) {
+    return undefined;
+  }
+
+  const runPropsFromPpr = resolveRunFormattingWithoutDefaults(
+    conditional.pPr?.runProperties,
+    styleResolver,
+  );
+  const resolvedRpr = resolveRunFormattingWithoutDefaults(conditional.rPr, styleResolver);
+  const result: TableConditionalStyle = {};
+  const rPr = mergeTextFormatting(runPropsFromPpr, resolvedRpr);
+  const pPr = extractTableParagraphOverlay(conditional.pPr);
+  if (conditional.tcPr) {
+    result.tcPr = conditional.tcPr;
+  }
+  if (rPr) {
+    result.rPr = rPr;
+  }
+  if (pPr) {
+    result.pPr = pPr;
+  }
+  return result;
+};
+
+const resolveTableBaseStyle = (
+  styleResolver: TableConditionalStyleResolver,
+  tableStyleId: string,
+): TableConditionalStyle | undefined => {
+  const style = styleResolver.getStyle(tableStyleId);
+  if (!style) {
+    return undefined;
+  }
+  const runPropsFromPpr = resolveRunFormattingWithoutDefaults(
+    style.pPr?.runProperties,
+    styleResolver,
+  );
+  const resolvedRpr = resolveRunFormattingWithoutDefaults(style.rPr, styleResolver);
+  const result: TableConditionalStyle = {};
+  const rPr = mergeTextFormatting(runPropsFromPpr, resolvedRpr);
+  const pPr = extractTableParagraphOverlay(style.pPr);
+  if (style.tcPr) {
+    result.tcPr = style.tcPr;
+  }
+  if (rPr) {
+    result.rPr = rPr;
+  }
+  if (pPr) {
+    result.pPr = pPr;
+  }
+  return result.tcPr || result.rPr || result.pPr ? result : undefined;
+};
+
+export const mergeTableConditionalStyles = (
+  base?: TableConditionalStyle,
+  override?: TableConditionalStyle,
+): TableConditionalStyle | undefined => {
+  if (!base) {
+    return override;
+  }
+  if (!override) {
+    return base;
+  }
+
+  const merged: TableConditionalStyle = {};
+  if (base.tcPr || override.tcPr) {
+    merged.tcPr = {
+      ...base.tcPr,
+      ...override.tcPr,
+      ...(base.tcPr?.borders || override.tcPr?.borders
+        ? { borders: { ...base.tcPr?.borders, ...override.tcPr?.borders } }
+        : {}),
+      ...(base.tcPr?.shading || override.tcPr?.shading
+        ? { shading: { ...base.tcPr?.shading, ...override.tcPr?.shading } }
+        : {}),
+      ...(base.tcPr?.margins || override.tcPr?.margins
+        ? { margins: { ...base.tcPr?.margins, ...override.tcPr?.margins } }
+        : {}),
+    };
+  }
+  const rPr = mergeTextFormatting(base.rPr, override.rPr);
+  if (rPr) {
+    merged.rPr = rPr;
+  }
+  const pPr = mergeParagraphFormatting(base.pPr, override.pPr);
+  if (pPr) {
+    merged.pPr = pPr;
+  }
+  return merged;
+};
+
+export const resolveTableConditionalStyles = (
+  styleResolver: TableConditionalStyleResolver | null,
+  tableStyleId: string | undefined,
+): TableConditionalStyles => {
+  if (!styleResolver) {
+    return {};
+  }
+  const style = tableStyleId
+    ? styleResolver.getStyle(tableStyleId)
+    : styleResolver.getDefaultTableStyle();
+  if (!style) {
+    return {};
+  }
+
+  const styles: TableConditionalStyles = {};
+  for (const type of TABLE_CONDITIONAL_STYLE_TYPES) {
+    const conditional = resolveTableStyleConditional(styleResolver, style.styleId, type);
+    if (conditional) {
+      styles[type] = conditional;
+    }
+  }
+  const wholeTable = mergeTableConditionalStyles(
+    resolveTableBaseStyle(styleResolver, style.styleId),
+    styles.wholeTable,
+  );
+  if (wholeTable) {
+    styles.wholeTable = wholeTable;
+  }
+  return styles;
+};
+
+type ResolveTableCellConditionalStyleOptions = {
+  styles: TableConditionalStyles;
+  look: TableLook | undefined;
+  rowIndex: number;
+  totalRows: number;
+  columnIndex: number;
+  columnSpan: number;
+  totalColumns: number;
+  rowFormatting: Pick<TableRowFormatting, "conditionalFormat"> | undefined;
+  cellFormatting: Pick<TableCellFormatting, "conditionalFormat"> | undefined;
+};
+
+export const resolveTableCellConditionalStyle = ({
+  styles,
+  look,
+  rowIndex,
+  totalRows,
+  columnIndex,
+  columnSpan,
+  totalColumns,
+  rowFormatting,
+  cellFormatting,
+}: ResolveTableCellConditionalStyleOptions): TableConditionalStyle | undefined => {
+  const rowCnf = rowFormatting?.conditionalFormat;
+  const cellCnf = cellFormatting?.conditionalFormat;
+  const isFirstRow = rowIndex === 0;
+  const isLastRow = rowIndex === totalRows - 1;
+  const isFirstColumn = columnIndex === 0;
+  const isLastColumn = columnIndex + columnSpan === totalColumns;
+  const cellIsFirstRow = cellCnf?.firstRow ?? rowCnf?.firstRow ?? isFirstRow;
+  const cellIsLastRow = cellCnf?.lastRow ?? rowCnf?.lastRow ?? isLastRow;
+  const cellIsFirstColumn = cellCnf?.firstColumn ?? isFirstColumn;
+  const cellIsLastColumn = cellCnf?.lastColumn ?? isLastColumn;
+
+  let rowBand: TableConditionalStyle | undefined;
+  const firstRowStyled = isFirstRow && look?.firstRow === true;
+  const lastRowStyled = isLastRow && look?.lastRow === true;
+  if (look?.noHBand !== true && !firstRowStyled && !lastRowStyled) {
+    const bandIndex = rowIndex - (look?.firstRow === true ? 1 : 0);
+    rowBand = bandIndex % 2 === 0 ? styles.band1Horz : styles.band2Horz;
+  }
+  if (rowCnf?.oddHBand) {
+    rowBand = styles.band1Horz;
+  } else if (rowCnf?.evenHBand) {
+    rowBand = styles.band2Horz;
+  }
+  if (cellCnf?.oddHBand) {
+    rowBand = styles.band1Horz;
+  } else if (cellCnf?.evenHBand) {
+    rowBand = styles.band2Horz;
+  }
+
+  let columnBand: TableConditionalStyle | undefined;
+  if (look?.noVBand !== true) {
+    const bandIndex = columnIndex - (look?.firstColumn === true ? 1 : 0);
+    const isEligible =
+      bandIndex >= 0 &&
+      !(look?.firstColumn && cellIsFirstColumn) &&
+      !(look?.lastColumn && cellIsLastColumn);
+    if (isEligible) {
+      columnBand = bandIndex % 2 === 0 ? styles.band1Vert : styles.band2Vert;
+    }
+  }
+  if (cellCnf?.oddVBand) {
+    columnBand = styles.band1Vert;
+  } else if (cellCnf?.evenVBand) {
+    columnBand = styles.band2Vert;
+  }
+
+  const firstRowActive =
+    cellIsFirstRow && !!(look?.firstRow || rowCnf?.firstRow || cellCnf?.firstRow);
+  const lastRowActive = cellIsLastRow && !!(look?.lastRow || rowCnf?.lastRow || cellCnf?.lastRow);
+  const firstColumnActive =
+    cellIsFirstColumn && !!(look?.firstColumn || rowCnf?.firstColumn || cellCnf?.firstColumn);
+  const lastColumnActive =
+    cellIsLastColumn && !!(look?.lastColumn || rowCnf?.lastColumn || cellCnf?.lastColumn);
+
+  let result = styles.wholeTable;
+  result = mergeTableConditionalStyles(result, rowBand);
+  result = mergeTableConditionalStyles(result, columnBand);
+  if (firstColumnActive) {
+    result = mergeTableConditionalStyles(result, styles.firstCol);
+  }
+  if (lastColumnActive) {
+    result = mergeTableConditionalStyles(result, styles.lastCol);
+  }
+  if (firstRowActive) {
+    result = mergeTableConditionalStyles(result, styles.firstRow);
+  }
+  if (lastRowActive) {
+    result = mergeTableConditionalStyles(result, styles.lastRow);
+  }
+
+  const cornerFallbacks = {
+    nwCell: firstRowActive && firstColumnActive,
+    neCell: firstRowActive && lastColumnActive,
+    swCell: lastRowActive && firstColumnActive,
+    seCell: lastRowActive && lastColumnActive,
+  } as const;
+  for (const corner of ["nwCell", "neCell", "swCell", "seCell"] as const) {
+    const explicit = cellCnf?.[corner];
+    if (explicit ?? cornerFallbacks[corner]) {
+      result = mergeTableConditionalStyles(result, styles[corner]);
+    }
+  }
+  return result;
+};
+
+export type TableParagraphStyleContext = {
+  pPr?: TableCellParagraphSpacingOverlay;
+  rPr?: TextFormatting;
+};
+
+export type TableParagraphStyleContextByParagraph = {
+  take: (paragraph: PMNode) => TableParagraphStyleContext | null | undefined;
+};
+
+export type TableRunFormattingByParagraph = {
+  take: (paragraph: PMNode) => TextFormatting | null | undefined;
+};
+
+export const emptyTableParagraphStyleContext = (): TableParagraphStyleContextByParagraph => ({
+  take: () => undefined,
+});
+
+export const emptyTableRunFormatting = (): TableRunFormattingByParagraph => ({
+  take: () => undefined,
+});
+
+type PlacedTableCell = {
+  cell: PMNode;
+  columnIndex: number;
+  columnSpan: number;
+};
+
+type PlacedTableRow = {
+  cells: PlacedTableCell[];
+  row: PMNode;
+};
+
+type TableGridPlacement = {
+  rows: PlacedTableRow[];
+  totalColumns: number;
+};
+
+/**
+ * Place cells on the OOXML grid, including columns occupied by a rowspan from
+ * an earlier row. PM removes the continuation cells when it imports vMerge,
+ * so a row-local colspan sum shifts every later conditional region left.
+ */
+const placeTableCells = (table: PMNode): TableGridPlacement => {
+  const rows: PMNode[] = [];
+  table.forEach((row) => {
+    if (row.type.name === "tableRow") {
+      rows.push(row);
+    }
+  });
+
+  const occupiedUntilRow: number[] = [];
+  const placedRows: PlacedTableRow[] = [];
+  let totalColumns = Math.max(1, expectTableAttrs(table).columnWidths?.length ?? 0);
+  for (const [rowIndex, row] of rows.entries()) {
+    const rowFormatting = expectTableRowAttrs(row)._originalFormatting;
+    let columnIndex = rowFormatting?.gridBefore ?? 0;
+    const cells: PlacedTableCell[] = [];
+    row.forEach((cell) => {
+      if (cell.type.name !== "tableCell" && cell.type.name !== "tableHeader") {
+        return;
+      }
+      const cellAttrs = expectTableCellAttrs(cell);
+      const columnSpan = cellAttrs.colspan;
+      const spanIsOccupied = (): boolean => {
+        for (let column = columnIndex; column < columnIndex + columnSpan; column++) {
+          if ((occupiedUntilRow[column] ?? 0) > rowIndex) {
+            return true;
+          }
+        }
+        return false;
+      };
+      while (spanIsOccupied()) {
+        columnIndex += 1;
+      }
+      cells.push({ cell, columnIndex, columnSpan });
+      const occupiedUntil = rowIndex + cellAttrs.rowspan;
+      for (let column = columnIndex; column < columnIndex + columnSpan; column++) {
+        occupiedUntilRow[column] = Math.max(occupiedUntilRow[column] ?? 0, occupiedUntil);
+      }
+      columnIndex += columnSpan;
+    });
+    totalColumns = Math.max(totalColumns, columnIndex + (rowFormatting?.gridAfter ?? 0));
+    placedRows.push({ cells, row });
+  }
+  return { rows: placedRows, totalColumns };
+};
+
+/** Index the conditional table paragraph/run cascade for every paragraph occurrence. */
+export const tableParagraphStyleContextByParagraph = (
+  doc: PMNode,
+  styleResolver: TableConditionalStyleResolver | null,
+): TableParagraphStyleContextByParagraph => {
+  const formattingByParagraph = new WeakMap<
+    PMNode,
+    Array<TableParagraphStyleContext | null>
+  >();
+  const append = (paragraph: PMNode, formatting: TableParagraphStyleContext | null): void => {
+    const existing = formattingByParagraph.get(paragraph);
+    if (existing) {
+      existing.push(formatting);
+    } else {
+      formattingByParagraph.set(paragraph, [formatting]);
+    }
+  };
+
+  const visit = (node: PMNode, tableFormatting: TableParagraphStyleContext | null = null): void => {
+    if (node.type.name === "paragraph") {
+      append(node, tableFormatting);
+      return;
+    }
+    if (node.type.name === "table") {
+      visitTable(node);
+      return;
+    }
+    const childTableFormatting = node.type.name === "textBox" ? null : tableFormatting;
+    node.forEach((child) => visit(child, childTableFormatting));
+  };
+
+  const visitTable = (table: PMNode): void => {
+    const tableAttrs = expectTableAttrs(table);
+    const styles = resolveTableConditionalStyles(styleResolver, tableAttrs.styleId);
+    const { rows, totalColumns } = placeTableCells(table);
+    for (const [rowIndex, { cells, row }] of rows.entries()) {
+      const rowFormatting = expectTableRowAttrs(row)._originalFormatting;
+      for (const { cell, columnIndex, columnSpan } of cells) {
+        const cellAttrs = expectTableCellAttrs(cell);
+        const conditional = resolveTableCellConditionalStyle({
+          styles,
+          look: tableAttrs.look,
+          rowIndex,
+          totalRows: rows.length,
+          columnIndex,
+          columnSpan,
+          totalColumns,
+          rowFormatting,
+          cellFormatting: cellAttrs._originalFormatting,
+        });
+        cell.forEach((block) => visit(block, conditional ?? {}));
+      }
+    }
+  };
+
+  visit(doc);
+  const offsets = new WeakMap<PMNode, number>();
+  return {
+    take: (paragraph) => {
+      const values = formattingByParagraph.get(paragraph);
+      const offset = offsets.get(paragraph) ?? 0;
+      const formatting = values?.at(offset);
+      if (formatting === undefined) {
+        return panic("Paragraph traversal diverged from its structural table-format index");
+      }
+      offsets.set(paragraph, offset + 1);
+      return formatting;
+    },
+  };
+};
+
+/** Project the occurrence index into stable ProseMirror paragraph positions. */
+export const tableParagraphStyleContextAtPositions = (
+  doc: PMNode,
+  styleResolver: TableConditionalStyleResolver | null,
+): ReadonlyMap<number, TableParagraphStyleContext | null> => {
+  const byOccurrence = tableParagraphStyleContextByParagraph(doc, styleResolver);
+  const byPosition = new Map<number, TableParagraphStyleContext | null>();
+  doc.descendants((node, position) => {
+    if (node.type.name === "paragraph") {
+      byPosition.set(position, byOccurrence.take(node) ?? null);
+      return false;
+    }
+    return true;
+  });
+  return byPosition;
+};
+
+/** Run-only view used by PM-to-document serialization. */
+export const tableRunFormattingByParagraph = (
+  doc: PMNode,
+  styleResolver: TableConditionalStyleResolver | null,
+): TableRunFormattingByParagraph => {
+  const contexts = tableParagraphStyleContextByParagraph(doc, styleResolver);
+  return {
+    take: (paragraph) => {
+      const context = contexts.take(paragraph);
+      return context === undefined ? undefined : (context?.rPr ?? null);
+    },
+  };
+};
+
+/** Run-only paragraph-position view retained for run-formatting callers. */
+export const tableRunFormattingAtParagraphPositions = (
+  doc: PMNode,
+  styleResolver: TableConditionalStyleResolver | null,
+): ReadonlyMap<number, TextFormatting | null> => {
+  const contexts = tableParagraphStyleContextAtPositions(doc, styleResolver);
+  return new Map(
+    [...contexts].map(([position, context]) => [position, context?.rPr ?? null] as const),
+  );
+};

--- a/packages/core/src/prosemirror/yjsParagraphSourceContract.ts
+++ b/packages/core/src/prosemirror/yjsParagraphSourceContract.ts
@@ -3,36 +3,83 @@ import type { Node as PMNode } from "prosemirror-model";
 import type * as Y from "yjs";
 
 import {
+  ParagraphPropertySourceContract,
+  ParagraphPropertySourceValidationError,
+  type ParagraphPropertySourceAttribute,
   PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR,
-  getProseDocumentParagraphPropertySourceContract,
+  readProseDocumentParagraphPropertySourceContract,
 } from "../docx/paragraphPropertySource";
+import {
+  readParagraphPropertyState,
+  readPersistableParagraphPropertyState,
+} from "./paragraphPropertyState";
 
 const FOLIO_YJS_METADATA_MAP_NAME = "folio:document-metadata";
 const PARAGRAPH_SOURCE_CONTRACT_KEY = "paragraphSourceContract";
 
-export const proseDocumentParagraphSourceContract = (document: PMNode): string | null => {
-  return getProseDocumentParagraphPropertySourceContract(document);
+export const proseDocumentParagraphSourceContract = (
+  document: PMNode,
+): ParagraphPropertySourceAttribute<ParagraphPropertySourceContract> =>
+  readProseDocumentParagraphPropertySourceContract(document);
+
+/** Reject internal-only paragraph state before it reaches collaboration storage. */
+export const assertPersistableParagraphPropertyStates = (document: PMNode): void => {
+  document.descendants((node) => {
+    if (node.type.name !== "paragraph") {
+      return true;
+    }
+    const persistable = readPersistableParagraphPropertyState(
+      node.attrs["_paragraphPropertyState"],
+    );
+    if (persistable.status === "valid") {
+      return false;
+    }
+    const internal = readParagraphPropertyState(node.attrs["_paragraphPropertyState"]);
+    if (internal.status === "valid") {
+      if (internal.value.type !== "transient-template") {
+        panic("Persistable paragraph-property state failed persistence validation");
+      }
+      throw new ParagraphPropertySourceValidationError({
+        code: "transient_state",
+        message: "Transient paragraph-property templates cannot cross collaboration boundaries.",
+      });
+    }
+    throw new ParagraphPropertySourceValidationError({
+      code: "invalid_state",
+      message: "Collaboration requires valid persistable paragraph-property state.",
+      ...(internal.status === "invalid" ? { token: internal.raw } : {}),
+    });
+  });
 };
 
 export const writeYjsParagraphSourceContract = (ydoc: Y.Doc, document: PMNode): void => {
+  assertPersistableParagraphPropertyStates(document);
   const contract = proseDocumentParagraphSourceContract(document);
-  if (!contract) {
+  if (contract.status !== "valid") {
     panic("Cannot seed collaboration without a paragraph-property source contract");
   }
-  ydoc.getMap(FOLIO_YJS_METADATA_MAP_NAME).set(PARAGRAPH_SOURCE_CONTRACT_KEY, contract);
+  ydoc
+    .getMap(FOLIO_YJS_METADATA_MAP_NAME)
+    .set(PARAGRAPH_SOURCE_CONTRACT_KEY, contract.value.serialized);
 };
 
-export const readYjsParagraphSourceContract = (ydoc: Y.Doc): string | null => {
+export const readYjsParagraphSourceContract = (
+  ydoc: Y.Doc,
+): ParagraphPropertySourceAttribute<ParagraphPropertySourceContract> => {
   const contract = ydoc.getMap(FOLIO_YJS_METADATA_MAP_NAME).get(PARAGRAPH_SOURCE_CONTRACT_KEY);
-  return typeof contract === "string" ? contract : null;
+  return ParagraphPropertySourceContract.read(contract);
 };
 
-export const withParagraphSourceContract = (document: PMNode, contract: string): PMNode => {
+export const withParagraphSourceContract = (
+  document: PMNode,
+  contract: ParagraphPropertySourceContract,
+): PMNode => {
   if (document.type.name !== "doc") {
     panic("A paragraph-property source contract can only attach to a document node");
   }
+  assertPersistableParagraphPropertyStates(document);
   return document.type.create(
-    { ...document.attrs, [PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR]: contract },
+    { ...document.attrs, [PROSE_PARAGRAPH_SOURCE_CONTRACT_ATTR]: contract.serialized },
     document.content,
     document.marks,
   );

--- a/packages/core/src/utils/paragraphFormattingMerge.ts
+++ b/packages/core/src/utils/paragraphFormattingMerge.ts
@@ -1,10 +1,10 @@
 import { panic } from "better-result";
-
-import type { ParagraphFormatting, TabStop } from "../types/document";
 import {
   PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR,
   PARAGRAPH_FORMATTING_PROPERTY_KEY_LIST,
-} from "../docx/paragraphPropertyDescriptor";
+} from "@stll/docx-core/model";
+
+import type { ParagraphFormatting, TabStop } from "../types/document";
 import { mergeTextFormatting } from "./textFormattingMerge";
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>

--- a/packages/core/src/utils/paragraphFormattingMerge.ts
+++ b/packages/core/src/utils/paragraphFormattingMerge.ts
@@ -1,48 +1,14 @@
+import { panic } from "better-result";
+
 import type { ParagraphFormatting, TabStop } from "../types/document";
+import {
+  PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR,
+  PARAGRAPH_FORMATTING_PROPERTY_KEY_LIST,
+} from "../docx/paragraphPropertyDescriptor";
 import { mergeTextFormatting } from "./textFormattingMerge";
 
-const PARAGRAPH_REPLACE_KEYS = [
-  "alignment",
-  "bidi",
-  "kinsoku",
-  "overflowPunctuation",
-  "spaceBefore",
-  "spaceAfter",
-  "lineSpacing",
-  "lineSpacingRule",
-  "snapToGrid",
-  "beforeAutospacing",
-  "afterAutospacing",
-  "spacingExplicit",
-  "indentLeft",
-  "indentRight",
-  "indentFirstLine",
-  "hangingIndent",
-  "shading",
-  "keepNext",
-  "keepLines",
-  "widowControl",
-  "pageBreakBefore",
-  "contextualSpacing",
-  "outlineLevel",
-  "styleId",
-  "suppressLineNumbers",
-  "suppressAutoHyphens",
-  "runInWithNext",
-] as const satisfies readonly (keyof ParagraphFormatting)[];
-
-type ParagraphReplaceKey = (typeof PARAGRAPH_REPLACE_KEYS)[number];
-
-const copyDefinedParagraphProperty = <K extends ParagraphReplaceKey>(
-  target: Pick<ParagraphFormatting, K>,
-  source: Pick<ParagraphFormatting, K>,
-  key: K,
-): void => {
-  const value = source[key];
-  if (value !== undefined) {
-    target[key] = value;
-  }
-};
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
 
 /**
  * Merge custom tab stops across OOXML paragraph-property layers.
@@ -95,40 +61,48 @@ export function mergeParagraphFormatting(
   if (!source) {
     return target;
   }
-  if (!target) {
-    const result = { ...source };
-    if (source.tabs !== undefined) {
-      result.tabs = [...source.tabs];
-    }
-    return result;
-  }
 
   const result: ParagraphFormatting = { ...target };
-
-  for (const key of PARAGRAPH_REPLACE_KEYS) {
-    copyDefinedParagraphProperty(result, source, key);
-  }
-
-  if (source.indentFirstLine !== undefined) {
-    result.hangingIndent = source.hangingIndent === true;
-  }
-
-  const mergedRunProperties = mergeTextFormatting(result.runProperties, source.runProperties);
-  if (mergedRunProperties) {
-    result.runProperties = mergedRunProperties;
-  }
-
-  if (source.borders !== undefined) {
-    result.borders = { ...result.borders, ...source.borders };
-  }
-  if (source.numPr !== undefined) {
-    result.numPr = { ...result.numPr, ...source.numPr };
-  }
-  if (source.frame !== undefined) {
-    result.frame = { ...result.frame, ...source.frame };
-  }
-  if (source.tabs !== undefined) {
-    result.tabs = mergeParagraphTabStops(result.tabs, source.tabs);
+  for (const key of PARAGRAPH_FORMATTING_PROPERTY_KEY_LIST) {
+    const sourceValue = source[key];
+    if (sourceValue === undefined) {
+      continue;
+    }
+    const { cascade } = PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR[key];
+    switch (cascade) {
+      case "replace":
+        Reflect.set(result, key, sourceValue);
+        break;
+      case "first-line":
+        result.indentFirstLine = source.indentFirstLine;
+        result.hangingIndent = source.hangingIndent === true;
+        break;
+      case "fieldwise":
+        if (!isRecord(sourceValue)) {
+          return panic(`Paragraph property ${key} requires a fieldwise record`);
+        }
+        Reflect.set(result, key, {
+          ...(isRecord(result[key]) ? result[key] : {}),
+          ...sourceValue,
+        });
+        break;
+      case "run-properties": {
+        const merged = mergeTextFormatting(result.runProperties, source.runProperties);
+        if (merged) {
+          result.runProperties = merged;
+        }
+        break;
+      }
+      case "tab-stops":
+        result.tabs = mergeParagraphTabStops(result.tabs, source.tabs);
+        break;
+      case "preserve-derived":
+        break;
+      default: {
+        const exhaustive: never = cascade;
+        return exhaustive;
+      }
+    }
   }
 
   return result;

--- a/packages/docx-core/src/model/colors.ts
+++ b/packages/docx-core/src/model/colors.ts
@@ -7,6 +7,13 @@
 /**
  * Theme color slots from theme1.xml
  */
+const freezeDescriptor = <const Value extends Record<string, object>>(value: Value): Value => {
+  for (const entry of Object.values(value)) {
+    Object.freeze(entry);
+  }
+  return Object.freeze(value);
+};
+
 export const THEME_COLOR_SLOTS = Object.freeze([
   "dk1",
   "lt1",
@@ -48,7 +55,7 @@ type SelfDescribingFieldMap<Value, Descriptor> = {
   [Field in keyof Value]-?: Descriptor & { field: Field };
 };
 
-export const COLOR_VALUE_PROPERTY_DESCRIPTORS = {
+export const COLOR_VALUE_PROPERTY_DESCRIPTORS = freezeDescriptor({
   rgb: { field: "rgb", validation: "hex" },
   themeColor: { field: "themeColor", validation: "theme-color" },
   themeTint: { field: "themeTint", validation: "hex" },
@@ -57,7 +64,7 @@ export const COLOR_VALUE_PROPERTY_DESCRIPTORS = {
 } as const satisfies SelfDescribingFieldMap<
   ColorValue,
   { validation: "boolean" | "hex" | "theme-color" }
->;
+>);
 
 export type KnownBorderStyle =
   | "none"
@@ -167,8 +174,11 @@ export type ShadingProperties = {
   pattern?: (typeof SHADING_PATTERNS)[number];
 };
 
-export const SHADING_PROPERTY_DESCRIPTORS = {
+export const SHADING_PROPERTY_DESCRIPTORS = freezeDescriptor({
   color: { field: "color", validation: "color" },
   fill: { field: "fill", validation: "color" },
   pattern: { field: "pattern", validation: "pattern" },
-} as const satisfies SelfDescribingFieldMap<ShadingProperties, { validation: "color" | "pattern" }>;
+} as const satisfies SelfDescribingFieldMap<
+  ShadingProperties,
+  { validation: "color" | "pattern" }
+>);

--- a/packages/docx-core/src/model/colors.ts
+++ b/packages/docx-core/src/model/colors.ts
@@ -7,23 +7,26 @@
 /**
  * Theme color slots from theme1.xml
  */
-export type ThemeColorSlot =
-  | "dk1"
-  | "lt1"
-  | "dk2"
-  | "lt2"
-  | "accent1"
-  | "accent2"
-  | "accent3"
-  | "accent4"
-  | "accent5"
-  | "accent6"
-  | "hlink"
-  | "folHlink"
-  | "background1"
-  | "text1"
-  | "background2"
-  | "text2";
+export const THEME_COLOR_SLOTS = Object.freeze([
+  "dk1",
+  "lt1",
+  "dk2",
+  "lt2",
+  "accent1",
+  "accent2",
+  "accent3",
+  "accent4",
+  "accent5",
+  "accent6",
+  "hlink",
+  "folHlink",
+  "background1",
+  "text1",
+  "background2",
+  "text2",
+] as const);
+
+export type ThemeColorSlot = (typeof THEME_COLOR_SLOTS)[number];
 
 /**
  * Color value - can be direct RGB, theme reference, or auto
@@ -40,6 +43,21 @@ export type ColorValue = {
   /** Auto color - context-dependent (usually black for text) */
   auto?: boolean;
 };
+
+type SelfDescribingFieldMap<Value, Descriptor> = {
+  [Field in keyof Value]-?: Descriptor & { field: Field };
+};
+
+export const COLOR_VALUE_PROPERTY_DESCRIPTORS = {
+  rgb: { field: "rgb", validation: "hex" },
+  themeColor: { field: "themeColor", validation: "theme-color" },
+  themeTint: { field: "themeTint", validation: "hex" },
+  themeShade: { field: "themeShade", validation: "hex" },
+  auto: { field: "auto", validation: "boolean" },
+} as const satisfies SelfDescribingFieldMap<
+  ColorValue,
+  { validation: "boolean" | "hex" | "theme-color" }
+>;
 
 export type KnownBorderStyle =
   | "none"
@@ -99,49 +117,58 @@ export type BorderSpec = {
 /**
  * Shading/background properties
  */
+export const SHADING_PATTERNS = Object.freeze([
+  "clear",
+  "solid",
+  "horzStripe",
+  "vertStripe",
+  "reverseDiagStripe",
+  "diagStripe",
+  "horzCross",
+  "diagCross",
+  "thinHorzStripe",
+  "thinVertStripe",
+  "thinReverseDiagStripe",
+  "thinDiagStripe",
+  "thinHorzCross",
+  "thinDiagCross",
+  "pct5",
+  "pct10",
+  "pct12",
+  "pct15",
+  "pct20",
+  "pct25",
+  "pct30",
+  "pct35",
+  "pct37",
+  "pct40",
+  "pct45",
+  "pct50",
+  "pct55",
+  "pct60",
+  "pct62",
+  "pct65",
+  "pct70",
+  "pct75",
+  "pct80",
+  "pct85",
+  "pct87",
+  "pct90",
+  "pct95",
+  "nil",
+] as const);
+
 export type ShadingProperties = {
   /** Pattern fill color */
   color?: ColorValue;
   /** Background fill color */
   fill?: ColorValue;
   /** Shading pattern type */
-  pattern?:
-    | "clear"
-    | "solid"
-    | "horzStripe"
-    | "vertStripe"
-    | "reverseDiagStripe"
-    | "diagStripe"
-    | "horzCross"
-    | "diagCross"
-    | "thinHorzStripe"
-    | "thinVertStripe"
-    | "thinReverseDiagStripe"
-    | "thinDiagStripe"
-    | "thinHorzCross"
-    | "thinDiagCross"
-    | "pct5"
-    | "pct10"
-    | "pct12"
-    | "pct15"
-    | "pct20"
-    | "pct25"
-    | "pct30"
-    | "pct35"
-    | "pct37"
-    | "pct40"
-    | "pct45"
-    | "pct50"
-    | "pct55"
-    | "pct60"
-    | "pct62"
-    | "pct65"
-    | "pct70"
-    | "pct75"
-    | "pct80"
-    | "pct85"
-    | "pct87"
-    | "pct90"
-    | "pct95"
-    | "nil";
+  pattern?: (typeof SHADING_PATTERNS)[number];
 };
+
+export const SHADING_PROPERTY_DESCRIPTORS = {
+  color: { field: "color", validation: "color" },
+  fill: { field: "fill", validation: "color" },
+  pattern: { field: "pattern", validation: "pattern" },
+} as const satisfies SelfDescribingFieldMap<ShadingProperties, { validation: "color" | "pattern" }>;

--- a/packages/docx-core/src/model/document.ts
+++ b/packages/docx-core/src/model/document.ts
@@ -56,6 +56,9 @@ export type {
   LineSpacingRule,
   ParagraphAlignment,
   ParagraphFormatting,
+  NumberingLevelIndentGeometry,
+  NonEmptyNumberingLevelIndentGeometry,
+  NumberingLevelIndentProvenance,
   SpacingExplicit,
   TableWidthType,
   TableMeasurement,
@@ -69,6 +72,40 @@ export type {
   ConditionalFormatStyle,
   TableCellFormatting,
 } from "./formatting";
+
+export {
+  canonicalParagraphPropertySourceFingerprintJson,
+  isParagraphFormattingPropertyKey,
+  paragraphFormattingWithPropertySourceFingerprint,
+  paragraphPropertySourceDelta,
+  paragraphPropertySourceFingerprintFromFormatting,
+  paragraphPropertySourceFingerprintFromParts,
+  ParagraphPropertySourceDelta,
+  PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR,
+  PARAGRAPH_FORMATTING_PROPERTY_KEY_LIST,
+  PARAGRAPH_PROPERTY_CASCADE,
+  PARAGRAPH_PROPERTY_OWNER,
+  PARAGRAPH_PROPERTY_PROJECTION,
+  PARAGRAPH_PROPERTY_SOURCE_XML_GROUP,
+  PARAGRAPH_STYLE_TRANSITION,
+  PPR_CHANGE_SCOPED_FORMATTING_KEYS,
+  PPR_OPAQUE_FORMATTING_KEYS,
+  PPR_PARAGRAPH_MARK_FORMATTING_KEYS,
+  PPR_STYLE_REPLACED_FORMATTING_KEYS,
+  selectAuthoredParagraphProperties,
+  selectParagraphMarkProperties,
+} from "./paragraphProperties";
+export type {
+  AuthoredParagraphProperties,
+  AuthoredParagraphPropertyKey,
+  DerivedParagraphProperties,
+  DerivedParagraphPropertyKey,
+  ParagraphMarkProperties,
+  ParagraphMarkPropertyKey,
+  ParagraphPropertyDescriptor,
+  ParagraphPropertySourceFingerprint,
+  ParagraphPropertySourceXmlGroup,
+} from "./paragraphProperties";
 
 // Lists & Numbering
 export type {
@@ -205,6 +242,16 @@ export type {
   RelationshipMap,
   MediaFile,
 } from "./styles";
+export {
+  createParagraphStyleNumberingResolver,
+  isNonEmptyNumberingLevelIndentGeometry,
+  numberingIdentityEqual,
+  verifiedNumberingLevelIndent,
+} from "./styleNumbering";
+export type {
+  NumberingIdentity,
+  ParagraphStyleNumberingResolver,
+} from "./styleNumbering";
 
 // ============================================================================
 // DOCX PACKAGE & TOP-LEVEL DOCUMENT

--- a/packages/docx-core/src/model/document.ts
+++ b/packages/docx-core/src/model/document.ts
@@ -17,6 +17,12 @@ import type { NumberingDefinitions } from "./lists";
 import type { StyleDefinitions, Theme, FontTable, RelationshipMap, MediaFile } from "./styles";
 
 // Color & Styling Primitives
+export {
+  COLOR_VALUE_PROPERTY_DESCRIPTORS,
+  SHADING_PATTERNS,
+  SHADING_PROPERTY_DESCRIPTORS,
+  THEME_COLOR_SLOTS,
+} from "./colors";
 export type {
   ThemeColorSlot,
   ColorValue,
@@ -26,6 +32,19 @@ export type {
 } from "./colors";
 
 // Text & Paragraph Formatting
+export {
+  ASCII_THEME_FONTS,
+  EMPHASIS_MARKS,
+  FONT_HINTS,
+  HIGHLIGHT_COLORS,
+  TEXT_EFFECTS,
+  TEXT_FORMATTING_FONT_FAMILY_FIELD_DESCRIPTORS,
+  TEXT_FORMATTING_LANGUAGE_FIELD_DESCRIPTORS,
+  TEXT_FORMATTING_PROPERTY_DESCRIPTORS,
+  TEXT_FORMATTING_UNDERLINE_FIELD_DESCRIPTORS,
+  UNDERLINE_STYLES,
+  VERTICAL_ALIGNMENTS,
+} from "./formatting";
 export type {
   UnderlineStyle,
   TextEffect,

--- a/packages/docx-core/src/model/formatting.ts
+++ b/packages/docx-core/src/model/formatting.ts
@@ -14,42 +14,91 @@ import type { ColorValue, BorderSpec, ShadingProperties } from "./colors";
 /**
  * Underline style options
  */
-export type UnderlineStyle =
-  | "none"
-  | "single"
-  | "words"
-  | "double"
-  | "thick"
-  | "dotted"
-  | "dottedHeavy"
-  | "dash"
-  | "dashedHeavy"
-  | "dashLong"
-  | "dashLongHeavy"
-  | "dotDash"
-  | "dashDotHeavy"
-  | "dotDotDash"
-  | "dashDotDotHeavy"
-  | "wave"
-  | "wavyHeavy"
-  | "wavyDouble";
+export const UNDERLINE_STYLES = Object.freeze([
+  "none",
+  "single",
+  "words",
+  "double",
+  "thick",
+  "dotted",
+  "dottedHeavy",
+  "dash",
+  "dashedHeavy",
+  "dashLong",
+  "dashLongHeavy",
+  "dotDash",
+  "dashDotHeavy",
+  "dotDotDash",
+  "dashDotDotHeavy",
+  "wave",
+  "wavyHeavy",
+  "wavyDouble",
+] as const);
+
+export type UnderlineStyle = (typeof UNDERLINE_STYLES)[number];
 
 /**
  * Text effect animations
  */
-export type TextEffect =
-  | "none"
-  | "blinkBackground"
-  | "lights"
-  | "antsBlack"
-  | "antsRed"
-  | "shimmer"
-  | "sparkle";
+export const TEXT_EFFECTS = Object.freeze([
+  "none",
+  "blinkBackground",
+  "lights",
+  "antsBlack",
+  "antsRed",
+  "shimmer",
+  "sparkle",
+] as const);
+
+export type TextEffect = (typeof TEXT_EFFECTS)[number];
 
 /**
  * Emphasis mark type
  */
-export type EmphasisMark = "none" | "dot" | "comma" | "circle" | "underDot";
+export const EMPHASIS_MARKS = Object.freeze([
+  "none",
+  "dot",
+  "comma",
+  "circle",
+  "underDot",
+] as const);
+
+export type EmphasisMark = (typeof EMPHASIS_MARKS)[number];
+
+export const VERTICAL_ALIGNMENTS = Object.freeze(["baseline", "superscript", "subscript"] as const);
+
+export const HIGHLIGHT_COLORS = Object.freeze([
+  "black",
+  "blue",
+  "cyan",
+  "darkBlue",
+  "darkCyan",
+  "darkGray",
+  "darkGreen",
+  "darkMagenta",
+  "darkRed",
+  "darkYellow",
+  "green",
+  "lightGray",
+  "magenta",
+  "none",
+  "red",
+  "white",
+  "yellow",
+] as const);
+
+export const FONT_HINTS = Object.freeze(["default", "eastAsia", "cs"] as const);
+
+export const ASCII_THEME_FONTS = Object.freeze([
+  "majorAscii",
+  "majorHAnsi",
+  "majorEastAsia",
+  "majorBidi",
+  "minorAscii",
+  "minorHAnsi",
+  "minorEastAsia",
+  "minorBidi",
+] as const);
 
 /**
  * Complete text formatting properties (w:rPr)
@@ -78,7 +127,7 @@ export type TextFormatting = {
 
   // Vertical alignment
   /** Superscript/subscript (w:vertAlign) */
-  vertAlign?: "baseline" | "superscript" | "subscript";
+  vertAlign?: (typeof VERTICAL_ALIGNMENTS)[number];
 
   // Capitalization
   /** Small caps (w:smallCaps) */
@@ -94,24 +143,7 @@ export type TextFormatting = {
   /** Text color (w:color) */
   color?: ColorValue;
   /** Highlight/background color (w:highlight) */
-  highlight?:
-    | "black"
-    | "blue"
-    | "cyan"
-    | "darkBlue"
-    | "darkCyan"
-    | "darkGray"
-    | "darkGreen"
-    | "darkMagenta"
-    | "darkRed"
-    | "darkYellow"
-    | "green"
-    | "lightGray"
-    | "magenta"
-    | "none"
-    | "red"
-    | "white"
-    | "yellow";
+  highlight?: (typeof HIGHLIGHT_COLORS)[number];
   /** Character shading (w:shd) */
   shading?: ShadingProperties;
 
@@ -127,17 +159,9 @@ export type TextFormatting = {
     eastAsia?: string;
     cs?: string;
     /** Script slot Word should prefer when selecting a glyph font (w:hint). */
-    hint?: "default" | "eastAsia" | "cs";
+    hint?: (typeof FONT_HINTS)[number];
     /** Theme font reference */
-    asciiTheme?:
-      | "majorAscii"
-      | "majorHAnsi"
-      | "majorEastAsia"
-      | "majorBidi"
-      | "minorAscii"
-      | "minorHAnsi"
-      | "minorEastAsia"
-      | "minorBidi";
+    asciiTheme?: (typeof ASCII_THEME_FONTS)[number];
     hAnsiTheme?: string;
     eastAsiaTheme?: string;
     csTheme?: string;
@@ -183,6 +207,283 @@ export type TextFormatting = {
   /** Character style ID (w:rStyle) */
   styleId?: string;
 };
+
+type SelfDescribingFieldMap<Value, Descriptor> = {
+  [Field in keyof Value]-?: Descriptor & { field: Field };
+};
+
+type TextFormattingPropertyDescriptor = {
+  comparison: "exact";
+  validation:
+    | "boolean"
+    | "color"
+    | "effect"
+    | "emphasis"
+    | "finite-number"
+    | "font-family"
+    | "highlight"
+    | "language"
+    | "nonnegative-number"
+    | "shading"
+    | "string"
+    | "underline"
+    | "vertical-alignment";
+  visualGroup: string | null;
+  fastPath: "character-style" | "structural" | "visual";
+};
+
+/** Total semantic descriptor for every modeled run-formatting property. */
+export const TEXT_FORMATTING_PROPERTY_DESCRIPTORS = {
+  bold: {
+    field: "bold",
+    comparison: "exact",
+    validation: "boolean",
+    visualGroup: "bold",
+    fastPath: "visual",
+  },
+  boldCs: {
+    field: "boldCs",
+    comparison: "exact",
+    validation: "boolean",
+    visualGroup: null,
+    fastPath: "structural",
+  },
+  italic: {
+    field: "italic",
+    comparison: "exact",
+    validation: "boolean",
+    visualGroup: "italic",
+    fastPath: "visual",
+  },
+  italicCs: {
+    field: "italicCs",
+    comparison: "exact",
+    validation: "boolean",
+    visualGroup: null,
+    fastPath: "structural",
+  },
+  underline: {
+    field: "underline",
+    comparison: "exact",
+    validation: "underline",
+    visualGroup: "underline",
+    fastPath: "visual",
+  },
+  strike: {
+    field: "strike",
+    comparison: "exact",
+    validation: "boolean",
+    visualGroup: "strike",
+    fastPath: "visual",
+  },
+  doubleStrike: {
+    field: "doubleStrike",
+    comparison: "exact",
+    validation: "boolean",
+    visualGroup: "strike",
+    fastPath: "visual",
+  },
+  vertAlign: {
+    field: "vertAlign",
+    comparison: "exact",
+    validation: "vertical-alignment",
+    visualGroup: "vertAlign",
+    fastPath: "visual",
+  },
+  smallCaps: {
+    field: "smallCaps",
+    comparison: "exact",
+    validation: "boolean",
+    visualGroup: "smallCaps",
+    fastPath: "visual",
+  },
+  allCaps: {
+    field: "allCaps",
+    comparison: "exact",
+    validation: "boolean",
+    visualGroup: "allCaps",
+    fastPath: "visual",
+  },
+  hidden: {
+    field: "hidden",
+    comparison: "exact",
+    validation: "boolean",
+    visualGroup: "hidden",
+    fastPath: "visual",
+  },
+  color: {
+    field: "color",
+    comparison: "exact",
+    validation: "color",
+    visualGroup: "color",
+    fastPath: "visual",
+  },
+  highlight: {
+    field: "highlight",
+    comparison: "exact",
+    validation: "highlight",
+    visualGroup: "highlight",
+    fastPath: "visual",
+  },
+  shading: {
+    field: "shading",
+    comparison: "exact",
+    validation: "shading",
+    visualGroup: "shading",
+    fastPath: "visual",
+  },
+  fontSize: {
+    field: "fontSize",
+    comparison: "exact",
+    validation: "nonnegative-number",
+    visualGroup: "fontSize",
+    fastPath: "visual",
+  },
+  fontSizeCs: {
+    field: "fontSizeCs",
+    comparison: "exact",
+    validation: "nonnegative-number",
+    visualGroup: null,
+    fastPath: "structural",
+  },
+  fontFamily: {
+    field: "fontFamily",
+    comparison: "exact",
+    validation: "font-family",
+    visualGroup: "fontFamily",
+    fastPath: "visual",
+  },
+  language: {
+    field: "language",
+    comparison: "exact",
+    validation: "language",
+    visualGroup: "language",
+    fastPath: "visual",
+  },
+  spacing: {
+    field: "spacing",
+    comparison: "exact",
+    validation: "finite-number",
+    visualGroup: "characterSpacing",
+    fastPath: "visual",
+  },
+  position: {
+    field: "position",
+    comparison: "exact",
+    validation: "finite-number",
+    visualGroup: "characterSpacing",
+    fastPath: "visual",
+  },
+  scale: {
+    field: "scale",
+    comparison: "exact",
+    validation: "finite-number",
+    visualGroup: "characterSpacing",
+    fastPath: "visual",
+  },
+  kerning: {
+    field: "kerning",
+    comparison: "exact",
+    validation: "nonnegative-number",
+    visualGroup: "characterSpacing",
+    fastPath: "visual",
+  },
+  effect: {
+    field: "effect",
+    comparison: "exact",
+    validation: "effect",
+    visualGroup: "effect",
+    fastPath: "visual",
+  },
+  emphasisMark: {
+    field: "emphasisMark",
+    comparison: "exact",
+    validation: "emphasis",
+    visualGroup: "emphasisMark",
+    fastPath: "visual",
+  },
+  emboss: {
+    field: "emboss",
+    comparison: "exact",
+    validation: "boolean",
+    visualGroup: "emboss",
+    fastPath: "visual",
+  },
+  imprint: {
+    field: "imprint",
+    comparison: "exact",
+    validation: "boolean",
+    visualGroup: "imprint",
+    fastPath: "visual",
+  },
+  outline: {
+    field: "outline",
+    comparison: "exact",
+    validation: "boolean",
+    visualGroup: "outline",
+    fastPath: "visual",
+  },
+  shadow: {
+    field: "shadow",
+    comparison: "exact",
+    validation: "boolean",
+    visualGroup: "shadow",
+    fastPath: "visual",
+  },
+  rtl: {
+    field: "rtl",
+    comparison: "exact",
+    validation: "boolean",
+    visualGroup: "rtl",
+    fastPath: "visual",
+  },
+  cs: {
+    field: "cs",
+    comparison: "exact",
+    validation: "boolean",
+    visualGroup: null,
+    fastPath: "structural",
+  },
+  styleId: {
+    field: "styleId",
+    comparison: "exact",
+    validation: "string",
+    visualGroup: null,
+    fastPath: "character-style",
+  },
+} as const satisfies SelfDescribingFieldMap<TextFormatting, TextFormattingPropertyDescriptor>;
+
+export const TEXT_FORMATTING_FONT_FAMILY_FIELD_DESCRIPTORS = {
+  ascii: { field: "ascii", validation: "string" },
+  hAnsi: { field: "hAnsi", validation: "string" },
+  eastAsia: { field: "eastAsia", validation: "string" },
+  cs: { field: "cs", validation: "string" },
+  hint: { field: "hint", validation: "font-hint" },
+  asciiTheme: { field: "asciiTheme", validation: "ascii-theme" },
+  hAnsiTheme: { field: "hAnsiTheme", validation: "string" },
+  eastAsiaTheme: { field: "eastAsiaTheme", validation: "string" },
+  csTheme: { field: "csTheme", validation: "string" },
+} as const satisfies SelfDescribingFieldMap<
+  NonNullable<TextFormatting["fontFamily"]>,
+  { validation: "ascii-theme" | "font-hint" | "string" }
+>;
+
+export const TEXT_FORMATTING_LANGUAGE_FIELD_DESCRIPTORS = {
+  val: { field: "val", validation: "string" },
+  eastAsia: { field: "eastAsia", validation: "string" },
+  bidi: { field: "bidi", validation: "string" },
+} as const satisfies SelfDescribingFieldMap<
+  NonNullable<TextFormatting["language"]>,
+  { validation: "string" }
+>;
+
+export const TEXT_FORMATTING_UNDERLINE_FIELD_DESCRIPTORS = {
+  style: { field: "style", validation: "underline-style" },
+  color: { field: "color", validation: "color" },
+} as const satisfies SelfDescribingFieldMap<
+  NonNullable<TextFormatting["underline"]>,
+  { validation: "color" | "underline-style" }
+>;
 
 // ============================================================================
 // PARAGRAPH FORMATTING (Paragraph Properties - pPr)

--- a/packages/docx-core/src/model/formatting.ts
+++ b/packages/docx-core/src/model/formatting.ts
@@ -7,6 +7,13 @@
 
 import type { ColorValue, BorderSpec, ShadingProperties } from "./colors";
 
+const freezeDescriptor = <const Value extends Record<string, object>>(value: Value): Value => {
+  for (const entry of Object.values(value)) {
+    Object.freeze(entry);
+  }
+  return Object.freeze(value);
+};
+
 // ============================================================================
 // TEXT FORMATTING (Run Properties - rPr)
 // ============================================================================
@@ -233,7 +240,7 @@ type TextFormattingPropertyDescriptor = {
 };
 
 /** Total semantic descriptor for every modeled run-formatting property. */
-export const TEXT_FORMATTING_PROPERTY_DESCRIPTORS = {
+export const TEXT_FORMATTING_PROPERTY_DESCRIPTORS = freezeDescriptor({
   bold: {
     field: "bold",
     comparison: "exact",
@@ -451,9 +458,9 @@ export const TEXT_FORMATTING_PROPERTY_DESCRIPTORS = {
     visualGroup: null,
     fastPath: "character-style",
   },
-} as const satisfies SelfDescribingFieldMap<TextFormatting, TextFormattingPropertyDescriptor>;
+} as const satisfies SelfDescribingFieldMap<TextFormatting, TextFormattingPropertyDescriptor>);
 
-export const TEXT_FORMATTING_FONT_FAMILY_FIELD_DESCRIPTORS = {
+export const TEXT_FORMATTING_FONT_FAMILY_FIELD_DESCRIPTORS = freezeDescriptor({
   ascii: { field: "ascii", validation: "string" },
   hAnsi: { field: "hAnsi", validation: "string" },
   eastAsia: { field: "eastAsia", validation: "string" },
@@ -466,24 +473,24 @@ export const TEXT_FORMATTING_FONT_FAMILY_FIELD_DESCRIPTORS = {
 } as const satisfies SelfDescribingFieldMap<
   NonNullable<TextFormatting["fontFamily"]>,
   { validation: "ascii-theme" | "font-hint" | "string" }
->;
+>);
 
-export const TEXT_FORMATTING_LANGUAGE_FIELD_DESCRIPTORS = {
+export const TEXT_FORMATTING_LANGUAGE_FIELD_DESCRIPTORS = freezeDescriptor({
   val: { field: "val", validation: "string" },
   eastAsia: { field: "eastAsia", validation: "string" },
   bidi: { field: "bidi", validation: "string" },
 } as const satisfies SelfDescribingFieldMap<
   NonNullable<TextFormatting["language"]>,
   { validation: "string" }
->;
+>);
 
-export const TEXT_FORMATTING_UNDERLINE_FIELD_DESCRIPTORS = {
+export const TEXT_FORMATTING_UNDERLINE_FIELD_DESCRIPTORS = freezeDescriptor({
   style: { field: "style", validation: "underline-style" },
   color: { field: "color", validation: "color" },
 } as const satisfies SelfDescribingFieldMap<
   NonNullable<TextFormatting["underline"]>,
   { validation: "color" | "underline-style" }
->;
+>);
 
 // ============================================================================
 // PARAGRAPH FORMATTING (Paragraph Properties - pPr)

--- a/packages/docx-core/src/model/paragraphProperties.test.ts
+++ b/packages/docx-core/src/model/paragraphProperties.test.ts
@@ -1,11 +1,38 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR,
+  PARAGRAPH_PROPERTY_SOURCE_XML_GROUP,
   paragraphPropertySourceDelta,
   paragraphPropertySourceFingerprintFromParts,
 } from "./paragraphProperties";
+import { COLOR_VALUE_PROPERTY_DESCRIPTORS, SHADING_PROPERTY_DESCRIPTORS } from "./colors";
+import {
+  TEXT_FORMATTING_FONT_FAMILY_FIELD_DESCRIPTORS,
+  TEXT_FORMATTING_LANGUAGE_FIELD_DESCRIPTORS,
+  TEXT_FORMATTING_PROPERTY_DESCRIPTORS,
+  TEXT_FORMATTING_UNDERLINE_FIELD_DESCRIPTORS,
+} from "./formatting";
 
 describe("paragraph property source delta", () => {
+  test("published formatting descriptors are recursively immutable", () => {
+    for (const descriptor of [
+      COLOR_VALUE_PROPERTY_DESCRIPTORS,
+      SHADING_PROPERTY_DESCRIPTORS,
+      TEXT_FORMATTING_PROPERTY_DESCRIPTORS,
+      TEXT_FORMATTING_FONT_FAMILY_FIELD_DESCRIPTORS,
+      TEXT_FORMATTING_LANGUAGE_FIELD_DESCRIPTORS,
+      TEXT_FORMATTING_UNDERLINE_FIELD_DESCRIPTORS,
+      PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR,
+    ]) {
+      expect(Object.isFrozen(descriptor)).toBe(true);
+      for (const entry of Object.values(descriptor)) {
+        expect(Object.isFrozen(entry)).toBe(true);
+      }
+    }
+    expect(Object.isFrozen(PARAGRAPH_PROPERTY_SOURCE_XML_GROUP)).toBe(true);
+  });
+
   test("is empty when authored pPr and paragraph-mark properties are unchanged", () => {
     const fingerprint = paragraphPropertySourceFingerprintFromParts(
       { kinsoku: false, numPr: { ilvl: 2 } },
@@ -32,11 +59,7 @@ describe("paragraph property source delta", () => {
 
     const delta = paragraphPropertySourceDelta(before, after);
 
-    expect(delta.changedPPrBaseKeys).toEqual([
-      "kinsoku",
-      "spaceBefore",
-      "beforeAutospacing",
-    ]);
+    expect(delta.changedPPrBaseKeys).toEqual(["kinsoku", "spaceBefore", "beforeAutospacing"]);
     expect(delta.changedParagraphMarkKeys).toEqual(["runProperties", "runInWithNext"]);
     expect(delta.changedXmlGroups).toEqual(["kinsoku", "spacing", "rPr"]);
     expect(delta.isEmpty).toBe(false);
@@ -56,4 +79,3 @@ describe("paragraph property source delta", () => {
     expect(delta.changedXmlGroups).toEqual(["numPr", "suppressAutoHyphens"]);
   });
 });
-

--- a/packages/docx-core/src/model/paragraphProperties.test.ts
+++ b/packages/docx-core/src/model/paragraphProperties.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  paragraphPropertySourceDelta,
+  paragraphPropertySourceFingerprintFromParts,
+} from "./paragraphProperties";
+
+describe("paragraph property source delta", () => {
+  test("is empty when authored pPr and paragraph-mark properties are unchanged", () => {
+    const fingerprint = paragraphPropertySourceFingerprintFromParts(
+      { kinsoku: false, numPr: { ilvl: 2 } },
+      { runInWithNext: false },
+    );
+
+    const delta = paragraphPropertySourceDelta(fingerprint, fingerprint);
+
+    expect(delta.isEmpty).toBe(true);
+    expect(delta.changedPPrBaseKeys).toEqual([]);
+    expect(delta.changedParagraphMarkKeys).toEqual([]);
+    expect(delta.changedXmlGroups).toEqual([]);
+  });
+
+  test("coalesces changed modeled fields by their exact raw OOXML child", () => {
+    const before = paragraphPropertySourceFingerprintFromParts(
+      { spaceBefore: 120, beforeAutospacing: true, kinsoku: true },
+      { runProperties: { bold: true } },
+    );
+    const after = paragraphPropertySourceFingerprintFromParts(
+      { spaceBefore: 240, beforeAutospacing: false, kinsoku: false },
+      { runProperties: { italic: true }, runInWithNext: false },
+    );
+
+    const delta = paragraphPropertySourceDelta(before, after);
+
+    expect(delta.changedPPrBaseKeys).toEqual([
+      "kinsoku",
+      "spaceBefore",
+      "beforeAutospacing",
+    ]);
+    expect(delta.changedParagraphMarkKeys).toEqual(["runProperties", "runInWithNext"]);
+    expect(delta.changedXmlGroups).toEqual(["kinsoku", "spacing", "rPr"]);
+    expect(delta.isEmpty).toBe(false);
+    expect(Object.isFrozen(delta.changedXmlGroups)).toBe(true);
+  });
+
+  test("distinguishes explicit false and partial numbering from absence", () => {
+    const empty = paragraphPropertySourceFingerprintFromParts({}, {});
+    const authored = paragraphPropertySourceFingerprintFromParts(
+      { suppressAutoHyphens: false, numPr: { ilvl: 0 } },
+      {},
+    );
+
+    const delta = paragraphPropertySourceDelta(empty, authored);
+
+    expect(delta.changedPPrBaseKeys).toEqual(["numPr", "suppressAutoHyphens"]);
+    expect(delta.changedXmlGroups).toEqual(["numPr", "suppressAutoHyphens"]);
+  });
+});
+

--- a/packages/docx-core/src/model/paragraphProperties.ts
+++ b/packages/docx-core/src/model/paragraphProperties.ts
@@ -1,4 +1,4 @@
-import type { ParagraphFormatting } from "../types/document";
+import type { ParagraphFormatting } from "./formatting";
 
 export const PARAGRAPH_PROPERTY_OWNER = {
   pPrBase: "pPr-base",
@@ -257,6 +257,48 @@ export const PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR = {
   },
 } as const satisfies Record<keyof ParagraphFormatting, ParagraphPropertyDescriptor>;
 
+export const PARAGRAPH_PROPERTY_SOURCE_XML_GROUP = {
+  alignment: "jc",
+  bidi: "bidi",
+  kinsoku: "kinsoku",
+  overflowPunctuation: "overflowPunct",
+  spaceBefore: "spacing",
+  spaceAfter: "spacing",
+  lineSpacing: "spacing",
+  lineSpacingRule: "spacing",
+  snapToGrid: "snapToGrid",
+  beforeAutospacing: "spacing",
+  afterAutospacing: "spacing",
+  spacingExplicit: "spacing",
+  indentLeft: "ind",
+  indentRight: "ind",
+  indentFirstLine: "ind",
+  hangingIndent: "ind",
+  numberingLevelIndent: null,
+  borders: "pBdr",
+  shading: "shd",
+  tabs: "tabs",
+  keepNext: "keepNext",
+  keepLines: "keepLines",
+  widowControl: "widowControl",
+  pageBreakBefore: "pageBreakBefore",
+  contextualSpacing: "contextualSpacing",
+  numPr: "numPr",
+  numPrFromStyle: null,
+  outlineLevel: "outlineLvl",
+  styleId: "pStyle",
+  frame: "framePr",
+  suppressLineNumbers: "suppressLineNumbers",
+  suppressAutoHyphens: "suppressAutoHyphens",
+  runProperties: "rPr",
+  runInWithNext: "rPr",
+} as const satisfies Record<keyof ParagraphFormatting, string | null>;
+
+export type ParagraphPropertySourceXmlGroup = Exclude<
+  (typeof PARAGRAPH_PROPERTY_SOURCE_XML_GROUP)[keyof typeof PARAGRAPH_PROPERTY_SOURCE_XML_GROUP],
+  null
+>;
+
 // SAFETY: `Object.keys` erases keys that the total descriptor establishes.
 export const PARAGRAPH_FORMATTING_PROPERTY_KEY_LIST = Object.freeze(
   Object.keys(PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR) as (
@@ -397,6 +439,100 @@ export const canonicalParagraphPropertySourceFingerprintJson = (
   fingerprint: ParagraphPropertySourceFingerprint,
 ): string => JSON.stringify(canonicalJsonValue(fingerprint));
 
+const canonicalPropertyValueEqual = (left: unknown, right: unknown): boolean =>
+  JSON.stringify(canonicalJsonValue(left)) === JSON.stringify(canonicalJsonValue(right));
+
+/**
+ * Immutable proof of the modeled raw-property groups changed since capture.
+ * Serializers use the groups to replace only owned OOXML children and retain
+ * every unknown child from the imported `w:pPr`.
+ */
+export class ParagraphPropertySourceDelta {
+  readonly #changedParagraphMarkKeys: readonly ParagraphMarkPropertyKey[];
+  readonly #changedPPrBaseKeys: readonly AuthoredParagraphPropertyKey[];
+  readonly #changedXmlGroups: readonly ParagraphPropertySourceXmlGroup[];
+
+  private constructor({
+    changedParagraphMarkKeys,
+    changedPPrBaseKeys,
+    changedXmlGroups,
+  }: {
+    changedParagraphMarkKeys: ParagraphMarkPropertyKey[];
+    changedPPrBaseKeys: AuthoredParagraphPropertyKey[];
+    changedXmlGroups: ParagraphPropertySourceXmlGroup[];
+  }) {
+    this.#changedParagraphMarkKeys = Object.freeze(changedParagraphMarkKeys);
+    this.#changedPPrBaseKeys = Object.freeze(changedPPrBaseKeys);
+    this.#changedXmlGroups = Object.freeze(changedXmlGroups);
+    Object.freeze(this);
+  }
+
+  static between(
+    before: ParagraphPropertySourceFingerprint,
+    after: ParagraphPropertySourceFingerprint,
+  ): ParagraphPropertySourceDelta {
+    const changedParagraphMarkKeys: ParagraphMarkPropertyKey[] = [];
+    const changedPPrBaseKeys: AuthoredParagraphPropertyKey[] = [];
+    const changedXmlGroups: ParagraphPropertySourceXmlGroup[] = [];
+    const seenGroups = new Set<ParagraphPropertySourceXmlGroup>();
+    for (const key of PARAGRAPH_FORMATTING_PROPERTY_KEY_LIST) {
+      const descriptor = PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR[key];
+      if (descriptor.owner === PARAGRAPH_PROPERTY_OWNER.derived) {
+        continue;
+      }
+      const beforeOwner =
+        descriptor.owner === PARAGRAPH_PROPERTY_OWNER.pPrBase
+          ? before.pPrBase
+          : before.paragraphMark;
+      const afterOwner =
+        descriptor.owner === PARAGRAPH_PROPERTY_OWNER.pPrBase
+          ? after.pPrBase
+          : after.paragraphMark;
+      if (canonicalPropertyValueEqual(Reflect.get(beforeOwner, key), Reflect.get(afterOwner, key))) {
+        continue;
+      }
+      if (descriptor.owner === PARAGRAPH_PROPERTY_OWNER.pPrBase) {
+        // SAFETY: the descriptor owner narrows the key to CT_PPrBase ownership.
+        changedPPrBaseKeys.push(key as AuthoredParagraphPropertyKey);
+      } else {
+        // SAFETY: the only remaining descriptor owner is the paragraph mark.
+        changedParagraphMarkKeys.push(key as ParagraphMarkPropertyKey);
+      }
+      const group = PARAGRAPH_PROPERTY_SOURCE_XML_GROUP[key];
+      if (group !== null && !seenGroups.has(group)) {
+        seenGroups.add(group);
+        changedXmlGroups.push(group);
+      }
+    }
+    return new ParagraphPropertySourceDelta({
+      changedParagraphMarkKeys,
+      changedPPrBaseKeys,
+      changedXmlGroups,
+    });
+  }
+
+  get changedParagraphMarkKeys(): readonly ParagraphMarkPropertyKey[] {
+    return this.#changedParagraphMarkKeys;
+  }
+
+  get changedPPrBaseKeys(): readonly AuthoredParagraphPropertyKey[] {
+    return this.#changedPPrBaseKeys;
+  }
+
+  get changedXmlGroups(): readonly ParagraphPropertySourceXmlGroup[] {
+    return this.#changedXmlGroups;
+  }
+
+  get isEmpty(): boolean {
+    return this.#changedXmlGroups.length === 0;
+  }
+}
+
+export const paragraphPropertySourceDelta = (
+  before: ParagraphPropertySourceFingerprint,
+  after: ParagraphPropertySourceFingerprint,
+): ParagraphPropertySourceDelta => ParagraphPropertySourceDelta.between(before, after);
+
 const formattingKeys = (
   predicate: (descriptor: ParagraphPropertyDescriptor) => boolean,
 ): readonly string[] =>
@@ -432,3 +568,4 @@ export const isParagraphFormattingPropertyKey = (
   key: string,
 ): key is keyof typeof PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR =>
   PARAGRAPH_FORMATTING_PROPERTY_KEY_SET.has(key);
+

--- a/packages/docx-core/src/model/paragraphProperties.ts
+++ b/packages/docx-core/src/model/paragraphProperties.ts
@@ -1,5 +1,12 @@
 import type { ParagraphFormatting } from "./formatting";
 
+const freezeDescriptor = <const Value extends Record<string, object>>(value: Value): Value => {
+  for (const entry of Object.values(value)) {
+    Object.freeze(entry);
+  }
+  return Object.freeze(value);
+};
+
 export const PARAGRAPH_PROPERTY_OWNER = {
   pPrBase: "pPr-base",
   derived: "derived",
@@ -50,7 +57,7 @@ export type ParagraphPropertyDescriptor = {
  * serialization, and style transitions from silently growing different
  * interpretations of that boundary when `ParagraphFormatting` gains a field.
  */
-export const PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR = {
+export const PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR = freezeDescriptor({
   alignment: {
     owner: "pPr-base",
     projection: "alignment",
@@ -255,9 +262,9 @@ export const PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR = {
     styleTransition: "preserve",
     cascade: "replace",
   },
-} as const satisfies Record<keyof ParagraphFormatting, ParagraphPropertyDescriptor>;
+} as const satisfies Record<keyof ParagraphFormatting, ParagraphPropertyDescriptor>);
 
-export const PARAGRAPH_PROPERTY_SOURCE_XML_GROUP = {
+export const PARAGRAPH_PROPERTY_SOURCE_XML_GROUP = Object.freeze({
   alignment: "jc",
   bidi: "bidi",
   kinsoku: "kinsoku",
@@ -292,7 +299,7 @@ export const PARAGRAPH_PROPERTY_SOURCE_XML_GROUP = {
   suppressAutoHyphens: "suppressAutoHyphens",
   runProperties: "rPr",
   runInWithNext: "rPr",
-} as const satisfies Record<keyof ParagraphFormatting, string | null>;
+} as const satisfies Record<keyof ParagraphFormatting, string | null>);
 
 export type ParagraphPropertySourceXmlGroup = Exclude<
   (typeof PARAGRAPH_PROPERTY_SOURCE_XML_GROUP)[keyof typeof PARAGRAPH_PROPERTY_SOURCE_XML_GROUP],
@@ -301,9 +308,9 @@ export type ParagraphPropertySourceXmlGroup = Exclude<
 
 // SAFETY: `Object.keys` erases keys that the total descriptor establishes.
 export const PARAGRAPH_FORMATTING_PROPERTY_KEY_LIST = Object.freeze(
-  Object.keys(PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR) as (
-    keyof typeof PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR
-  )[],
+  Object.keys(
+    PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR,
+  ) as (keyof typeof PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR)[],
 );
 
 type FormattingKeysOwnedBy<Owner extends ParagraphPropertyDescriptor["owner"]> = {
@@ -314,10 +321,7 @@ type FormattingKeysOwnedBy<Owner extends ParagraphPropertyDescriptor["owner"]> =
 
 /** Exact authored CT_PPrBase payload, before style or numbering resolution. */
 export type AuthoredParagraphPropertyKey = FormattingKeysOwnedBy<"pPr-base">;
-export type AuthoredParagraphProperties = Pick<
-  ParagraphFormatting,
-  AuthoredParagraphPropertyKey
->;
+export type AuthoredParagraphProperties = Pick<ParagraphFormatting, AuthoredParagraphPropertyKey>;
 
 /** Paragraph-mark properties intentionally kept outside CT_PPrBase provenance. */
 export type ParagraphMarkPropertyKey = FormattingKeysOwnedBy<"paragraph-mark">;
@@ -347,9 +351,7 @@ const clonePropertyValue = (value: unknown): unknown => {
   return value;
 };
 
-const selectParagraphPropertiesOwnedBy = <
-  Owner extends ParagraphPropertyDescriptor["owner"],
->(
+const selectParagraphPropertiesOwnedBy = <Owner extends ParagraphPropertyDescriptor["owner"]>(
   formatting: ParagraphFormatting | null | undefined,
   owner: Owner,
 ): Pick<ParagraphFormatting, FormattingKeysOwnedBy<Owner>> => {
@@ -485,10 +487,10 @@ export class ParagraphPropertySourceDelta {
           ? before.pPrBase
           : before.paragraphMark;
       const afterOwner =
-        descriptor.owner === PARAGRAPH_PROPERTY_OWNER.pPrBase
-          ? after.pPrBase
-          : after.paragraphMark;
-      if (canonicalPropertyValueEqual(Reflect.get(beforeOwner, key), Reflect.get(afterOwner, key))) {
+        descriptor.owner === PARAGRAPH_PROPERTY_OWNER.pPrBase ? after.pPrBase : after.paragraphMark;
+      if (
+        canonicalPropertyValueEqual(Reflect.get(beforeOwner, key), Reflect.get(afterOwner, key))
+      ) {
         continue;
       }
       if (descriptor.owner === PARAGRAPH_PROPERTY_OWNER.pPrBase) {
@@ -568,4 +570,3 @@ export const isParagraphFormattingPropertyKey = (
   key: string,
 ): key is keyof typeof PARAGRAPH_FORMATTING_PROPERTY_DESCRIPTOR =>
   PARAGRAPH_FORMATTING_PROPERTY_KEY_SET.has(key);
-

--- a/packages/docx-core/src/model/styleNumbering.test.ts
+++ b/packages/docx-core/src/model/styleNumbering.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+
+import type { StyleDefinitions } from "./styles";
+import {
+  createParagraphStyleNumberingResolver,
+  numberingIdentityEqual,
+  verifiedNumberingLevelIndent,
+} from "./styleNumbering";
+
+describe("paragraph style numbering", () => {
+  test("compares effective numbering identities", () => {
+    expect(numberingIdentityEqual(null, undefined)).toBe(true);
+    expect(numberingIdentityEqual({ numId: 7 }, { numId: 7, ilvl: 0 })).toBe(true);
+    expect(numberingIdentityEqual({ numId: 7 }, { numId: 8 })).toBe(false);
+    expect(numberingIdentityEqual({ numId: 7, ilvl: 1 }, { numId: 7 })).toBe(false);
+    expect(numberingIdentityEqual({}, {})).toBe(true);
+  });
+
+  test("verifies numbering-owned indentation against its latent baseline", () => {
+    const owned = { indentLeft: 720 };
+    const baseline = {
+      indentLeft: 720,
+      indentFirstLine: -360,
+      hangingIndent: true,
+    };
+    const formatting = {
+      numPr: { numId: 7, ilvl: 0 },
+      numberingLevelIndent: {
+        type: "owned" as const,
+        numId: 7,
+        ilvl: 0,
+        baseline,
+        owned,
+      },
+    };
+
+    expect(verifiedNumberingLevelIndent(formatting)).toBe(owned);
+    expect(
+      verifiedNumberingLevelIndent({
+        ...formatting,
+        numberingLevelIndent: { type: "latent", numId: 7, ilvl: 0, baseline },
+      }),
+    ).toBeUndefined();
+    expect(
+      verifiedNumberingLevelIndent({
+        ...formatting,
+        numberingLevelIndent: {
+          ...formatting.numberingLevelIndent,
+          owned: { indentLeft: 360 },
+        },
+      }),
+    ).toBeUndefined();
+    const malformed = { ...formatting };
+    Reflect.deleteProperty(malformed.numberingLevelIndent, "owned");
+    expect(verifiedNumberingLevelIndent(malformed)).toBeUndefined();
+  });
+
+  test("resolves partial and cyclic paragraph-style chains", () => {
+    const styles = {
+      styles: [
+        {
+          styleId: "Base",
+          type: "paragraph",
+          pPr: { numPr: { numId: 7, ilvl: 2 } },
+        },
+        {
+          styleId: "Partial",
+          type: "paragraph",
+          basedOn: "Base",
+          pPr: { numPr: { ilvl: 0 } },
+        },
+        { styleId: "CycleA", type: "paragraph", basedOn: "CycleB" },
+        {
+          styleId: "CycleB",
+          type: "paragraph",
+          basedOn: "CycleA",
+          pPr: { numPr: { numId: 8 } },
+        },
+      ],
+    } satisfies StyleDefinitions;
+    const styleSuppliesNumbering = createParagraphStyleNumberingResolver(styles);
+
+    expect(
+      styleSuppliesNumbering({
+        styleId: "Partial",
+        numPrFromStyle: { numId: 7, ilvl: 0 },
+      }),
+    ).toBe(true);
+    expect(
+      styleSuppliesNumbering({
+        styleId: "Partial",
+        numPrFromStyle: { numId: 7, ilvl: 2 },
+      }),
+    ).toBe(false);
+    expect(
+      styleSuppliesNumbering({ styleId: "CycleA", numPrFromStyle: { numId: 8 } }),
+    ).toBe(true);
+    expect(
+      styleSuppliesNumbering({ styleId: "Partial", numPrFromStyle: { ilvl: 0 } }),
+    ).toBe(false);
+  });
+});

--- a/packages/docx-core/src/model/styleNumbering.ts
+++ b/packages/docx-core/src/model/styleNumbering.ts
@@ -1,0 +1,109 @@
+import type {
+  NonEmptyNumberingLevelIndentGeometry,
+  NumberingLevelIndentGeometry,
+  ParagraphFormatting,
+} from "./formatting";
+import type { StyleDefinitions } from "./styles";
+
+export type NumberingIdentity = NonNullable<ParagraphFormatting["numPr"]>;
+
+/** Compare numbering identities, treating an omitted level as level zero. */
+export const numberingIdentityEqual = (
+  left: NumberingIdentity | null | undefined,
+  right: NumberingIdentity | null | undefined,
+): boolean => {
+  if (left == null || right == null) {
+    return left == null && right == null;
+  }
+  return left.numId === right.numId && (left.ilvl ?? 0) === (right.ilvl ?? 0);
+};
+
+/** Narrow numbering geometry to the structurally non-empty provenance payload. */
+export const isNonEmptyNumberingLevelIndentGeometry = (
+  geometry: NumberingLevelIndentGeometry | null | undefined,
+): geometry is NonEmptyNumberingLevelIndentGeometry =>
+  geometry !== undefined &&
+  geometry !== null &&
+  (geometry.indentLeft !== undefined ||
+    geometry.indentRight !== undefined ||
+    geometry.indentFirstLine !== undefined);
+
+/** Return numbering-owned indentation only when its identity and baseline agree. */
+export const verifiedNumberingLevelIndent = (
+  formatting: ParagraphFormatting | null | undefined,
+): NonEmptyNumberingLevelIndentGeometry | undefined => {
+  const active = formatting?.numPr;
+  const provenance = formatting?.numberingLevelIndent;
+  if (
+    active?.numId === undefined ||
+    active.numId === 0 ||
+    provenance?.type !== "owned" ||
+    !isNonEmptyNumberingLevelIndentGeometry(provenance.owned) ||
+    !isNonEmptyNumberingLevelIndentGeometry(provenance.baseline) ||
+    !numberingIdentityEqual(active, provenance)
+  ) {
+    return undefined;
+  }
+  for (const key of [
+    "indentLeft",
+    "indentRight",
+    "indentFirstLine",
+    "hangingIndent",
+  ] as const) {
+    if (
+      provenance.owned[key] !== undefined &&
+      provenance.owned[key] !== provenance.baseline[key]
+    ) {
+      return undefined;
+    }
+  }
+  return provenance.owned;
+};
+
+export type ParagraphStyleNumberingResolver = (
+  formatting: ParagraphFormatting | undefined,
+) => boolean;
+
+/** Build a bounded resolver for numbering supplied by paragraph-style inheritance. */
+export const createParagraphStyleNumberingResolver = (
+  styles: StyleDefinitions | undefined,
+): ParagraphStyleNumberingResolver => {
+  if (!styles) {
+    return () => false;
+  }
+
+  const styleById = new Map(styles.styles.map((style) => [style.styleId, style]));
+  const cache = new Map<string, NumberingIdentity | undefined>();
+  const resolveStyleNumbering = (styleId: string): NumberingIdentity | undefined => {
+    if (cache.has(styleId)) {
+      return cache.get(styleId);
+    }
+
+    const chain: (typeof styles.styles)[number][] = [];
+    const seen = new Set<string>();
+    let style = styleById.get(styleId);
+    while (style?.type === "paragraph" && !seen.has(style.styleId)) {
+      seen.add(style.styleId);
+      chain.push(style);
+      style = style.basedOn ? styleById.get(style.basedOn) : undefined;
+    }
+
+    let numbering: NumberingIdentity | undefined;
+    for (const current of chain.toReversed()) {
+      if (current.pPr?.numPr !== undefined) {
+        numbering = { ...numbering, ...current.pPr.numPr };
+      }
+    }
+    cache.set(styleId, numbering);
+    return numbering;
+  };
+
+  return (formatting) => {
+    const provenance = formatting?.numPrFromStyle;
+    return (
+      formatting?.styleId !== undefined &&
+      provenance?.numId !== undefined &&
+      numberingIdentityEqual(resolveStyleNumbering(formatting.styleId), provenance)
+    );
+  };
+};


### PR DESCRIPTION
## Summary

- centralize paragraph property state, projection, mutation, and ownership
- derive modeled DOCX formatting and numbering properties from total descriptors
- route editor paragraph transitions through explicit source-owned operations

## Status

Stacked on #814. Draft while the state algebra, transition coverage, and integration surface are reviewed.